### PR TITLE
enable IO reread check also for LIME

### DIFF
--- a/hmc_tm.c
+++ b/hmc_tm.c
@@ -424,8 +424,8 @@ int main(int argc,char *argv[]) {
           fprintf(stderr, "Error %d while writing gauge field to %s\nAborting...\n", status, tmp_filename);
           exit(-2);
         }
+
         if (!g_disable_IO_checks) {
-#ifdef HAVE_LIBLEMON
           /* Read gauge field back to verify the writeout */
           if (g_proc_id == 0) {
             fprintf(stdout, "# Write completed, verifying write...\n");
@@ -438,11 +438,10 @@ int main(int argc,char *argv[]) {
           if (g_proc_id == 0) {
             fprintf(stdout, "# Write successfully verified.\n");
           }
-#else
+        } else {
           if (g_proc_id == 0) {
-            fprintf(stdout, "# Write completed successfully.\n");
+            fprintf(stdout, "# Write completed successfully. Write not verified!\n");
           }
-#endif
         }
         free(xlfInfo);
       }


### PR DESCRIPTION
as a precaution it would be a good idea to enable the checksum comparison also for the LIME writer
