### PR TITLE
g_dbw2rand is not required for the clover term

### DIFF
--- a/read_input.l
+++ b/read_input.l
@@ -794,12 +794,10 @@ inline void rmQuotes(char *str){
   else if(strcmp(yytext, "CLOVERDET")==0) {
     mnl->type = CLOVERDET;
     strcpy((*mnl).name, "CLOVERDET");
-    g_dbw2rand = 1;
   }
   else if(strcmp(yytext, "CLOVERDETRATIO")==0) {
     mnl->type = CLOVERDETRATIO;
     strcpy((*mnl).name, "CLOVERDETRATIO");
-    g_dbw2rand = 1;
   }
   else if(strcmp(yytext, "DETRATIO")==0) {
     mnl->type = DETRATIO;


### PR DESCRIPTION
Testing with 4D parallelization it does not seem like the dbw2rand is required for the clover term. After 100 trajectories I get exactly the same output.data. I haven't tested with other parallelizations but I'm in the process of doing that too.
