### PR TITLE
make configure fail if (F)LEX is not found

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -21,7 +21,12 @@ AC_C_INLINE
 AC_C_RESTRICT
 AC_F77_LIBRARY_LDFLAGS
 LIBS="$LIBS $FLIBS -lm"
+
 AC_PROG_LEX
+if ["$LEX" != "lex" || "$LEX" != "flex"]; then
+  AC_MSG_ERROR([(F)LEX is required for building read_input.c. Please install it, delete config.log and run configure again.])
+fi
+
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
 AC_CHECK_PROG(CCDEP, gcc, "gcc", "$CC")


### PR DESCRIPTION
we need to fail if (f)lex is not found because otherwise, if read_input.c already exists and read_input.l changes, read_input.c will not be rebuilt in a sort of silent manner with only a warning in the build log

this situation can occur if one obtains a source tree which has been compiled once from someone else and one tries to modify read_input.l, only to find that read_input.c is not being updated silently, even though it is clearly a target with correct dependencies in the Makefile
