### PR TITLE
Fix logic mistake in GIT-VERSION-GEN which would overwrite git_hash.h

### DIFF
--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -26,6 +26,14 @@
 
 #!/bin/sh
 
+# write the hash to git_hash.h
+write_git_hash() {
+  echo "#ifndef _GIT_HASH_H" > git_hash.h
+  echo "#define _GIT_HASH_H" >> git_hash.h
+  echo "const char git_hash[] = {\"${GIT_HASH}\"};" >> git_hash.h
+  echo "#endif /* _GIT_HASH_H */" >> git_hash.h
+}
+
 # extract default version from configure.in if it exists
 if test -r configure.in
 then
@@ -40,6 +48,7 @@ GIT_BIN=`command -v git`
 # First see if there is a version file (included in release tarballs),
 # compare whether it matches the current HEAD commit,
 # then try git rev-parse HEAD, then default.
+# We also check whether we should leave it alone and just exit.
 if test -f git_hash.h
 then
   # remove all unneccessary fields and characters
@@ -55,22 +64,23 @@ then
       exit 0  
     else
       GIT_HASH=${GIT_REV}
+      write_git_hash
     fi
-fi
+  # we are not in a git repository but git_hash.h exists. We must be building from
+  # a tarball! Let's assume git_hash.h is correct and exit before we do any damage
+  # (this branch will also be followed if .git exists but there is no git available
+  # to extract version information)
+  else
+    exit 0
+  fi
+# git_hash.h does not exist, let's try to generate it  
 elif test -d .git -o -f .git && test -x ${GIT_BIN}
 then
   # .git exists and we are in a git repo
   GIT_HASH=$(git rev-parse HEAD)
+  write_git_hash
 else
   GIT_HASH=${DEF_VER}
+  write_git_hash
 fi
-
-
-# write the hash to git_hash.h
-echo "#ifndef _GIT_HASH_H" > git_hash.h
-echo "#define _GIT_HASH_H" >> git_hash.h
-
-echo "const char git_hash[] = {\"${GIT_HASH}\"};" >> git_hash.h
-
-echo "#endif /* _GIT_HASH_H */" >> git_hash.h
 


### PR DESCRIPTION
I made a silly logic mistake when I implemented GIT-VERSION-GEN whereby it would overwrite git_hash.h if there was no git available or no .git directory available but git_hash.h was perfectly valid.

This would have meant that when building from a tarball any git_hash.h we include in the tarball would have been overwritten.

This commit fixes this bug.
