### PR TITLE
fixed typo preventing to properly include config.h

### DIFF
--- a/solver/dirac_operator_eigenvectors.c
+++ b/solver/dirac_operator_eigenvectors.c
@@ -1,5 +1,24 @@
+/***********************************************************************
+ *
+ * Copyright (C) 2014 Carsten Urbach
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ ************************************************************************/
 
-#if HAVE_CONFIG_H
+#ifdef HAVE_CONFIG_H
 #include<config.h>
 #endif
 #include <stdlib.h>

--- a/solver/dirac_operator_eigenvectors.h
+++ b/solver/dirac_operator_eigenvectors.h
@@ -1,7 +1,29 @@
+/***********************************************************************
+ *
+ * Copyright (C) 2014 Carsten Urbach
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ ************************************************************************/
+
 #ifndef _DIRAC_EIGENVALUES_H
 #define _DIRAC_EIGENVALUES_H
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
 #ifdef HAVE_FFTW
   #include <fftw3.h>
 #endif


### PR DESCRIPTION
this fixes a wrongly included config.h in dirac_operator_eigenvectors.c|h
