### PR TITLE
add verbosity flag to invert.c usage information

### DIFF
--- a/invert.c
+++ b/invert.c
@@ -96,6 +96,7 @@ void usage()
   fprintf(stdout, "Usage:   invert [options]\n");
   fprintf(stdout, "Options: [-f input-filename]\n");
   fprintf(stdout, "         [-o output-filename]\n");
+  fprintf(stdout, "         [-v] more verbosity\n");
   fprintf(stdout, "         [-h|-? this help]\n");
   fprintf(stdout, "         [-V] print version information and exit\n");
   exit(0);


### PR DESCRIPTION
invert supports the verbosity flag -v but the usage information does not indicate it, this fixes this
