### PR TITLE
Typo fixed that lead to dead lock in certain input constellations

### DIFF
--- a/online_measurement.c
+++ b/online_measurement.c
@@ -73,7 +73,7 @@ void online_measurement(const int traj, const int id, const int ieo) {
   sprintf(filename,"%s%.6d", "onlinemeas." ,traj);
 
   init_operators();
-  if(no_operators < 1 && g_proc_id == 0) {
+  if(no_operators < 1) {
     if(g_proc_id == 0) {
       fprintf(stderr, "Warning! no operators defined in input file, cannot perform online correlator mesurements!\n");
     }


### PR DESCRIPTION
If online measurement `CORRELLATORS` was defined in the input file, but no `Operator`, the code would run into a dead lock, which is fixed now.
