### PR TITLE
in hmc_tm, correctly pass acctest to update_tm even for trajectory 0

### DIFF
--- a/hmc_tm.c
+++ b/hmc_tm.c
@@ -394,7 +394,7 @@ int main(int argc,char *argv[]) {
     return_check = return_check_flag && (trajectory_counter%return_check_interval == 0);
 
     accept = update_tm(&plaquette_energy, &rectangle_energy, datafilename, 
-		       return_check, Ntherm<trajectory_counter, trajectory_counter);
+		       return_check, trajectory_counter>=Ntherm, trajectory_counter);
     Rate += accept;
 
     /* Save gauge configuration all Nsave times */

--- a/update_tm.c
+++ b/update_tm.c
@@ -187,6 +187,7 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
   }
 #endif
 
+  /* when acctest is 0 (i.e. do not perform acceptance test), the trajectory is accepted whatever the energy difference */
   accept = (!acctest | (expmdh > yy[0]));
   if(g_proc_id == 0) {
     fprintf(stdout, "# Trajectory is %saccepted.\n", (accept ? "" : "not "));


### PR DESCRIPTION
Fixes a silly bug introduced by me when i made the initial trajectory number consistent across parameter values. At the time the first trajectory would be 0 if "readin" was specified but .nstore_counter would fail to be read. Otherwise it would start at 1. With my changes from a couple of months ago it now always starts at 0. I overlooked, however, that update_tm is called with acctest equal to the result of a comparison between Ntherm and trajcounter, which would evaluate to false (0) for trajectory 0 and Ntherm 0, thereby skipping the acceptance test in the first trajectory.
