### PR TITLE
tiny improvement to functions in start.c

### DIFF
--- a/start.c
+++ b/start.c
@@ -228,7 +228,7 @@ void unit_spinor_field(const int k)
 
 /* Function provides a spinor field of length VOLUME with
    distributions given by rn_type as defined in start.h */
-void random_spinor_field_lexic(spinor * const k, const int repro, const int rn_type) {
+void random_spinor_field_lexic(spinor * const k, const int repro, const enum RN_TYPE rn_type) {
   int x, y, z, t, X, Y, Z, tt, id=0;
 
   void (*random_vector)(double*,int) = NULL;
@@ -307,7 +307,7 @@ void random_spinor_field_lexic(spinor * const k, const int repro, const int rn_t
 /* Function provides a spinor field of length VOLUME/2 for even odd preconditioning 
    with distributions given by rn_type as defined in start.h */
 
-void random_spinor_field_eo(spinor * const k, const int repro, const int rn_type ) {
+void random_spinor_field_eo(spinor * const k, const int repro, const enum RN_TYPE rn_type ) {
   int x, X, y, Y, z, Z, t, t0, id = 0;
 
   void (*random_vector)(double*,int) = NULL;

--- a/start.h
+++ b/start.h
@@ -26,8 +26,8 @@ void unit_spinor_field(const int k);
 void zero_spinor_field(spinor * const k, const int N);
 void constant_spinor_field(spinor * const k, const int p, const int N);
 
-void random_spinor_field_lexic(spinor * const k, const int repro, const int rn_type);
-void random_spinor_field_eo(spinor * const k, const int repro, const int rn_type);
+void random_spinor_field_lexic(spinor * const k, const int repro, const enum RN_TYPE);
+void random_spinor_field_eo(spinor * const k, const int repro, const enum RN_TYPE);
 
 void unit_g_gauge_field(void);
 


### PR DESCRIPTION
use RN_TYPE enum type for last argument of random_spinor_field_\* functions, makes passing of incompatible int impossible even at compile-time
