### PR TITLE
offline_measurement: fix failed compilation of offline_measuremet

### DIFF
--- a/offline_measurement.c
+++ b/offline_measurement.c
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
             conf_filename, (gauge_precision_read_flag == 32 ? "single" : "double"));
       fflush(stdout);
     }
-    if( (i = read_gauge_field(conf_filename)) !=0) {
+    if( (i = read_gauge_field(conf_filename,g_gauge_field)) !=0) {
       fprintf(stderr, "Error %d while reading gauge field from %s\n Aborting...\n", i, conf_filename);
       exit(-2);
     }
@@ -297,7 +297,7 @@ int main(int argc, char *argv[])
 #endif
 
     /*compute the energy of the gauge field*/
-    plaquette_energy = measure_gauge_action( (const su3** const) g_gauge_field);
+    plaquette_energy = measure_plaquette( (const su3** const) g_gauge_field);
 
     if (g_cart_id == 0) {
       printf("# The computed plaquette value is %e.\n", plaquette_energy / (6.*VOLUME*g_nproc));


### PR DESCRIPTION
Due to an oversight offline_measurement could not be compiled. This fixes the problem.