### PR TITLE
Fix random seed bug

### DIFF
--- a/start.c
+++ b/start.c
@@ -787,12 +787,15 @@ void source_spinor_field_point_from_file(spinor * const P, spinor * const Q, int
   }
 }
 
-void start_ranlux(int level,int seed)
+void start_ranlux(int level, int seed)
 {
    unsigned int max_seed,loc_seed;
+   unsigned int step = g_proc_coords[0]*g_nproc_x*g_nproc_y*g_nproc_z +
+     g_nproc_y*g_proc_coords[1]*g_nproc_y*g_nproc_z +
+     g_proc_coords[2]*g_nproc_z + g_proc_coords[3];
 
-   max_seed=2147483647/g_nproc;
-   loc_seed=(seed+g_proc_id*max_seed) % max_seed;
+   max_seed = 2147483647 / g_nproc;
+   loc_seed = (seed + step*max_seed) % max_seed;
 
    if(loc_seed == 0) loc_seed++;
 


### PR DESCRIPTION
From about 2^15 MPI processes on (depending on the Seed value) the MPI local seed computed in `start.c` `start_ranlux` function produced local seed values larger than the maximal allowed value. This is fixed now by a modulo operation.

It also sets the local seed now only depending on the cartesian coordinates of the calling MPI process, which should allow for reproducable random numbers at least for identical parallelisation (and independent of how the MPI process id is mapped onto the cartesian grid).
