### PR TITLE
Make MPI_Finalize the last instruction executed

### DIFF
--- a/benchmark.c
+++ b/benchmark.c
@@ -415,9 +415,6 @@ int main(int argc,char *argv[])
 #endif
 
 
-#ifdef MPI
-  MPI_Finalize();
-#endif
 #ifdef OMP
   free_omp_accumulators();
 #endif
@@ -425,5 +422,9 @@ int main(int argc,char *argv[])
   free_geometry_indices();
   free_spinor_field();
   free_moment_field();
+#ifdef MPI
+  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Finalize();
+#endif
   return(0);
 }

--- a/hmc_tm.c
+++ b/hmc_tm.c
@@ -522,9 +522,6 @@ int main(int argc,char *argv[]) {
     fclose(parameterfile);
   }
 
-#ifdef MPI
-  MPI_Finalize();
-#endif
 #ifdef OMP
   free_omp_accumulators();
 #endif
@@ -540,6 +537,10 @@ int main(int argc,char *argv[]) {
   }
   free(input_filename);
   free(filename);
+#ifdef MPI
+  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Finalize();
+#endif
   return(0);
 #ifdef _KOJAK_INST
 #pragma pomp inst end(main)

--- a/invert.c
+++ b/invert.c
@@ -477,9 +477,6 @@ int main(int argc, char *argv[])
     nstore += Nsave;
   }
 
-#ifdef MPI
-  MPI_Finalize();
-#endif
 #ifdef OMP
   free_omp_accumulators();
 #endif
@@ -492,6 +489,10 @@ int main(int argc, char *argv[])
   free_chi_spinor_field();
   free(filename);
   free(input_filename);
+#ifdef MPI
+  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Finalize();
+#endif
   return(0);
 #ifdef _KOJAK_INST
 #pragma pomp inst end(main)


### PR DESCRIPTION
MPI Finalize should be the very last instruction executed before the final return
