### PR TITLE
fix for random seed XOR and initialization of trajectory_counter

### DIFF
--- a/hmc_tm.c
+++ b/hmc_tm.c
@@ -90,7 +90,7 @@ int main(int argc,char *argv[]) {
   char tmp_filename[50];
   char *input_filename = NULL;
   int status = 0, accept = 0;
-  int j,ix,mu, trajectory_counter=1;
+  int j,ix,mu, trajectory_counter=0;
   struct timeval t1;
 
   /* Energy corresponding to the Gauge part */
@@ -287,7 +287,7 @@ int main(int argc,char *argv[]) {
 #endif
 
   /* Initialise random number generator */
-  start_ranlux(rlxd_level, random_seed^nstore );
+  start_ranlux(rlxd_level, random_seed^trajectory_counter);
 
   /* Set up the gauge field */
   /* continue and restart */


### PR DESCRIPTION
- when nmeas < nsave, nstore is not incremented from run to run and exactly the same random numbers will be used from run to run. This pull-request uses trajectory_counter to XOR "random_seed" with, thereby guaranteeing that the mentioned situation cannot occur.
- also, trajectory_counter is normally initialized to 1 but it was set to 0 if initialstorecounter was "readin" but no .nstore_counter file was present (or it was impossible to read), this commit makes the two self-consistent by numbering the first trajectory "0" in the default case as well
