### PR TITLE
sw_term and sw_invert were missing in cloverdetratio_acc

### DIFF
--- a/monomial/cloverdetratio_monomial.c
+++ b/monomial/cloverdetratio_monomial.c
@@ -286,6 +286,9 @@ double cloverdetratio_acc(const int id, hamiltonian_field_t * const hf) {
   atime = gettime();
   g_mu = mnl->mu;
   boundary(mnl->kappa);
+
+  sw_term( (const su3**) hf->gaugefield, mnl->kappa, mnl->c_sw); 
+  sw_invert(EE, mnl->mu);
   
   g_mu3 = mnl->rho2;
   mnl->Qp(mnl->w_fields[1], mnl->pf);


### PR DESCRIPTION
fixed now
