### PR TITLE
update SSE flags in linalg for SSE3

### DIFF
--- a/linalg/assign_add_mul_r.c
+++ b/linalg/assign_add_mul_r.c
@@ -33,7 +33,7 @@
 #include "assign_add_mul_r.h"
 
 
-#if defined SSE2
+#if ( defined SSE2 || defined SSE3 )
 
 /*   (*P) = (*P) + c(*Q)        c is a complex constant   */
 

--- a/linalg/assign_add_mul_r_add_mul.c
+++ b/linalg/assign_add_mul_r_add_mul.c
@@ -31,7 +31,7 @@
 #include "su3adj.h"
 #include "assign_add_mul_r_add_mul.h"
 
-#if defined SSE2
+#if ( defined SSE2 || defined SSE3 )
 void assign_add_mul_r_add_mul(spinor * const R, spinor * const S, spinor * const U,
 			      const double c1,const double c2, const int N) {
 

--- a/linalg/assign_add_mul_r_bi.c
+++ b/linalg/assign_add_mul_r_bi.c
@@ -40,7 +40,7 @@
 #include "assign_add_mul_r_bi.h"
 
 
-#if defined SSE2
+#if ( defined SSE2 || defined SSE3 )
 /*  k input, l output */
 void assign_add_mul_r_bi(bispinor * const P, bispinor * const Q, const double c, const int N) {
   

--- a/linalg/assign_mul_add_r.c
+++ b/linalg/assign_mul_add_r.c
@@ -27,7 +27,7 @@
 #include "assign_mul_add_r.h"
 
 
-#if defined SSE2
+#if ( defined SSE2 || defined SSE3 )
 /* k input , l output*/
 void assign_mul_add_r(spinor * const S, const double c, spinor * const R, const int N) {
 

--- a/linalg/assign_mul_add_r_bi.c
+++ b/linalg/assign_mul_add_r_bi.c
@@ -36,7 +36,7 @@
 #include "assign_mul_add_r_bi.h"
 
 
-#if defined SSE2
+#if ( defined SSE2 || defined SSE3 )
 /* k input , l output*/
 void assign_mul_add_r_bi(bispinor * const S, const double c, bispinor * const R, const int N) {
 


### PR DESCRIPTION
The SSEn #ifdef in the linalg modules were limited to SSE2. This expands it to SSE2||SSE3 
