### PR TITLE
Rewrite g_gauge_buffers to avoid a segmentation fault and memory leaks.

### DIFF
--- a/buffers/gauge.h
+++ b/buffers/gauge.h
@@ -13,7 +13,7 @@ typedef struct
   su3_tuple **reserve;
   unsigned int max;
   unsigned int allocated;
-  int stack;
+  unsigned int free;
 } gauge_buffers_t;
 
 typedef struct

--- a/buffers/gauge_allocate_gauge_buffers.c
+++ b/buffers/gauge_allocate_gauge_buffers.c
@@ -14,8 +14,8 @@ void allocate_gauge_buffers(unsigned int count)
     p = ((p + ALIGN_BASE) & ~ALIGN_BASE);
     ((void**)p)[-1] = raw;
 
-    ++g_gauge_buffers.stack;
-    g_gauge_buffers.reserve[g_gauge_buffers.stack] = (su3_tuple*)p;
+    g_gauge_buffers.reserve[g_gauge_buffers.free] = (su3_tuple*)p;
     ++g_gauge_buffers.allocated;
+    ++g_gauge_buffers.free;
   }
 }

--- a/buffers/gauge_finalize_gauge_buffers.c
+++ b/buffers/gauge_finalize_gauge_buffers.c
@@ -2,13 +2,10 @@
 
 void finalize_gauge_buffers()
 {
-  if (g_gauge_buffers.stack != g_gauge_buffers.allocated - 1)
-    fatal_error("Finalized g_gauge_buffers with unreturned fields!", "finalize_gauge_buffers"); /* Make error? */
-  for (unsigned int ctr = 0; ctr < (g_gauge_buffers.stack); ++ctr)
-  {
-    /* We need to retrieve the unaligned pointers, stored _before_ the actual fields. */
-    void* ptr = ((void**)g_gauge_buffers.reserve[ctr])[-1];
-    free(ptr);
-  }
+  if (g_gauge_buffers.free != g_gauge_buffers.allocated)
+    fatal_error("Finalized g_gauge_buffers with unreturned fields!", "finalize_gauge_buffers");
+
+  free_unused_gauge_buffers();
   free(g_gauge_buffers.reserve);
+  g_gauge_buffers.max = 0;
 }

--- a/buffers/gauge_free_unused_gauge_buffers.c
+++ b/buffers/gauge_free_unused_gauge_buffers.c
@@ -2,9 +2,9 @@
 
 void free_unused_gauge_buffers()
 {
-  for ( ; g_gauge_buffers.stack >= 0; --g_gauge_buffers.stack, --g_gauge_buffers.allocated)
+  for ( ; g_gauge_buffers.free > 0; --g_gauge_buffers.free, --g_gauge_buffers.allocated)
   {
-    void* ptr = ((void**)g_gauge_buffers.reserve[g_gauge_buffers.stack])[-1];
+    void* ptr = ((void**)g_gauge_buffers.reserve[g_gauge_buffers.free - 1])[-1];
     free(ptr);
   }
 }

--- a/buffers/gauge_get_gauge_field.c
+++ b/buffers/gauge_get_gauge_field.c
@@ -9,12 +9,12 @@ gauge_field_t get_gauge_field()
 {
   gauge_field_t gauge_field;
 
-  if (g_gauge_buffers.stack < 0) /* Need to allocate a new buffer */
+  if (g_gauge_buffers.free == 0) /* Need to allocate a new buffer */
     allocate_gauge_buffers(1);
-
-  gauge_field.field = g_gauge_buffers.reserve[g_gauge_buffers.stack];
-  g_gauge_buffers.reserve[g_gauge_buffers.stack] = NULL;
-  --g_gauge_buffers.stack;
+  --g_gauge_buffers.free;
+  
+  gauge_field.field = g_gauge_buffers.reserve[g_gauge_buffers.free];
+  g_gauge_buffers.reserve[g_gauge_buffers.free] = NULL;
 
   return gauge_field;
 }

--- a/buffers/gauge_get_gauge_field_array.c
+++ b/buffers/gauge_get_gauge_field_array.c
@@ -6,14 +6,14 @@ gauge_field_array_t get_gauge_field_array(unsigned int length)
   gauge_field_array.length = length;
   gauge_field_array.field_array = (gauge_field_t*)calloc(length, sizeof(gauge_field_t));
 
-  if (g_gauge_buffers.stack < (length - 1)) /* Need to allocate more buffers */
-    allocate_gauge_buffers(length - g_gauge_buffers.stack - 1);
+  if (g_gauge_buffers.free < length) /* Need to allocate more buffers */
+    allocate_gauge_buffers(length - g_gauge_buffers.free);
 
   for (unsigned int ctr = 0; ctr < length; ++ctr)
   {
-    gauge_field_array.field_array[ctr].field = g_gauge_buffers.reserve[g_gauge_buffers.stack];
-    g_gauge_buffers.reserve[g_gauge_buffers.stack] = NULL;
-    --g_gauge_buffers.stack;
+    --g_gauge_buffers.free;
+    gauge_field_array.field_array[ctr].field = g_gauge_buffers.reserve[g_gauge_buffers.free];
+    g_gauge_buffers.reserve[g_gauge_buffers.free] = NULL;
   }
 
   return gauge_field_array;

--- a/buffers/gauge_initialize_gauge_buffers.c
+++ b/buffers/gauge_initialize_gauge_buffers.c
@@ -4,7 +4,7 @@ void initialize_gauge_buffers(unsigned int max)
 {
   g_gauge_buffers.max = max;
   g_gauge_buffers.allocated = 0;
-  g_gauge_buffers.stack = -1;
+  g_gauge_buffers.free = 0;
   g_gauge_buffers.reserve = (su3_tuple**)calloc(max, sizeof(su3_tuple*));
 }
 

--- a/buffers/gauge_return_gauge_field.c
+++ b/buffers/gauge_return_gauge_field.c
@@ -2,8 +2,8 @@
 
 void return_gauge_field(gauge_field_t *gauge_field)
 {
-  ++g_gauge_buffers.stack;
-  g_gauge_buffers.reserve[g_gauge_buffers.stack] = gauge_field->field;
+  g_gauge_buffers.reserve[g_gauge_buffers.free] = gauge_field->field;
+  ++g_gauge_buffers.free;
   gauge_field->field = NULL;
 }
 

--- a/buffers/gauge_return_gauge_field_array.c
+++ b/buffers/gauge_return_gauge_field_array.c
@@ -4,8 +4,9 @@ void return_gauge_field_array(gauge_field_array_t *gauge_field_array)
 {
   for (unsigned int ctr = 0; ctr < gauge_field_array->length; ++ctr)
   {
-    ++g_gauge_buffers.stack;
-    g_gauge_buffers.reserve[g_gauge_buffers.stack] = gauge_field_array->field_array[ctr].field;
+    g_gauge_buffers.reserve[g_gauge_buffers.free] = gauge_field_array->field_array[ctr].field;
+    ++g_gauge_buffers.free;
     gauge_field_array->field_array[ctr].field = NULL;
   }
+  free(gauge_field_array->field_array);
 }


### PR DESCRIPTION
This rewrite fixes, hopefully, all issues by getting rid of the integer `g_gauge_buffers.stack` and replacing it by `g_gauge_buffers.free`, an unsigned integer. The `finalize_gauge_fields` function has been refactored and a memory leak was fixed in return_gauge_field_array. Fixes #57.
