### PR TITLE
Fix bug with the 'hot' starting condition for scalar fields

### DIFF
--- a/start.c
+++ b/start.c
@@ -468,7 +468,8 @@ void unit_g_gauge_field(void)
 
 void random_gauge_field(const int repro) {
 
-  int ix, mu, t0, t, x, X, y, Y, z, Z, id;
+  int ix, mu, t0, t, x, X, y, Y, z, Z;
+  int id = 0; /* May not be initialized for scalar builds! */
   int coords[4];
   su3 ALIGN tmp;
 #ifdef MPI


### PR DESCRIPTION
An utterly trivial change. In the generation of random gauge fields (start.c), the int 'id', used to track the rank of the node, was used uninitialized for scalar builds. It would often be set to 0 anyway and go unnoticed, but would sometimes contain an arbitrary value. In those cases, every site would be considered off-node and none of them were ever initialized.

All this patch does, is set id to 0 at the point it is declared.
