### PR TITLE
read_input: make rmQuotes static inline void to satisfy Cray compiler

### DIFF
--- a/read_input.l
+++ b/read_input.l
@@ -63,7 +63,7 @@ EQL {SPC}*={SPC}*
 #include"phmc.h"
 #include<io/params.h>
 
-inline void rmQuotes(char *str){
+static inline void rmQuotes(char *str){
   char* strsave=str;
 
   while(*str== ' ' || *str == '\t') str++;


### PR DESCRIPTION
The Cray compiler complains about not being able to find the rmQuotes function. Declaring it ```static inline void``` seems to fix the problem.