### PR TITLE
sse.h was not included when configured for SSEX usage

### DIFF
--- a/matrix_utils.c
+++ b/matrix_utils.c
@@ -25,6 +25,9 @@
 #include <math.h>
 #include <complex.h> 
 
+#if (defined SSE || defined SSE2 || defined SSE3)
+# include "sse.h"
+#endif
 #include "su3.h"
 
 #ifndef OMP


### PR DESCRIPTION
hmm, somehow I never tested this with SSE ...

We could also include `global.h` instead, but this would create more dependencies. 