### PR TITLE
use POSIX 199309 by default when using clock_gettime

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -302,13 +302,13 @@ dnl for the case of other configure scripts
 dnl AC_CONFIG_SUBDIRS( rng )
 
 dnl check for clock_gettime and set correct library flag if one is required
-dnl (as done by AC_CHECK_LIB)
+dnl (this is done by AC_CHECK_LIB)
 AC_CHECK_FUNCS(clock_gettime, [], [AC_CHECK_LIB(rt, clock_gettime)])
 
-
-dnl with glibc and c99 mode the timespec required for clock_gettime is only
-dnl available in POSIX 199309L compatibility mode when clock_gettime is in librt
-if test "$ac_cv_lib_rt_clock_gettime" = "yes"; then
+dnl in principle clock_gettime and CLOCK_MONOTONIC/CLOCK_REALTIME should be available
+dnl only when using POSIX 199309, we set this explicitly here
+dnl this should not cause problems on any relatively modern (post y2k) machine!
+if ( test "$ac_cv_lib_rt_clock_gettime" = "yes" || test "$ac_cv_func_clock_gettime" = "yes" ); then
   AC_DEFINE(HAVE_CLOCK_GETTIME,1)
   CFLAGS="$CFLAGS -D_POSIX_C_SOURCE=199309L"
   AC_MSG_NOTICE([Instructing the compiler to use POSIX 199309L])

--- a/gettime.c
+++ b/gettime.c
@@ -23,6 +23,10 @@
 # include<config.h>
 #endif
 #include <time.h>
+#ifdef HAVE_CLOCK_GETTIME
+#include <sys/time.h>
+#include <bits/time.h>
+#endif
 #if (defined BGL && !defined BGP)
 #  include <rts.h>
 #endif


### PR DESCRIPTION
I've been noticing that without MPI, when gettime uses clock_gettime there are build failures on certain machines. This should fix these.
