### PR TITLE
fix compilation error in xchange_deri.c for PARALLELT

### DIFF
--- a/xchange_deri.c
+++ b/xchange_deri.c
@@ -183,10 +183,9 @@ void xchange_deri(su3adj ** const df)
 void xchange_deri(su3adj ** const df)
 {
 #  ifdef MPI
-  int ix, t, y, z, x;
+  int ix,iy, t, y, z, x;
   MPI_Status status;
 #    if (defined PARALLELXT || defined PARALLELXYT || defined PARALLELXYZT)
-  int iy;
   /* The edges need to come first */
 
   /* send the data to the neighbour on the left in t direction */


### PR DESCRIPTION
iy is used in a section which is run even in PARALLELT for indexing ddummy
