### PR TITLE
Fix I/O attempts logic

### DIFF
--- a/LapH_ev.c
+++ b/LapH_ev.c
@@ -158,7 +158,7 @@ int main(int argc,char *argv[])
 	   conf_filename, (gauge_precision_read_flag == 32 ? "single" : "double"));
     fflush(stdout);
   }
-  if( (j = read_gauge_field(conf_filename)) !=0) {
+  if( (j = read_gauge_field(conf_filename,g_gauge_field)) !=0) {
     fprintf(stderr, "Error %d while reading gauge field from %s\n Aborting...\n", j, conf_filename);
     exit(-2);
   }

--- a/hopping_test.c
+++ b/hopping_test.c
@@ -256,7 +256,7 @@ int main(int argc,char *argv[])
   } else if ( startoption == 0 ) { /* cold */
     unit_g_gauge_field();
   } else if (startoption == 3 ) { /* continue */
-    read_gauge_field(gauge_input_filename);
+    read_gauge_field(gauge_input_filename,g_gauge_field);
   } else if ( startoption == 1 ) { /* hot */
   }
 

--- a/invert.c
+++ b/invert.c
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
             conf_filename, (gauge_precision_read_flag == 32 ? "single" : "double"));
       fflush(stdout);
     }
-    if( (i = read_gauge_field(conf_filename)) !=0) {
+    if( (i = read_gauge_field(conf_filename,g_gauge_field)) !=0) {
       fprintf(stderr, "Error %d while reading gauge field from %s\n Aborting...\n", i, conf_filename);
       exit(-2);
     }

--- a/io/gauge.h
+++ b/io/gauge.h
@@ -29,8 +29,8 @@
 #include <io/utils.h>
 
 
-int read_gauge_field(char *filename);
-int read_binary_gauge_data(READER *reader, DML_Checksum *checksum, paramsIldgFormat * ildgformat);
+int read_gauge_field(char *filename, su3 ** const gf);
+int read_binary_gauge_data(READER *reader, DML_Checksum *checksum, paramsIldgFormat * ildgformat, su3 ** const gf);
 
 int write_gauge_field(char * filename, int prec, paramsXlfInfo const *xlfInfo);
 int write_binary_gauge_data(WRITER * writer, const int prec, DML_Checksum * checksum);

--- a/io/gauge_read.c
+++ b/io/gauge_read.c
@@ -23,7 +23,7 @@
 extern int gauge_precision_read_flag;
 paramsGaugeInfo GaugeInfo = { 0., 0, {0,0}, NULL, NULL};
 
-int read_gauge_field(char * filename) {
+int read_gauge_field(char * filename, su3 ** const gf) {
   int status = 0;
   char *header_type = NULL;
   READER *reader = NULL;
@@ -64,7 +64,7 @@ int read_gauge_field(char * filename) {
         fprintf(stderr, "Unable to verify integrity of the gauge field data.\n");
         return(-1);
       }
-      gauge_binary_status = read_binary_gauge_data(reader, &checksum_calc, ildgformat_input);
+      gauge_binary_status = read_binary_gauge_data(reader, &checksum_calc, ildgformat_input, gf);
       if (gauge_binary_status) {
         fprintf(stderr, "Gauge file reading failed at binary part, unable to proceed.\n");
         return(-1);

--- a/io/gauge_read_binary.c
+++ b/io/gauge_read_binary.c
@@ -22,9 +22,8 @@
 /* FIXME I will first fix this function by using referral.
          Probably should be done better in the future. AD. */
 
-
 #ifdef HAVE_LIBLEMON
-int read_binary_gauge_data(LemonReader * lemonreader, DML_Checksum * checksum, paramsIldgFormat * input)
+int read_binary_gauge_data(LemonReader * lemonreader, DML_Checksum * checksum, paramsIldgFormat * input, su3 ** const gf)
 {
   int t, x, y, z, status = 0;
   int latticeSize[] = {input->lt, input->lx, input->ly, input->lz};
@@ -102,16 +101,16 @@ int read_binary_gauge_data(LemonReader * lemonreader, DML_Checksum * checksum, p
           current = filebuffer + bytes * (x + (y + (t * LZ + z) * LY) * LX);
           DML_checksum_accum(checksum, rank, current, bytes);
           if (input->prec == 32) {
-            be_to_cpu_assign_single2double(&g_gauge_field[ g_ipt[t][x][y][z] ][1], current            , sizeof(su3) / 8);
-            be_to_cpu_assign_single2double(&g_gauge_field[ g_ipt[t][x][y][z] ][2], current +     fbsu3, sizeof(su3) / 8);
-            be_to_cpu_assign_single2double(&g_gauge_field[ g_ipt[t][x][y][z] ][3], current + 2 * fbsu3, sizeof(su3) / 8);
-            be_to_cpu_assign_single2double(&g_gauge_field[ g_ipt[t][x][y][z] ][0], current + 3 * fbsu3, sizeof(su3) / 8);
+            be_to_cpu_assign_single2double(&gf[ g_ipt[t][x][y][z] ][1], current            , sizeof(su3) / 8);
+            be_to_cpu_assign_single2double(&gf[ g_ipt[t][x][y][z] ][2], current +     fbsu3, sizeof(su3) / 8);
+            be_to_cpu_assign_single2double(&gf[ g_ipt[t][x][y][z] ][3], current + 2 * fbsu3, sizeof(su3) / 8);
+            be_to_cpu_assign_single2double(&gf[ g_ipt[t][x][y][z] ][0], current + 3 * fbsu3, sizeof(su3) / 8);
           }
           else {
-            be_to_cpu_assign(&g_gauge_field[ g_ipt[t][x][y][z] ][1], current            , sizeof(su3) / 8);
-            be_to_cpu_assign(&g_gauge_field[ g_ipt[t][x][y][z] ][2], current +     fbsu3, sizeof(su3) / 8);
-            be_to_cpu_assign(&g_gauge_field[ g_ipt[t][x][y][z] ][3], current + 2 * fbsu3, sizeof(su3) / 8);
-            be_to_cpu_assign(&g_gauge_field[ g_ipt[t][x][y][z] ][0], current + 3 * fbsu3, sizeof(su3) / 8);
+            be_to_cpu_assign(&gf[ g_ipt[t][x][y][z] ][1], current            , sizeof(su3) / 8);
+            be_to_cpu_assign(&gf[ g_ipt[t][x][y][z] ][2], current +     fbsu3, sizeof(su3) / 8);
+            be_to_cpu_assign(&gf[ g_ipt[t][x][y][z] ][3], current + 2 * fbsu3, sizeof(su3) / 8);
+            be_to_cpu_assign(&gf[ g_ipt[t][x][y][z] ][0], current + 3 * fbsu3, sizeof(su3) / 8);
           }
         }
       }
@@ -123,7 +122,7 @@ int read_binary_gauge_data(LemonReader * lemonreader, DML_Checksum * checksum, p
   return(0);
 }
 #else /* HAVE_LIBLEMON */
-int read_binary_gauge_data(LimeReader * limereader, DML_Checksum * checksum, paramsIldgFormat * input) {
+int read_binary_gauge_data(LimeReader * limereader, DML_Checksum * checksum, paramsIldgFormat * input, su3 ** const gf) {
 
   int t, x, y , z, status=0;
   int latticeSize[] = {input->lt, input->lx, input->ly, input->lz};
@@ -186,16 +185,16 @@ int read_binary_gauge_data(LimeReader * limereader, DML_Checksum * checksum, par
             return(-2);
           }
           if(input->prec == 32) {
-            be_to_cpu_assign_single2double(&g_gauge_field[ g_ipt[t][x][y][z] ][0], &tmp2[3*18], sizeof(su3)/8);
-            be_to_cpu_assign_single2double(&g_gauge_field[ g_ipt[t][x][y][z] ][1], &tmp2[0*18], sizeof(su3)/8);
-            be_to_cpu_assign_single2double(&g_gauge_field[ g_ipt[t][x][y][z] ][2], &tmp2[1*18], sizeof(su3)/8);
-            be_to_cpu_assign_single2double(&g_gauge_field[ g_ipt[t][x][y][z] ][3], &tmp2[2*18], sizeof(su3)/8);
+            be_to_cpu_assign_single2double(&gf[ g_ipt[t][x][y][z] ][0], &tmp2[3*18], sizeof(su3)/8);
+            be_to_cpu_assign_single2double(&gf[ g_ipt[t][x][y][z] ][1], &tmp2[0*18], sizeof(su3)/8);
+            be_to_cpu_assign_single2double(&gf[ g_ipt[t][x][y][z] ][2], &tmp2[1*18], sizeof(su3)/8);
+            be_to_cpu_assign_single2double(&gf[ g_ipt[t][x][y][z] ][3], &tmp2[2*18], sizeof(su3)/8);
           }
           else {
-            be_to_cpu_assign(&g_gauge_field[ g_ipt[t][x][y][z] ][0], &tmp[3], sizeof(su3)/8);
-            be_to_cpu_assign(&g_gauge_field[ g_ipt[t][x][y][z] ][1], &tmp[0], sizeof(su3)/8);
-            be_to_cpu_assign(&g_gauge_field[ g_ipt[t][x][y][z] ][2], &tmp[1], sizeof(su3)/8);
-            be_to_cpu_assign(&g_gauge_field[ g_ipt[t][x][y][z] ][3], &tmp[2], sizeof(su3)/8);
+            be_to_cpu_assign(&gf[ g_ipt[t][x][y][z] ][0], &tmp[3], sizeof(su3)/8);
+            be_to_cpu_assign(&gf[ g_ipt[t][x][y][z] ][1], &tmp[0], sizeof(su3)/8);
+            be_to_cpu_assign(&gf[ g_ipt[t][x][y][z] ][2], &tmp[1], sizeof(su3)/8);
+            be_to_cpu_assign(&gf[ g_ipt[t][x][y][z] ][3], &tmp[2], sizeof(su3)/8);
           }
         }
       }

--- a/test/test_eigenvalues.c
+++ b/test/test_eigenvalues.c
@@ -400,7 +400,7 @@ int main(int argc,char *argv[]) {
 	printf("Reading Gauge field from file %s\n", gauge_input_filename); fflush(stdout);
       }
       
-      read_gauge_field_time_p(gauge_input_filename);
+      read_gauge_field_time_p(gauge_input_filename,g_gauge_field);
     }
   }
   if(startoption != 3){
@@ -444,7 +444,7 @@ int main(int argc,char *argv[]) {
       if (g_proc_id == 0){
 	printf("Reading Gauge field from file %s\n", gauge_input_filename); fflush(stdout);
       }
-      read_gauge_field_time_p(gauge_input_filename);
+      read_gauge_field_time_p(gauge_input_filename,g_gauge_field);
     }
 
   }

--- a/update_tm.c
+++ b/update_tm.c
@@ -68,7 +68,6 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
 	      const int traj_counter) {
 
   su3 *v, *w;
-  static int ini_g_tmp = 0;
   int accept, i=0, j=0, iostatus=0;
 
   double yy[1];
@@ -99,13 +98,6 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
   integrator_set_fields(&hf);
 
   strcpy(tmp_filename, ".conf.tmp");
-  if(ini_g_tmp == 0) {
-    ini_g_tmp = init_gauge_tmp(VOLUME);
-    if(ini_g_tmp != 0) {
-      exit(-1);
-    }
-    ini_g_tmp = 1;
-  }
   atime = gettime();
 
   /*
@@ -298,12 +290,13 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
     }
 
     if(accept) {
-      /* Read back gauge field */
+      /* Read back gauge field
+         FIXME unlike in hmc_tm we abort immediately if there is a failure */
       if(g_proc_id == 0 && g_debug_level > 0) {
         fprintf(stdout, "# Trying to read gauge field from file %s.\n", tmp_filename);
       }
 
-      if((iostatus = read_gauge_field(tmp_filename) != 0)) {
+      if((iostatus = read_gauge_field(tmp_filename,g_gauge_field) != 0)) {
         fprintf(stderr, "Error %d while reading gauge field from %s\nAborting...\n", iostatus, tmp_filename);
         exit(-2);
       }


### PR DESCRIPTION
This commit fixes the bug that caused the reread check to overwrite
the original gauge field memory. If the n'th write attempt then succeeded,
the configuration would be written with the wrong contents from the point of view
of the simulation.

Changes:
Add gauge field pointer argument to gauge field reading functions.
Use gauge_tmp as a buffer for gauge reread checks in hmc_tm.
Make multiple attempts at reading .conf.tmp
If all attempts fail, write again.
If all writing attempts fail, abort the program.
