### PR TITLE
random_gauge_field incorrect ranlux state reset

### DIFF
--- a/start.c
+++ b/start.c
@@ -475,7 +475,7 @@ void random_gauge_field(const int repro, su3 ** const gf) {
     }
 #ifdef MPI
     if(g_proc_id != 0) {
-      rlxd_get(rlxd_state_backup);
+      rlxd_reset(rlxd_state_backup);
     }
 #endif
   }


### PR DESCRIPTION
in reproduce_randomnumber mode the ranlux state was not correctly reset

this was probably of minimal consequence because where it mattered random numbers were requested only through the routines in start.c, which all support the repro mode, but it did mean that after a hot start (or another request for a random gauge field), all N-1 RNGs were in the same state from here onwards and if RNs were requested via any other means, all processes would produce the same ones!
