### PR TITLE
Remove .NOTPARALLEL specifier from Makefile.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -101,9 +101,6 @@ all: Makefile all-recursive dep hmc_tm invert
 ${top_srcdir}/git_hash.h:
 	@cd @srcdir@ && sh GIT-VERSION-GEN
 
-# no targets to be built serially
-.NOTPARALLEL:
-
 -include $(addsuffix .d,$(ALLOBJ))
 
 include ${top_srcdir}/Makefile.global
@@ -162,7 +159,7 @@ uninstall: Makefile
 	echo "done";
 
 compile-clean: compile-clean-recursive Makefile
-	rm -f *.o *.d
+	rm -f *.o *.d test/*.o test/*.d tests/*.o tests/*.d
 
 clean: clean-recursive Makefile
 	rm -f hmc_tm invert *.o *.d test/*.o test/*.d tests/*.o tests/*.d


### PR DESCRIPTION
The .NOTPARALLEL specifier prevents all files in ${top_srcdir} from being built in parallel, significantly slowing down compilation for no reason.

In addition, this commit adds test/_.[o,d] and tests/_.[o,d] to the compile clean target for consistency.
