### PR TITLE
Fix infinite make loop during dependency file building.

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -3,8 +3,6 @@
 
 # refresh Makefile and other stuff
 
-PROGRAMS_WITH_GIT_HASH := hmc_tm invert
-
 .SUFFIXES:
 
 Makefile: ${top_srcdir}/Makefile.global $(srcdir)/Makefile.in $(abs_top_builddir)/config.status 
@@ -33,13 +31,7 @@ $(LINKLIBS): %.a: Makefile $(abs_top_builddir)/config.status $(top_srcdir)/confi
 
 #dep rules
 
-# PROGRAMS_WITH_GIT_HASH require git_hash.h which is dynamically built by a phony make target
-# to prevent too frequent building of git_hash (slowing down the build)
-# we filter the list of all objects and treat these separately
-$(addsuffix .d, $(filter-out ${PROGRAMS_WITH_GIT_HASH},${ALLOBJ})): %.d: ${srcdir}/%.c Makefile
-	@ $(CCDEP) ${DEPFLAGS} ${CPPFLAGS} ${INCLUDES} ${DEFS} $< > $@
-
-$(addsuffix .d, $(filter ${PROGRAMS_WITH_GIT_HASH},${ALLOBJ})): %.d: ${srcdir}/%.c ${top_srcdir}/git_hash.h Makefile
+$(addsuffix .d, ${ALLOBJ}): %.d: ${srcdir}/%.c Makefile
 	@ $(CCDEP) ${DEPFLAGS} ${CPPFLAGS} ${INCLUDES} ${DEFS} $< > $@
 
 ${top_builddir}/fixed_volume.h: ${top_srcdir}/fixed_volume.h.in ${top_builddir}/config.status

--- a/Makefile.in
+++ b/Makefile.in
@@ -137,7 +137,7 @@ ${addsuffix .o, ${PROGRAMS}}: %.o: ${srcdir}/%.c %.d Makefile $(abs_top_builddir
 ${PROGRAMS}: %: %.o libhmc.a all-recursive
 	 ${LINK}  $@.o $(GPUOBJECTS) $(GPUOBJECTS_C) $(LIBS)
 
-dep: $(addsuffix .d,$(ALLOBJ)) 
+dep: $(addsuffix .d,$(ALLOBJ)) ${top_srcdir}/git_hash.h
 	@ echo "...dependency files built"
 
 install: Makefile


### PR DESCRIPTION
As noted by Albert I introduced a stupid infinite loop in the building of dependency files during the introduction of git-version-gen. It was masked by the network file system in Zeuthen and so I didn't notice. This commit fixes this bug and incidentally simplifies the Makefile. I have no idea why I didn't think of this approach earlier :)
