### PR TITLE
monomial components for mixed cg

### DIFF
--- a/default_input_values.h
+++ b/default_input_values.h
@@ -171,7 +171,7 @@
 
 /* default mixed precision solver values */
 #define _default_mixcg_innereps 1.0e-6
-#define _default_mixcg_maxinnersolverit 1500
+#define _default_mixcg_maxinnersolverit 5000
 
 #define _default_use_preconditioning 0
 

--- a/hmc_tm.c
+++ b/hmc_tm.c
@@ -164,7 +164,10 @@ int main(int argc,char *argv[]) {
 
   DUM_BI_MATRIX = DUM_BI_SOLVER+6;
   NO_OF_BISPINORFIELDS = DUM_BI_MATRIX+6;
-
+  
+  //4 extra fields (corresponding to DUM_MATRIX+0..5) for deg. and ND matrix mult.
+  NO_OF_SPINORFIELDS_32 = 6;
+  
   tmlqcd_mpi_init(argc, argv);
 
   if(nstore == -1) {
@@ -190,8 +193,10 @@ int main(int argc,char *argv[]) {
   
 #ifdef _GAUGE_COPY
   status = init_gauge_field(VOLUMEPLUSRAND + g_dbw2rand, 1);
+  status += init_gauge_field_32(VOLUMEPLUSRAND + g_dbw2rand, 1);
 #else
   status = init_gauge_field(VOLUMEPLUSRAND + g_dbw2rand, 0);
+  status += init_gauge_field_32(VOLUMEPLUSRAND + g_dbw2rand, 0);   
 #endif
   /* need temporary gauge field for gauge reread checks and in update_tm */
   status += init_gauge_tmp(VOLUME);
@@ -207,9 +212,11 @@ int main(int argc,char *argv[]) {
   }
   if(even_odd_flag) {
     j = init_spinor_field(VOLUMEPLUSRAND/2, NO_OF_SPINORFIELDS);
+    j += init_spinor_field_32(VOLUMEPLUSRAND/2, NO_OF_SPINORFIELDS_32);      
   }
   else {
     j = init_spinor_field(VOLUMEPLUSRAND, NO_OF_SPINORFIELDS);
+    j += init_spinor_field_32(VOLUMEPLUSRAND, NO_OF_SPINORFIELDS_32);    
   }
   if (j != 0) {
     fprintf(stderr, "Not enough memory for spinor fields! Aborting...\n");
@@ -279,9 +286,14 @@ int main(int argc,char *argv[]) {
     fprintf(stderr, "Not enough memory for halffield! Aborting...\n");
     exit(-1);
   }
-  if(g_sloppy_precision_flag == 1) {
-    init_dirac_halfspinor32();
-  }
+
+  j = init_dirac_halfspinor32();
+  if (j != 0)
+  {
+    fprintf(stderr, "Not enough memory for 32-bit halffield! Aborting...\n");
+    exit(-1);
+  } 
+  
 #  if (defined _PERSISTENT)
   init_xchange_halffield();
 #  endif
@@ -321,7 +333,11 @@ int main(int argc,char *argv[]) {
 #ifdef MPI
   xchange_gauge(g_gauge_field);
 #endif
-
+    
+  /*Convert to a 32 bit gauge field, after xchange*/
+  convert_32_gauge_field(g_gauge_field_32, g_gauge_field, VOLUMEPLUSRAND + g_dbw2rand);
+  
+    
   if(even_odd_flag) {
     j = init_monomials(VOLUMEPLUSRAND/2, even_odd_flag);
   }
@@ -543,8 +559,10 @@ int main(int argc,char *argv[]) {
 #endif
   free_gauge_tmp();
   free_gauge_field();
+  free_gauge_field_32();  
   free_geometry_indices();
   free_spinor_field();
+  free_spinor_field_32();  
   free_moment_field();
   free_monomials();
   if(g_running_phmc) {

--- a/init/init_dirac_halfspinor.c
+++ b/init/init_dirac_halfspinor.c
@@ -96,57 +96,55 @@ int init_dirac_halfspinor() {
       y = (j-t*(LX*LY*LZ)-x*(LY*LZ))/(LZ);
       z = (j-t*(LX*LY*LZ)-x*(LY*LZ) - y*LZ);
       for(int mu = 0; mu < 4; mu++) {
-	NBPointer[ieo][8*i + 2*mu + 0] = &HalfSpinor[ 8*g_lexic2eosub[ g_idn[j][mu] ] + 2*mu + 0];
-	NBPointer[ieo][8*i + 2*mu + 1] = &HalfSpinor[ 8*g_lexic2eosub[ g_iup[j][mu] ] + 2*mu + 1];
+        NBPointer[ieo][8*i + 2*mu + 0] = &HalfSpinor[ 8*g_lexic2eosub[ g_idn[j][mu] ] + 2*mu + 0];
+        NBPointer[ieo][8*i + 2*mu + 1] = &HalfSpinor[ 8*g_lexic2eosub[ g_iup[j][mu] ] + 2*mu + 1];
       }
 #if ((defined PARALLELT) || (defined PARALLELXT) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(t == 0) {
-	k = (g_lexic2eosub[g_idn[j][0]] - VOLUME/2);
-	NBPointer[ieo][8*i] = &sendBuffer[ k ];
+        k = (g_lexic2eosub[g_idn[j][0]] - VOLUME/2);
+        NBPointer[ieo][8*i] = &sendBuffer[ k ];
       }
       if(t == T-1) {
-	k = (g_lexic2eosub[g_iup[j][0]] - VOLUME/2);
-	NBPointer[ieo][8*i + 1] = &sendBuffer[ k ];
+        k = (g_lexic2eosub[g_iup[j][0]] - VOLUME/2);
+        NBPointer[ieo][8*i + 1] = &sendBuffer[ k ];
       }
 #endif
 #if ((defined PARALLELX) || (defined PARALLELXY) || (defined PARALLELXYZ) || (defined PARALLELXT) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(x == 0) {
-	k = (g_lexic2eosub[g_idn[j][1]] - VOLUME/2);
-	NBPointer[ieo][8*i + 2] = &sendBuffer[ k ];
+        k = (g_lexic2eosub[g_idn[j][1]] - VOLUME/2);
+        NBPointer[ieo][8*i + 2] = &sendBuffer[ k ];
       }
       if(x == LX-1) {
-	k = (g_lexic2eosub[g_iup[j][1]] - VOLUME/2);
-	NBPointer[ieo][8*i + 3] = &sendBuffer[ k ];
+        k = (g_lexic2eosub[g_iup[j][1]] - VOLUME/2);
+        NBPointer[ieo][8*i + 3] = &sendBuffer[ k ];
       }
 #endif
 #if ((defined PARALLELXY) || (defined PARALLELXYZ) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(y == 0) {
-	k = (g_lexic2eosub[g_idn[j][2]] - VOLUME/2);
-	NBPointer[ieo][8*i + 4] = &sendBuffer[ k ];
+        k = (g_lexic2eosub[g_idn[j][2]] - VOLUME/2);
+        NBPointer[ieo][8*i + 4] = &sendBuffer[ k ];
       }
       if(y == LY-1) {
-	k = (g_lexic2eosub[g_iup[j][2]] - VOLUME/2);
-	NBPointer[ieo][8*i + 5] = &sendBuffer[ k ];
+        k = (g_lexic2eosub[g_iup[j][2]] - VOLUME/2);
+        NBPointer[ieo][8*i + 5] = &sendBuffer[ k ];
       }
 #endif
 #if ((defined PARALLELXYZ) || (defined PARALLELXYZT))
       if(z == 0) {
-	k = (g_lexic2eosub[g_idn[j][3]] - VOLUME/2);
-	NBPointer[ieo][8*i + 6] = &sendBuffer[ k ];
+        k = (g_lexic2eosub[g_idn[j][3]] - VOLUME/2);
+        NBPointer[ieo][8*i + 6] = &sendBuffer[ k ];
       }
       if(z == LZ-1) {
-	k = (g_lexic2eosub[g_iup[j][3]] - VOLUME/2);
-	NBPointer[ieo][8*i + 7] = &sendBuffer[ k ];
+        k = (g_lexic2eosub[g_iup[j][3]] - VOLUME/2);
+        NBPointer[ieo][8*i + 7] = &sendBuffer[ k ];
       }
 #endif
     }
     for(int i = VOLUME/2; i < (VOLUME+RAND)/2; i++) {
       for(int mu = 0; mu < 8; mu++) {
-	NBPointer[ieo][8*i + mu] = NBPointer[ieo][0];
+        NBPointer[ieo][8*i + mu] = NBPointer[ieo][0];
       }
     }
-#ifdef MPI
-#endif
   }
   for(int ieo = 2; ieo < 4; ieo++) {
     for(int i = 0; i < VOLUME/2; i++) {
@@ -157,44 +155,44 @@ int init_dirac_halfspinor() {
       y = (j-t*(LX*LY*LZ)-x*(LY*LZ))/(LZ);
       z = (j-t*(LX*LY*LZ)-x*(LY*LZ) - y*LZ);
       for(int mu = 0; mu < 8; mu++) {
-	NBPointer[ieo][8*i + mu] = &HalfSpinor[8*i + mu];
+        NBPointer[ieo][8*i + mu] = &HalfSpinor[8*i + mu];
       }
 #if ((defined PARALLELT) || (defined PARALLELXT) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(t == T-1) {
-	NBPointer[ieo][8*i]     = &recvBuffer[ (g_lexic2eosub[ g_iup[j][0] ] - VOLUME/2)];
+        NBPointer[ieo][8*i]     = &recvBuffer[ (g_lexic2eosub[ g_iup[j][0] ] - VOLUME/2)];
       }
       if(t == 0) {
-	NBPointer[ieo][8*i + 1] = &recvBuffer[ (g_lexic2eosub[ g_idn[j][0] ] - VOLUME/2)];
+        NBPointer[ieo][8*i + 1] = &recvBuffer[ (g_lexic2eosub[ g_idn[j][0] ] - VOLUME/2)];
       }
 #endif
 #if ((defined PARALLELX) || (defined PARALLELXY) || (defined PARALLELXYZ) || (defined PARALLELXT) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(x == LX-1) { 
-	NBPointer[ieo][8*i + 2] = &recvBuffer[ (g_lexic2eosub[ g_iup[j][1] ] - VOLUME/2)];
+        NBPointer[ieo][8*i + 2] = &recvBuffer[ (g_lexic2eosub[ g_iup[j][1] ] - VOLUME/2)];
       }
       if(x == 0) {
-	NBPointer[ieo][8*i + 3] = &recvBuffer[ (g_lexic2eosub[ g_idn[j][1] ] - VOLUME/2)];
+        NBPointer[ieo][8*i + 3] = &recvBuffer[ (g_lexic2eosub[ g_idn[j][1] ] - VOLUME/2)];
       }
 #endif
 #if ((defined PARALLELXY) || (defined PARALLELXYZ) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(y == LY-1) {
-	NBPointer[ieo][8*i + 4] = &recvBuffer[ (g_lexic2eosub[ g_iup[j][2] ] - VOLUME/2)];
+        NBPointer[ieo][8*i + 4] = &recvBuffer[ (g_lexic2eosub[ g_iup[j][2] ] - VOLUME/2)];
       }
       if(y == 0) {
-	NBPointer[ieo][8*i + 5] = &recvBuffer[ (g_lexic2eosub[ g_idn[j][2] ] - VOLUME/2)];
+        NBPointer[ieo][8*i + 5] = &recvBuffer[ (g_lexic2eosub[ g_idn[j][2] ] - VOLUME/2)];
       }
 #endif
 #if ((defined PARALLELXYZ) || (defined PARALLELXYZT))
       if(z == LZ-1) {
-	NBPointer[ieo][8*i + 6] = &recvBuffer[ (g_lexic2eosub[ g_iup[j][3] ] - VOLUME/2)];
+        NBPointer[ieo][8*i + 6] = &recvBuffer[ (g_lexic2eosub[ g_iup[j][3] ] - VOLUME/2)];
       }
       if(z == 0) {
-	NBPointer[ieo][8*i + 7] = &recvBuffer[ (g_lexic2eosub[ g_idn[j][3] ] - VOLUME/2)];
+        NBPointer[ieo][8*i + 7] = &recvBuffer[ (g_lexic2eosub[ g_idn[j][3] ] - VOLUME/2)];
       }
 #endif
     }
     for(int i = VOLUME/2; i < (VOLUME+RAND)/2; i++) {
       for(int mu = 0; mu < 8; mu++) {
-	NBPointer[ieo][8*i + mu] = NBPointer[ieo][0];
+        NBPointer[ieo][8*i + mu] = NBPointer[ieo][0];
       }
     }
   }
@@ -257,12 +255,12 @@ int init_dirac_halfspinor() {
 
   // Setup the FIFO handles
   rc = msg_InjFifoInit ( &injFifoHandle,
-			 0,                      /* startingSubgroupId */
-			 0,                      /* startingFifoId     */
-			 spi_num_dirs,           /* numFifos   */
-			 INJ_MEMORY_FIFO_SIZE+1, /* fifoSize */
-			 NULL                    /* Use default attributes */
-			 );
+       0,                      /* startingSubgroupId */
+       0,                      /* startingFifoId     */
+       spi_num_dirs,           /* numFifos   */
+       INJ_MEMORY_FIFO_SIZE+1, /* fifoSize */
+       NULL                    /* Use default attributes */
+       );
   if(rc != 0) {
     fprintf(stderr, "msg_InjFifoInit failed with rc=%d\n",rc);
     exit(1);
@@ -301,8 +299,8 @@ int init_dirac_halfspinor() {
   for (unsigned int j = 0; j < spi_num_dirs; j++) {
     descCount[ j ] =
       msg_InjFifoInject ( injFifoHandle,
-			  j,
-			  &SPIDescriptors[j]);
+        j,
+        &SPIDescriptors[j]);
   }
   // wait for receive completion
   while ( recvCounter > 0 );
@@ -321,16 +319,16 @@ int init_dirac_halfspinor() {
     if(i == 7) k = g_nb_z_dn;
     for(int mu = 0; mu < messageSizes[i]/sizeof(halfspinor); mu++) {
       if(k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s0.c0) ||
-	 k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s0.c1) ||
-	 k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s0.c2) ||
-	 k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s1.c0) ||
-	 k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s1.c1) ||
-	 k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s1.c2)) {
-	if(g_cart_id == 0) {
-	  printf("SPI exchange doesn't work for dir %d: %d != %d at point %d\n", 
-		 i, k ,(int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s0.c0), mu);
-	}
-	j++;
+   k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s0.c1) ||
+   k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s0.c2) ||
+   k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s1.c0) ||
+   k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s1.c1) ||
+   k != (int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s1.c2)) {
+  if(g_cart_id == 0) {
+    printf("SPI exchange doesn't work for dir %d: %d != %d at point %d\n", 
+     i, k ,(int)creal(recvBuffer[ soffsets[i]/sizeof(halfspinor) + mu ].s0.c0), mu);
+  }
+  j++;
       }
     }
   }
@@ -381,49 +379,54 @@ int init_dirac_halfspinor32() {
       y = (j-t*(LX*LY*LZ)-x*(LY*LZ))/(LZ);
       z = (j-t*(LX*LY*LZ)-x*(LY*LZ) - y*LZ);
       for(mu = 0; mu < 4; mu++) {
-	NBPointer32[ieo][8*i + 2*mu + 0] = &HalfSpinor32[ 8*g_lexic2eosub[ g_idn[j][mu] ] + 2*mu + 0];
-	NBPointer32[ieo][8*i + 2*mu + 1] = &HalfSpinor32[ 8*g_lexic2eosub[ g_iup[j][mu] ] + 2*mu + 1];
+        NBPointer32[ieo][8*i + 2*mu + 0] = &HalfSpinor32[ 8*g_lexic2eosub[ g_idn[j][mu] ] + 2*mu + 0];
+        NBPointer32[ieo][8*i + 2*mu + 1] = &HalfSpinor32[ 8*g_lexic2eosub[ g_iup[j][mu] ] + 2*mu + 1];
       }
 #if ((defined PARALLELT) || (defined PARALLELXT) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(t == 0) {
-	k = (g_lexic2eosub[g_idn[j][0]] - VOLUME/2);
-	NBPointer32[ieo][8*i] = &sendBuffer32[ k ];
+        k = (g_lexic2eosub[g_idn[j][0]] - VOLUME/2);
+        NBPointer32[ieo][8*i] = &sendBuffer32[ k ];
       }
       if(t == T-1) {
-	k = (g_lexic2eosub[g_iup[j][0]] - VOLUME/2);
-	NBPointer32[ieo][8*i + 1] = &sendBuffer32[ k ];
+        k = (g_lexic2eosub[g_iup[j][0]] - VOLUME/2);
+        NBPointer32[ieo][8*i + 1] = &sendBuffer32[ k ];
       }
 #endif
 #if ((defined PARALLELX) || (defined PARALLELXY) || (defined PARALLELXYZ) || (defined PARALLELXT) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(x == 0) {
-	k = (g_lexic2eosub[g_idn[j][1]] - VOLUME/2);
-	NBPointer32[ieo][8*i + 2] = &sendBuffer32[ k ];
+        k = (g_lexic2eosub[g_idn[j][1]] - VOLUME/2);
+        NBPointer32[ieo][8*i + 2] = &sendBuffer32[ k ];
       }
       if(x == LX-1) {
-	k = (g_lexic2eosub[g_iup[j][1]] - VOLUME/2);
-	NBPointer32[ieo][8*i + 3] = &sendBuffer32[ k ];
+        k = (g_lexic2eosub[g_iup[j][1]] - VOLUME/2);
+        NBPointer32[ieo][8*i + 3] = &sendBuffer32[ k ];
       }
 #endif
 #if ((defined PARALLELXY) || (defined PARALLELXYZ) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(y == 0) {
-	k = (g_lexic2eosub[g_idn[j][2]] - VOLUME/2);
-	NBPointer32[ieo][8*i + 4] = &sendBuffer32[ k ];
+        k = (g_lexic2eosub[g_idn[j][2]] - VOLUME/2);
+        NBPointer32[ieo][8*i + 4] = &sendBuffer32[ k ];
       }
       if(y == LY-1) {
-	k = (g_lexic2eosub[g_iup[j][2]] - VOLUME/2);
-	NBPointer32[ieo][8*i + 5] = &sendBuffer32[ k ];
+        k = (g_lexic2eosub[g_iup[j][2]] - VOLUME/2);
+        NBPointer32[ieo][8*i + 5] = &sendBuffer32[ k ];
       }
 #endif
 #if ((defined PARALLELXYZ) || (defined PARALLELXYZT))
       if(z == 0) {
-	k = (g_lexic2eosub[g_idn[j][3]] - VOLUME/2);
-	NBPointer32[ieo][8*i + 6] = &sendBuffer32[ k ];
+        k = (g_lexic2eosub[g_idn[j][3]] - VOLUME/2);
+        NBPointer32[ieo][8*i + 6] = &sendBuffer32[ k ];
       }
       if(z == LZ-1) {
-	k = (g_lexic2eosub[g_iup[j][3]] - VOLUME/2);
-	NBPointer32[ieo][8*i + 7] = &sendBuffer32[ k ];
+        k = (g_lexic2eosub[g_iup[j][3]] - VOLUME/2);
+        NBPointer32[ieo][8*i + 7] = &sendBuffer32[ k ];
       }
 #endif
+    }
+    for(int i = VOLUME/2; i < (VOLUME+RAND)/2; i++) {
+      for(int mu = 0; mu < 8; mu++) {
+        NBPointer32[ieo][8*i + mu] = NBPointer32[ieo][0];
+      }
     }
   }
   for(int ieo = 2; ieo < 4; ieo++) {
@@ -435,40 +438,45 @@ int init_dirac_halfspinor32() {
       y = (j-t*(LX*LY*LZ)-x*(LY*LZ))/(LZ);
       z = (j-t*(LX*LY*LZ)-x*(LY*LZ) - y*LZ);
       for(mu = 0; mu < 8; mu++) {
-	NBPointer32[ieo][8*i + mu] = &HalfSpinor32[8*i + mu];
+        NBPointer32[ieo][8*i + mu] = &HalfSpinor32[8*i + mu];
       }
 #if ((defined PARALLELT) || (defined PARALLELXT) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(t == T-1) {
-	NBPointer32[ieo][8*i]     = &recvBuffer32[ (g_lexic2eosub[ g_iup[j][0] ] - VOLUME/2)];
+        NBPointer32[ieo][8*i]     = &recvBuffer32[ (g_lexic2eosub[ g_iup[j][0] ] - VOLUME/2)];
       }
       if(t == 0) {
-	NBPointer32[ieo][8*i + 1] = &recvBuffer32[ (g_lexic2eosub[ g_idn[j][0] ] - VOLUME/2)];
+        NBPointer32[ieo][8*i + 1] = &recvBuffer32[ (g_lexic2eosub[ g_idn[j][0] ] - VOLUME/2)];
       }
 #endif
 #if ((defined PARALLELX) || (defined PARALLELXY) || (defined PARALLELXYZ) || (defined PARALLELXT) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(x == LX-1) { 
-	NBPointer32[ieo][8*i + 2] = &recvBuffer32[ (g_lexic2eosub[ g_iup[j][1] ] - VOLUME/2)];
+        NBPointer32[ieo][8*i + 2] = &recvBuffer32[ (g_lexic2eosub[ g_iup[j][1] ] - VOLUME/2)];
       }
       if(x == 0) {
-	NBPointer32[ieo][8*i + 3] = &recvBuffer32[ (g_lexic2eosub[ g_idn[j][1] ] - VOLUME/2)];
+        NBPointer32[ieo][8*i + 3] = &recvBuffer32[ (g_lexic2eosub[ g_idn[j][1] ] - VOLUME/2)];
       }
 #endif
 #if ((defined PARALLELXY) || (defined PARALLELXYZ) || (defined PARALLELXYT) || (defined PARALLELXYZT))
       if(y == LY-1) {
-	NBPointer32[ieo][8*i + 4] = &recvBuffer32[ (g_lexic2eosub[ g_iup[j][2] ] - VOLUME/2)];
+        NBPointer32[ieo][8*i + 4] = &recvBuffer32[ (g_lexic2eosub[ g_iup[j][2] ] - VOLUME/2)];
       }
       if(y == 0) {
-	NBPointer32[ieo][8*i + 5] = &recvBuffer32[ (g_lexic2eosub[ g_idn[j][2] ] - VOLUME/2)];
+        NBPointer32[ieo][8*i + 5] = &recvBuffer32[ (g_lexic2eosub[ g_idn[j][2] ] - VOLUME/2)];
       }
 #endif
 #if ((defined PARALLELXYZ) || (defined PARALLELXYZT))
       if(z == LZ-1) {
-	NBPointer32[ieo][8*i + 6] = &recvBuffer32[ (g_lexic2eosub[ g_iup[j][3] ] - VOLUME/2)];
+        NBPointer32[ieo][8*i + 6] = &recvBuffer32[ (g_lexic2eosub[ g_iup[j][3] ] - VOLUME/2)];
       }
       if(z == 0) {
-	NBPointer32[ieo][8*i + 7] = &recvBuffer32[ (g_lexic2eosub[ g_idn[j][3] ] - VOLUME/2)];
+        NBPointer32[ieo][8*i + 7] = &recvBuffer32[ (g_lexic2eosub[ g_idn[j][3] ] - VOLUME/2)];
       }
 #endif
+    }
+    for(int i = VOLUME/2; i < (VOLUME+RAND)/2; i++) {
+      for(int mu = 0; mu < 8; mu++) {
+        NBPointer32[ieo][8*i + mu] = NBPointer32[ieo][0];
+      }
     }
   }
 #if (defined SPI && defined MPI)
@@ -530,8 +538,8 @@ int init_dirac_halfspinor32() {
   for (unsigned int j = 0; j < spi_num_dirs; j++) {
     descCount[ j ] =
       msg_InjFifoInject ( injFifoHandle,
-			  j,
-			  &SPIDescriptors32[j]);
+        j,
+        &SPIDescriptors32[j]);
   }
   // wait for receive completion
   while ( recvCounter > 0 );
@@ -550,16 +558,16 @@ int init_dirac_halfspinor32() {
     if(i == 7) k = g_nb_z_dn;
     for(int mu = 0; mu < messageSizes[i]/sizeof(halfspinor32); mu++) {
       if(k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s0.c0) ||
-	 k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s0.c1) ||
-	 k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s0.c2) ||
-	 k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s1.c0) ||
-	 k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s1.c1) ||
-	 k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s1.c2)) {
-	if(g_cart_id == 0) {
-	  printf("32 Bit SPI exchange doesn't work for dir %d: %d != %d at point %d\n", 
-		 i, k ,(int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s0.c0), mu);
-	}
-	j++;
+   k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s0.c1) ||
+   k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s0.c2) ||
+   k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s1.c0) ||
+   k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s1.c1) ||
+   k != (int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s1.c2)) {
+  if(g_cart_id == 0) {
+    printf("32 Bit SPI exchange doesn't work for dir %d: %d != %d at point %d\n", 
+     i, k ,(int)creal(recvBuffer32[ soffsets[i]/sizeof(halfspinor32) + mu ].s0.c0), mu);
+  }
+  j++;
       }
     }
   }

--- a/init/init_dirac_halfspinor.c
+++ b/init/init_dirac_halfspinor.c
@@ -348,8 +348,9 @@ int init_dirac_halfspinor() {
 
 int init_dirac_halfspinor32() {
   int j=0, k;
-  int x, y, z, t, mu;
   
+  int x, y, z, t, mu;
+
   NBPointer32 = (halfspinor32***) calloc(4,sizeof(halfspinor32**));
   NBPointer32_ = (halfspinor32**) calloc(16,(VOLUME+RAND)*sizeof(halfspinor32*));
   NBPointer32[0] = NBPointer32_;
@@ -357,7 +358,7 @@ int init_dirac_halfspinor32() {
   NBPointer32[2] = NBPointer32_ + (16*(VOLUME+RAND)/2);
   NBPointer32[3] = NBPointer32_ + (24*(VOLUME+RAND)/2);
 
-  if((void*)(HalfSpinor32_ = (halfspinor32*)calloc(8*(VOLUME+RAND)+1, sizeof(halfspinor32))) == NULL) {
+  if((void*)(HalfSpinor32_ = (halfspinor32*)calloc(4*(VOLUME)+1, sizeof(halfspinor32))) == NULL) {
     printf ("malloc errno : %d\n",errno); 
     errno = 0;
     return(-1);
@@ -505,12 +506,12 @@ int init_dirac_halfspinor32() {
 
   // test communication
   for(unsigned int i = 0; i < RAND/2; i++) {
-    sendBuffer32[i].s0.c0 = (double)g_cart_id;
-    sendBuffer32[i].s0.c1 = (double)g_cart_id;
-    sendBuffer32[i].s0.c2 = (double)g_cart_id;
-    sendBuffer32[i].s1.c0 = (double)g_cart_id;
-    sendBuffer32[i].s1.c1 = (double)g_cart_id;
-    sendBuffer32[i].s1.c2 = (double)g_cart_id;
+    sendBuffer32[i].s0.c0 = (float)g_cart_id;
+    sendBuffer32[i].s0.c1 = (float)g_cart_id;
+    sendBuffer32[i].s0.c2 = (float)g_cart_id;
+    sendBuffer32[i].s1.c0 = (float)g_cart_id;
+    sendBuffer32[i].s1.c1 = (float)g_cart_id;
+    sendBuffer32[i].s1.c2 = (float)g_cart_id;
   }
 
   // Initialize the barrier, resetting the hardware.
@@ -519,10 +520,12 @@ int init_dirac_halfspinor32() {
     printf("MUSPI_GIBarrierInit returned rc = %d\n", rc);
     exit(__LINE__);
   }
-  // reset the recv counter 
+  // reset the recv counter, note the division by 2, totalMessageSize has been set in init_dirac_halfspinor 
+  // which must be called first!
   recvCounter = totalMessageSize/2;
   global_barrier(); // make sure everybody is set recv counter
   
+  // could do communication with multiple threads
   //#pragma omp for nowait
   for (unsigned int j = 0; j < spi_num_dirs; j++) {
     descCount[ j ] =

--- a/init/init_spinor_field.c
+++ b/init/init_spinor_field.c
@@ -80,7 +80,7 @@ void free_spinor_field() {
 }
 
 
-spinor * sp32 = NULL;
+spinor32 * sp32 = NULL;
 int init_spinor_field_32(const int V, const int nr) {
   int i = 0;
 

--- a/invert_clover_eo.c
+++ b/invert_clover_eo.c
@@ -109,6 +109,10 @@ int invert_clover_eo(spinor * const Even_new, spinor * const Odd_new,
     iter = mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], max_iter, precision, rel_prec, 
 			  VOLUME/2, &Qsw_pm_psi, &Qsw_pm_psi_32);
     Qm(Odd_new, Odd_new);
+  }else if(solver_flag == RGMIXEDCG){
+    iter = rg_mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], max_iter, precision, rel_prec, 
+			  VOLUME/2, &Qsw_pm_psi, &Qsw_pm_psi_32);
+    Qm(Odd_new, Odd_new);
    }else{
     if(g_proc_id == 0) {printf("# This solver is not available for this operator. Exisiting!\n"); fflush(stdout);}
     return 0;

--- a/invert_clover_eo.c
+++ b/invert_clover_eo.c
@@ -45,6 +45,7 @@
 #include"operator/D_psi.h"
 #include"gamma.h"
 #include"solver/solver.h"
+#include"solver/solver_params.h"
 #include"invert_clover_eo.h"
 #include "solver/dirac_operator_eigenvectors.h"
 #ifdef QUDA
@@ -98,20 +99,19 @@ int invert_clover_eo(spinor * const Even_new, spinor * const Odd_new,
 		 precision, rel_prec, 
 		 VOLUME/2, Qsq);
     Qm(Odd_new, Odd_new);
-    }else if(solver_flag == INCREIGCG){
-
-       if(g_proc_id == 0) {printf("# Using Incremental Eig-CG!\n"); fflush(stdout);}
-       iter = incr_eigcg(VOLUME/2,solver_params.eigcg_nrhs, solver_params.eigcg_nrhs1, Odd_new, g_spinor_field[DUM_DERI], solver_params.eigcg_ldh, Qsq,
- 		    	            solver_params.eigcg_tolsq1, solver_params.eigcg_tolsq, solver_params.eigcg_restolsq , solver_params.eigcg_rand_guess_opt, 
-                                    rel_prec, max_iter, solver_params.eigcg_nev, solver_params.eigcg_vmax);
-       Qm(Odd_new, Odd_new);
+  }else if(solver_flag == INCREIGCG){
+    if(g_proc_id == 0) {printf("# Using Incremental Eig-CG!\n"); fflush(stdout);}
+    iter = incr_eigcg(VOLUME/2,solver_params.eigcg_nrhs, solver_params.eigcg_nrhs1, Odd_new, g_spinor_field[DUM_DERI], solver_params.eigcg_ldh, Qsq,
+     	            solver_params.eigcg_tolsq1, solver_params.eigcg_tolsq, solver_params.eigcg_restolsq , solver_params.eigcg_rand_guess_opt, 
+                                 rel_prec, max_iter, solver_params.eigcg_nev, solver_params.eigcg_vmax);
+    Qm(Odd_new, Odd_new);
   }else if(solver_flag == MIXEDCG){
-    iter = mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], max_iter, precision, rel_prec, 
+    iter = mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], solver_params, max_iter, precision, rel_prec, 
 			  VOLUME/2, &Qsw_pm_psi, &Qsw_pm_psi_32);
     Qm(Odd_new, Odd_new);
   }else if(solver_flag == RGMIXEDCG){
-    iter = rg_mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], max_iter, precision, rel_prec, 
-			  VOLUME/2, &Qsw_pm_psi, &Qsw_pm_psi_32);
+    iter = rg_mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], solver_params, max_iter, precision, rel_prec,
+			                     VOLUME/2, &Qsw_pm_psi, &Qsw_pm_psi_32);
     Qm(Odd_new, Odd_new);
    }else{
     if(g_proc_id == 0) {printf("# This solver is not available for this operator. Exisiting!\n"); fflush(stdout);}

--- a/invert_doublet_eo.c
+++ b/invert_doublet_eo.c
@@ -45,6 +45,7 @@
 #include"read_input.h"
 #include"xchange/xchange.h"
 #include"operator/tm_operators_nd.h"
+#include"operator/tm_operators_nd_32.h"
 #include"invert_doublet_eo.h"
 #ifdef QUDA
 #  include "quda_interface.h"
@@ -68,7 +69,7 @@ int invert_doublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
                       spinor * const Even_s, spinor * const Odd_s,
                       spinor * const Even_c, spinor * const Odd_c,
                       const double precision, const int max_iter,
-                      const int solver_flag, const int rel_prec,
+                      const int solver_flag, const int rel_prec, solver_params_t solver_params,
                       const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression) {
 
   int iter = 0;
@@ -85,60 +86,10 @@ int invert_doublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
   
 #ifdef HAVE_GPU
 #  ifdef TEMPORALGAUGE
-  
-  /* initialize temporal gauge here */
-  int retval;
-  double dret1, dret2;
-  double plaquette1 = 0.0;
-  double plaquette2 = 0.0;
-  
   if (usegpu_flag) {
-    
-    /* need VOLUME here (not N=VOLUME/2)*/
-    if ((retval = init_temporalgauge_trafo(VOLUME, g_gauge_field)) != 0 ) {				// initializes the transformation matrices
-      if (g_proc_id == 0) printf("Error while gauge fixing to temporal gauge. Aborting...\n");   	//	g_tempgauge_field as a copy of g_gauge_field
-      exit(200);
-    }
-    
-    /* do trafo */
-    plaquette1 = measure_plaquette(g_gauge_field);
-    apply_gtrafo(g_gauge_field, g_trafo);								// transformation of the gauge field
-    plaquette2 = measure_plaquette(g_gauge_field);
-    if (g_proc_id == 0) printf("\tPlaquette before gauge fixing: %.16e\n", plaquette1/6./VOLUME);
-    if (g_proc_id == 0) printf("\tPlaquette after gauge fixing:  %.16e\n", plaquette2/6./VOLUME);
-    
-    /* do trafo to odd_s part of source */
-    dret1 = square_norm(Odd_s, VOLUME/2 , 1);
-    apply_gtrafo_spinor_odd(Odd_s, g_trafo);								// odd spinor transformation, strange
-    dret2 = square_norm(Odd_s, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2);
-    
-    /* do trafo to odd_c part of source */
-    dret1 = square_norm(Odd_c, VOLUME/2 , 1);
-    apply_gtrafo_spinor_odd(Odd_c, g_trafo);								// odd spinor transformation, charm
-    dret2 = square_norm(Odd_c, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2);       
-    
-    /* do trafo to even_s part of source */
-    dret1 = square_norm(Even_s, VOLUME/2 , 1);
-    apply_gtrafo_spinor_even(Even_s, g_trafo);							// even spinor transformation, strange
-    dret2 = square_norm(Even_s, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2);
-    
-    /* do trafo to even_c part of source */
-    dret1 = square_norm(Even_c, VOLUME/2 , 1);
-    apply_gtrafo_spinor_even(Even_c, g_trafo);							// even spinor transformation, charm
-    dret2 = square_norm(Even_c, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2);
-    
-#    ifdef MPI
-    xchange_gauge(g_gauge_field);
-#    endif
-    
+    gtrafo_eo_nd(Even_s, Odd_s, Even_c, Odd_c, 
+                 (spinor*const)NULL, (spinor*const)NULL, (spinor*const)NULL, (spinor*const)NULL, 
+                 GTRAFO_APPLY);    
   } 
 #  endif  
 #endif /* HAVE_GPU*/
@@ -189,9 +140,14 @@ int invert_doublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
 		     VOLUME/2, &Qtm_pm_ndpsi);
   }
 #else			// CPU, conjugate gradient
-  iter = cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
-		   max_iter, precision, rel_prec, 
-		   VOLUME/2, &Qtm_pm_ndpsi);
+  if(solver_flag == RGMIXEDCG){
+    iter = rg_mixed_cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
+                              solver_params, max_iter, precision, rel_prec, VOLUME/2,
+                              &Qtm_pm_ndpsi, &Qtm_pm_ndpsi_32);
+  } else {
+    iter = cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
+		     max_iter, precision, rel_prec, VOLUME/2, &Qtm_pm_ndpsi);
+  }
 #endif
   
   
@@ -214,83 +170,9 @@ int invert_doublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
 #ifdef HAVE_GPU  
   /* return from temporal gauge again */
 #  ifdef TEMPORALGAUGE
-  
   if (usegpu_flag) { 
-    
-    /* undo trafo */
-    /* apply_inv_gtrafo(g_gauge_field, g_trafo);*/
-    /* copy back the saved original field located in g_tempgauge_field -> update necessary*/
-    plaquette1 = measure_plaquette(g_gauge_field);
-    copy_gauge_field(g_gauge_field, g_tempgauge_field);
-    g_update_gauge_copy = 1;
-    plaquette2 = measure_plaquette(g_gauge_field);
-    if (g_proc_id == 0) printf("\tPlaquette before inverse gauge fixing: %.16e\n", plaquette1/6./VOLUME);
-    if (g_proc_id == 0) printf("\tPlaquette after inverse gauge fixing:  %.16e\n", plaquette2/6./VOLUME);
-    
-    /* undo trafo to source Even_s */
-    dret1 = square_norm(Even_s, VOLUME/2 , 1);
-    apply_inv_gtrafo_spinor_even(Even_s, g_trafo);
-    dret2 = square_norm(Even_s, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2);
-    
-    
-    /* undo trafo to source Even_c */
-    dret1 = square_norm(Even_c, VOLUME/2 , 1);
-    apply_inv_gtrafo_spinor_even(Even_c, g_trafo);
-    dret2 = square_norm(Even_c, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1);
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2); 
-    
-    /* undo trafo to source Odd_s */
-    dret1 = square_norm(Odd_s, VOLUME/2 , 1);
-    apply_inv_gtrafo_spinor_odd(Odd_s, g_trafo);
-    dret2 = square_norm(Odd_s, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2);
-    
-    /* undo trafo to source Odd_c */
-    dret1 = square_norm(Odd_c, VOLUME/2 , 1);
-    apply_inv_gtrafo_spinor_odd(Odd_c, g_trafo);
-    dret2 = square_norm(Odd_c, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2); 
-    
-    
-    // Even_new_s
-    dret1 = square_norm(Even_new_s, VOLUME/2 , 1);
-    apply_inv_gtrafo_spinor_even(Even_new_s, g_trafo);
-    dret2 = square_norm(Even_new_s, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2);
-    
-    // Even_new_c
-    dret1 = square_norm(Even_new_c, VOLUME/2 , 1);
-    apply_inv_gtrafo_spinor_even(Even_new_c, g_trafo);
-    dret2 = square_norm(Even_new_c, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2);
-    
-    // Odd_new_s
-    dret1 = square_norm(Odd_new_s, VOLUME/2 , 1);
-    apply_inv_gtrafo_spinor_odd(Odd_new_s, g_trafo);
-    dret2 = square_norm(Odd_new_s, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2);
-    
-    // Odd_new_c
-    dret1 = square_norm(Odd_new_c, VOLUME/2 , 1);
-    apply_inv_gtrafo_spinor_odd(Odd_new_c, g_trafo);
-    dret2 = square_norm(Odd_new_c, VOLUME/2, 1);
-    if (g_proc_id == 0) printf("\tsquare norm before gauge fixing: %.16e\n", dret1); 
-    if (g_proc_id == 0) printf("\tsquare norm after gauge fixing:  %.16e\n", dret2); 
-    
-    finalize_temporalgauge();
-    
-#    ifdef MPI
-    xchange_gauge(g_gauge_field);
-#    endif
-    
+    gtrafo_eo_nd(Even_s, Odd_s, Even_c, Odd_c, Even_new_s, Odd_new_s, Even_new_c, Odd_new_c,
+                 GTRAFO_REVERT);
   }
 #  endif
 #endif
@@ -303,7 +185,7 @@ int invert_cloverdoublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
                       spinor * const Even_s, spinor * const Odd_s,
                       spinor * const Even_c, spinor * const Odd_c,
                       const double precision, const int max_iter,
-                      const int solver_flag, const int rel_prec,
+                      const int solver_flag, const int rel_prec, solver_params_t solver_params,
                       const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression) {
   
   int iter = 0;

--- a/invert_doublet_eo.c
+++ b/invert_doublet_eo.c
@@ -224,9 +224,15 @@ int invert_cloverdoublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
   gamma5(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI], VOLUME/2);
   gamma5(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI+1], VOLUME/2);
   
-  iter = cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
-		   max_iter, precision, rel_prec, 
-		   VOLUME/2, &Qsw_pm_ndpsi);
+  if(solver_flag == RGMIXEDCG){
+    iter = rg_mixed_cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
+                              solver_params, max_iter, precision, rel_prec, VOLUME/2,
+                              &Qsw_pm_ndpsi, &Qsw_pm_ndpsi_32);
+  } else {
+    iter = cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
+		                 max_iter, precision, rel_prec, 
+		                 VOLUME/2, &Qsw_pm_ndpsi);
+  }
   
   
   Qsw_dagger_ndpsi(Odd_new_s, Odd_new_c,

--- a/invert_doublet_eo.h
+++ b/invert_doublet_eo.h
@@ -31,13 +31,14 @@
 #define _INVERT_DOUBLET_EO_H
 
 #include "global.h"
+#include "solver/solver_params.h"
 
 int invert_doublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s, 
                       spinor * const Even_new_c, spinor * const Odd_new_c,
                       spinor * const Even_s, spinor * const Odd_s,
                       spinor * const Even_c, spinor * const Odd_c,
                       const double precision, const int max_iter,
-                      const int solver_flag, const int rel_prec,
+                      const int solver_flag, const int rel_prec, solver_params_t solver_params,
                       const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression);
 
 
@@ -54,6 +55,6 @@ int invert_cloverdoublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
                       spinor * const Even_s, spinor * const Odd_s,
                       spinor * const Even_c, spinor * const Odd_c,
                       const double precision, const int max_iter,
-                      const int solver_flag, const int rel_prec,
+                      const int solver_flag, const int rel_prec, solver_params_t solver_params,
                       const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression);
 #endif

--- a/invert_eo.c
+++ b/invert_eo.c
@@ -202,6 +202,14 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
 			  VOLUME/2, &Qtm_pm_psi, &Qtm_pm_psi_32);
       Qtm_minus_psi(Odd_new, Odd_new);
     }
+    else if(solver_flag == RGMIXEDCG) {
+      /* Here we invert the hermitean operator squared */
+      gamma5(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI], VOLUME/2);
+      if(g_proc_id == 0) {printf("# Using Mixed Precision CG!\n"); fflush(stdout);}
+      iter = rg_mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], max_iter, precision, rel_prec, 
+			  VOLUME/2, &Qtm_pm_psi, &Qtm_pm_psi_32);
+      Qtm_minus_psi(Odd_new, Odd_new);
+    }
     else if(solver_flag == CG) {
       /* Here we invert the hermitean operator squared */
       gamma5(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI], VOLUME/2);
@@ -360,6 +368,12 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
       if(g_proc_id == 0) {printf("# Using MIXEDCG!\n"); fflush(stdout);}
     	gamma5(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI], VOLUME);
     	iter = mixed_cg_her(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1], max_iter, 
+                          precision, rel_prec, VOLUME, &Q_pm_psi, &Q_pm_psi_32);
+	    Q_minus_psi(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI]);
+    } else if(solver_flag == RGMIXEDCG) {
+      if(g_proc_id == 0) {printf("# Using MIXEDCG!\n"); fflush(stdout);}
+    	gamma5(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI], VOLUME);
+    	iter = rg_mixed_cg_her(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1], max_iter, 
                           precision, rel_prec, VOLUME, &Q_pm_psi, &Q_pm_psi_32);
 	    Q_minus_psi(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI]);
     } else if(solver_flag == FGMRES) {

--- a/invert_eo.c
+++ b/invert_eo.c
@@ -198,7 +198,7 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
       /* Here we invert the hermitean operator squared */
       gamma5(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI], VOLUME/2);
       if(g_proc_id == 0) {printf("# Using Mixed Precision CG!\n"); fflush(stdout);}
-      iter = mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], max_iter, precision, rel_prec, 
+      iter = mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], solver_params, max_iter, precision, rel_prec, 
 			  VOLUME/2, &Qtm_pm_psi, &Qtm_pm_psi_32);
       Qtm_minus_psi(Odd_new, Odd_new);
     }
@@ -206,30 +206,29 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
       /* Here we invert the hermitean operator squared */
       gamma5(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI], VOLUME/2);
       if(g_proc_id == 0) {printf("# Using Mixed Precision CG!\n"); fflush(stdout);}
-      iter = rg_mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], max_iter, precision, rel_prec, 
-			  VOLUME/2, &Qtm_pm_psi, &Qtm_pm_psi_32);
+      iter = rg_mixed_cg_her(Odd_new, g_spinor_field[DUM_DERI], solver_params, max_iter, precision, rel_prec,
+			                       VOLUME/2, &Qtm_pm_psi, &Qtm_pm_psi_32);
       Qtm_minus_psi(Odd_new, Odd_new);
     }
     else if(solver_flag == CG) {
       /* Here we invert the hermitean operator squared */
       gamma5(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI], VOLUME/2);
       if(g_proc_id == 0) {
-	printf("# Using CG!\n"); 
-	printf("# mu = %f, kappa = %f\n", g_mu/2./g_kappa, g_kappa);
-	fflush(stdout);
+        printf("# Using CG!\n"); 
+        printf("# mu = %f, kappa = %f\n", g_mu/2./g_kappa, g_kappa);
+        fflush(stdout);
       }
 #ifdef HAVE_GPU
       if(usegpu_flag){
-	if(g_proc_id == 0) printf("Using GPU for inversion\n");
-	iter = mixed_solve_eo(Odd_new, g_spinor_field[DUM_DERI], max_iter,   precision, rel_prec, VOLUME/2);
-      }
-      else{
+        if(g_proc_id == 0) printf("Using GPU for inversion\n");
+        iter = mixed_solve_eo(Odd_new, g_spinor_field[DUM_DERI], max_iter,   precision, rel_prec, VOLUME/2);
+      }else{
         iter = cg_her(Odd_new, g_spinor_field[DUM_DERI], max_iter, precision, rel_prec, VOLUME/2, &Qtm_pm_psi);
         Qtm_minus_psi(Odd_new, Odd_new);
       }
 #else        
       iter = cg_her(Odd_new, g_spinor_field[DUM_DERI], max_iter, precision, rel_prec, 
-		    VOLUME/2, &Qtm_pm_psi);
+		                VOLUME/2, &Qtm_pm_psi);
       Qtm_minus_psi(Odd_new, Odd_new);
 #endif /*HAVE_GPU*/
     }
@@ -367,13 +366,13 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
     else if(solver_flag == MIXEDCG) {
       if(g_proc_id == 0) {printf("# Using MIXEDCG!\n"); fflush(stdout);}
     	gamma5(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI], VOLUME);
-    	iter = mixed_cg_her(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1], max_iter, 
+    	iter = mixed_cg_her(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1], solver_params, max_iter, 
                           precision, rel_prec, VOLUME, &Q_pm_psi, &Q_pm_psi_32);
 	    Q_minus_psi(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI]);
     } else if(solver_flag == RGMIXEDCG) {
       if(g_proc_id == 0) {printf("# Using MIXEDCG!\n"); fflush(stdout);}
     	gamma5(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI], VOLUME);
-    	iter = rg_mixed_cg_her(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1], max_iter, 
+    	iter = rg_mixed_cg_her(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1], solver_params, max_iter, 
                           precision, rel_prec, VOLUME, &Q_pm_psi, &Q_pm_psi_32);
 	    Q_minus_psi(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI]);
     } else if(solver_flag == FGMRES) {

--- a/linalg/Makefile.in
+++ b/linalg/Makefile.in
@@ -35,7 +35,7 @@ liblinalg_TARGETS = assign_add_mul_r_add_mul \
 	scalar_prod_r scalar_prod_i \
 	square_and_prod_r assign_mul_bra_add_mul_r mul_r mul_r_32 \
 	diff_and_square_norm assign \
-	scalar_prod mul_diff_r mul_diff_mul assign_add_mul add \
+	scalar_prod mul_diff_r mul_diff_mul assign_add_mul assign_mul_add add \
 	assign_diff_mul mul_add_mul mul assign_add_mul_add_mul \
 	assign_mul_bra_add_mul_ket_add assign_mul_add_mul_add_mul_add_mul_r \
 	mul_diff_mul_r assign_add_mul_add_mul_r \

--- a/linalg/assign.c
+++ b/linalg/assign.c
@@ -45,6 +45,11 @@ void assign(spinor * const R, spinor * const S, const int N)
   return;
 }
 
+void assign_32(spinor32 * const R, spinor32 * const S, const int N)
+{
+  memcpy(R, S, N*sizeof(spinor32));
+  return;
+}
 
 #ifdef WITHLAPH
 void assign_su3vect(su3_vector * const R, su3_vector * const S, const int N)

--- a/linalg/assign_mul_add.c
+++ b/linalg/assign_mul_add.c
@@ -16,14 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
  ***********************************************************************/
-/*******************************************************************************
- *
- * File assign_add_mul.c 
- *
- *   void assign_add_mul(spinor * const P, spinor * const Q, const complex c)
- *     (*P) = (*P) + c(*Q)        c is a complex constant
- *
- *******************************************************************************/
 
 #ifdef HAVE_CONFIG_H
 # include<config.h>
@@ -37,8 +29,7 @@
 #include "su3.h"
 #include "assign_mul_add.h"
 
-
-void assign_add_mul(spinor * const R, const _Complex double c, spinor * const S, const int N)
+void assign_mul_add(spinor * const R, const _Complex double c, spinor * const S, const int N)
 {
 #ifdef OMP
 #pragma omp parallel

--- a/linalg/assign_mul_add.c
+++ b/linalg/assign_mul_add.c
@@ -1,0 +1,80 @@
+/***********************************************************************
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008 Carsten Urbach
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ ***********************************************************************/
+/*******************************************************************************
+ *
+ * File assign_add_mul.c 
+ *
+ *   void assign_add_mul(spinor * const P, spinor * const Q, const complex c)
+ *     (*P) = (*P) + c(*Q)        c is a complex constant
+ *
+ *******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+# include<config.h>
+#endif
+#ifdef OMP
+# include <omp.h>
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include "su3.h"
+#include "assign_mul_add.h"
+
+
+void assign_add_mul(spinor * const R, const _Complex double c, spinor * const S, const int N)
+{
+#ifdef OMP
+#pragma omp parallel
+  {
+#endif
+  spinor *r,*s;
+
+#ifdef OMP
+#pragma omp for
+#endif
+  for (int ix=0; ix<N; ix++)
+  {
+    r=(spinor *) R + ix;
+    s=(spinor *) S + ix;
+
+    r->s0.c0 = c * r->s0.c0 + s->s0.c0;
+    r->s0.c1 = c * r->s0.c1 + s->s0.c1;
+    r->s0.c2 = c * r->s0.c2 + s->s0.c2;
+                          
+    r->s1.c0 = c * r->s1.c0 + s->s1.c0;
+    r->s1.c1 = c * r->s1.c1 + s->s1.c1;
+    r->s1.c2 = c * r->s1.c2 + s->s1.c2;
+                          
+    r->s2.c0 = c * r->s2.c0 + s->s2.c0;
+    r->s2.c1 = c * r->s2.c1 + s->s2.c1;
+    r->s2.c2 = c * r->s2.c2 + s->s2.c2;
+                          
+    r->s3.c0 = c * r->s3.c0 + s->s3.c0;
+    r->s3.c1 = c * r->s3.c1 + s->s3.c1;
+    r->s3.c2 = c * r->s3.c2 + s->s3.c2;
+  }
+
+#ifdef OMP
+  } /* OpenMP closing brace */
+#endif
+
+}
+
+

--- a/linalg/assign_mul_add.h
+++ b/linalg/assign_mul_add.h
@@ -1,0 +1,28 @@
+/***********************************************************************
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008 Carsten Urbach
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ ***********************************************************************/
+
+#ifndef _ASSIGN_MUL_ADD_H
+#define _ASSIGN_MUL_ADD_H
+
+#include "su3.h"
+
+/*   (*P) = (*P) + c(*Q)        c is a complex constant   */
+void assign_mul_add(spinor * const P, const _Complex double c, spinor * const Q, const int N);
+
+#endif

--- a/linalg/assign_mul_add.h
+++ b/linalg/assign_mul_add.h
@@ -22,7 +22,7 @@
 
 #include "su3.h"
 
-/*   (*P) = (*P) + c(*Q)        c is a complex constant   */
+/*   (*P) = c(*P) + (*Q)        c is a complex constant   */
 void assign_mul_add(spinor * const P, const _Complex double c, spinor * const Q, const int N);
 
 #endif

--- a/linalg_eo.h
+++ b/linalg_eo.h
@@ -46,6 +46,7 @@
 #include "linalg/scalar_prod.h"
 #include "linalg/mul_diff_mul.h"
 #include "linalg/assign_add_mul.h"
+#include "linalg/assign_mul_add.h"
 #include "linalg/assign_diff_mul.h"
 #include "linalg/mul_add_mul.h"
 #include "linalg/mul.h"

--- a/monomial/cloverdet_monomial.c
+++ b/monomial/cloverdet_monomial.c
@@ -88,7 +88,7 @@ void cloverdet_derivative(const int id, hamiltonian_field_t * const hf) {
   // X_o -> w_fields[1]
   chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 	       mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
-  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->maxiter, mnl->forceprec, 
+  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->forceprec, 
 		       g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 		      mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -199,7 +199,7 @@ double cloverdet_acc(const int id, hamiltonian_field_t * const hf) {
   chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 	       mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
   g_sloppy_precision_flag = 0;
-  mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->maxiter, mnl->accprec,  
+  mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->accprec,  
 		      g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver); 
   mnl->Qm(mnl->w_fields[0], mnl->w_fields[0]);
   

--- a/monomial/cloverdet_monomial.c
+++ b/monomial/cloverdet_monomial.c
@@ -80,7 +80,7 @@ void cloverdet_derivative(const int id, hamiltonian_field_t * const hf) {
   // we invert it for the even sites only
   sw_invert(EE, mnl->mu);
 
-  if(mnl->solver != CG && g_proc_id == 0) {
+  if(mnl->solver == BICGSTAB && g_proc_id == 0) {
     fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (cloverdet_monomial.c)\n");
   }
   

--- a/monomial/cloverdetratio_monomial.c
+++ b/monomial/cloverdetratio_monomial.c
@@ -85,7 +85,7 @@ void cloverdetratio_derivative_orig(const int no, hamiltonian_field_t * const hf
   /* X_W -> w_fields[1] */
   chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 	       mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
-  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
+  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, mnl->maxiter, 
 		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 		      mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -194,7 +194,7 @@ void cloverdetratio_derivative(const int no, hamiltonian_field_t * const hf) {
   // X_W -> w_fields[1] 
   chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 	       mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
-  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
+  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, mnl->maxiter, 
 		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 		      mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -260,7 +260,7 @@ void cloverdetratio_heatbath(const int id, hamiltonian_field_t * const hf) {
   g_mu3 = mnl->rho2;
   zero_spinor_field(mnl->pf,VOLUME/2);
 
-  mnl->iter0 = solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->maxiter, mnl->accprec,  
+  mnl->iter0 = solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,  
 		      g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver); 
 
   chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
@@ -299,7 +299,7 @@ double cloverdetratio_acc(const int id, hamiltonian_field_t * const hf) {
   chrono_guess(mnl->w_fields[0], mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array, 
 	       mnl->csg_N, mnl->csg_n, VOLUME/2, &Qtm_plus_psi);
   g_sloppy_precision_flag = 0;    
-  mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec,  
+  mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,  
 		      g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
   mnl->Qm(mnl->w_fields[0], mnl->w_fields[0]);
 

--- a/monomial/cloverdetratio_monomial.c
+++ b/monomial/cloverdetratio_monomial.c
@@ -74,7 +74,7 @@ void cloverdetratio_derivative_orig(const int no, hamiltonian_field_t * const hf
   // we invert it for the even sites only including mu
   sw_invert(EE, mnl->mu);
   
-  if(mnl->solver != CG) {
+  if(mnl->solver == BICGSTAB && g_proc_id==0) {
     fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (detratio_monomial.c)\n");
   }
   
@@ -181,7 +181,7 @@ void cloverdetratio_derivative(const int no, hamiltonian_field_t * const hf) {
   // we invert it for the even sites only including mu
   sw_invert(EE, mnl->mu);
   
-  if(mnl->solver != CG) {
+  if(mnl->solver == BICGSTAB && g_proc_id == 0) {
     fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (cloverdetratio_monomial.c)\n");
   }
   

--- a/monomial/cloverdetratio_monomial.c
+++ b/monomial/cloverdetratio_monomial.c
@@ -37,8 +37,10 @@
 #include "operator/Hopping_Matrix.h"
 #include "solver/chrono_guess.h"
 #include "solver/solver.h"
+#include "solver/monomial_solve.h"
 #include "read_input.h"
 #include "operator/clovertm_operators.h"
+#include "operator/clovertm_operators_32.h"
 #include "operator/clover_leaf.h"
 #include "monomial/monomial.h"
 #include "boundary.h"
@@ -83,8 +85,8 @@ void cloverdetratio_derivative_orig(const int no, hamiltonian_field_t * const hf
   /* X_W -> w_fields[1] */
   chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 	       mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
-  mnl->iter1 += cg_her(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
-		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq);
+  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
+		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 		      mnl->csg_N, &mnl->csg_n, VOLUME/2);
   /* Y_W -> w_fields[0]  */
@@ -192,8 +194,8 @@ void cloverdetratio_derivative(const int no, hamiltonian_field_t * const hf) {
   // X_W -> w_fields[1] 
   chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 	       mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
-  mnl->iter1 += cg_her(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
-		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq);
+  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
+		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 		      mnl->csg_N, &mnl->csg_n, VOLUME/2);
   // Apply Q_{-} to get Y_W -> w_fields[0] 
@@ -258,8 +260,8 @@ void cloverdetratio_heatbath(const int id, hamiltonian_field_t * const hf) {
   g_mu3 = mnl->rho2;
   zero_spinor_field(mnl->pf,VOLUME/2);
 
-  mnl->iter0 = cg_her(mnl->pf, mnl->w_fields[1], mnl->maxiter, mnl->accprec,  
-		      g_relative_precision_flag, VOLUME/2, mnl->Qsq); 
+  mnl->iter0 = solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->maxiter, mnl->accprec,  
+		      g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver); 
 
   chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		      mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -297,8 +299,8 @@ double cloverdetratio_acc(const int id, hamiltonian_field_t * const hf) {
   chrono_guess(mnl->w_fields[0], mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array, 
 	       mnl->csg_N, mnl->csg_n, VOLUME/2, &Qtm_plus_psi);
   g_sloppy_precision_flag = 0;    
-  mnl->iter0 += cg_her(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec,  
-		      g_relative_precision_flag, VOLUME/2, mnl->Qsq);
+  mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec,  
+		      g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
   mnl->Qm(mnl->w_fields[0], mnl->w_fields[0]);
 
   g_sloppy_precision_flag = save_sloppy;

--- a/monomial/det_monomial.c
+++ b/monomial/det_monomial.c
@@ -35,6 +35,7 @@
 #include "operator/Hopping_Matrix.h"
 #include "solver/chrono_guess.h"
 #include "solver/solver.h"
+#include "solver/monomial_solve.h"
 #include "read_input.h"
 #include "hamiltonian_field.h"
 #include "boundary.h"
@@ -69,8 +70,19 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
     /* X_o -> w_fields[1] */
     chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		 mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
-    mnl->iter1 += cg_her(mnl->w_fields[1], mnl->pf, mnl->maxiter, mnl->forceprec, 
-			 g_relative_precision_flag, VOLUME/2, mnl->Qsq);
+
+    if((mnl->solver != CG)&&(mnl->solver != MIXEDCG)) 
+    {      
+	  fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (det_monomial.c)\n");
+	  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->maxiter, mnl->forceprec, 
+			 g_relative_precision_flag, VOLUME/2, mnl->Qsq, CG);
+    }
+    else{
+	  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->maxiter, mnl->forceprec, 
+			 g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
+    }
+
+
     chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 			mnl->csg_N, &mnl->csg_n, VOLUME/2);
     
@@ -97,14 +109,14 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
      *********************************************************************/
     g_mu = mnl->mu;
     boundary(mnl->kappa);
-    if(mnl->solver == CG) {
+    if((mnl->solver == CG) || (mnl->solver == MIXEDCG)) {
       /* Invert Q_{+} Q_{-} */
       /* X -> w_fields[1] */
       chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
-      mnl->iter1 += cg_her(mnl->w_fields[1], mnl->pf, 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, 
 			mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-			VOLUME, &Q_pm_psi);
+			VOLUME, &Q_pm_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
 
@@ -117,23 +129,23 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
       /* Y -> w_fields[0]  */
       chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_plus_psi);
-      mnl->iter1 += bicgstab_complex(mnl->w_fields[0], mnl->pf, 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[0], mnl->pf, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME, &Q_plus_psi);
+				     VOLUME, &Q_plus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[0], mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
       
       /* Now Q_- */
       /* X -> w_fields[1] */
-      g_mu = -g_mu;
+      
       chrono_guess(mnl->w_fields[1], mnl->w_fields[0], mnl->csg_field2, 
 		   mnl->csg_index_array2, mnl->csg_N2, mnl->csg_n2, VOLUME/2, &Q_minus_psi);
-      mnl->iter1 += bicgstab_complex(mnl->w_fields[1], mnl->w_fields[0], 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[0], 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME, &Q_minus_psi);
+				     VOLUME, &Q_minus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field2, mnl->csg_index_array2,
 			  mnl->csg_N2, &mnl->csg_n2, VOLUME/2);
-      g_mu = -g_mu;   
+        
     }
     
     /* \delta Q sandwitched by Y^\dagger and X */
@@ -212,20 +224,20 @@ double det_acc(const int id, hamiltonian_field_t * const hf) {
     chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
     	 mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
     g_sloppy_precision_flag = 0;
-    mnl->iter0 = cg_her(mnl->w_fields[0], mnl->pf, mnl->maxiter, mnl->accprec, g_relative_precision_flag,
-    			VOLUME/2, mnl->Qsq);
+    mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->maxiter, mnl->accprec, g_relative_precision_flag,
+    			VOLUME/2, mnl->Qsq, mnl->solver);
     mnl->Qm(mnl->w_fields[1], mnl->w_fields[0]);
     g_sloppy_precision_flag = save_sloppy;
     /* Compute the energy contr. from first field */
     mnl->energy1 = square_norm(mnl->w_fields[1], VOLUME/2, 1);
   }
   else {
-    if(mnl->solver == CG) {
+    if((mnl->solver == CG) || (mnl->solver == MIXEDCG)) {
       chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
-      mnl->iter0 = cg_her(mnl->w_fields[1], mnl->pf, 
+      mnl->iter0 = solve_degenerate(mnl->w_fields[1], mnl->pf, 
 			  mnl->maxiter, mnl->accprec, g_relative_precision_flag, 
-			  VOLUME, &Q_pm_psi);
+			  VOLUME, &Q_pm_psi, mnl->solver);
       Q_minus_psi(mnl->w_fields[0], mnl->w_fields[1]);
       /* Compute the energy contr. from first field */
       mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME, 1);
@@ -233,9 +245,9 @@ double det_acc(const int id, hamiltonian_field_t * const hf) {
     else {
       chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_plus_psi);
-      mnl->iter0 += bicgstab_complex(mnl->w_fields[0], mnl->pf, 
+      mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->pf, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME,  &Q_plus_psi);
+				     VOLUME,  &Q_plus_psi, mnl->solver);
       mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME, 1);
     }
   }

--- a/monomial/det_monomial.c
+++ b/monomial/det_monomial.c
@@ -62,16 +62,12 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
     g_mu = mnl->mu;
     boundary(mnl->kappa);
 
-    if(mnl->solver != CG) {
-      fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (det_monomial.c)\n");
-    }
-    
     /* Invert Q_{+} Q_{-} */
     /* X_o -> w_fields[1] */
     chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		 mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
 
-    if((mnl->solver != CG)&&(mnl->solver != MIXEDCG)) 
+    if(mnl->solver==BICGSTAB) 
     {      
 	  fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (det_monomial.c)\n");
 	  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->maxiter, mnl->forceprec, 
@@ -109,16 +105,16 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
      *********************************************************************/
     g_mu = mnl->mu;
     boundary(mnl->kappa);
-    if((mnl->solver == CG) || (mnl->solver == MIXEDCG)) {
+    if((mnl->solver == CG) || (mnl->solver == MIXEDCG) || (mnl->solver == RGMIXEDCG)) {
       /* Invert Q_{+} Q_{-} */
       /* X -> w_fields[1] */
       chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
-		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
+		               mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
       mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, 
-			mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-			VOLUME, &Q_pm_psi, mnl->solver);
+			                               mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
+			                               VOLUME, &Q_pm_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
-			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
+			                    mnl->csg_N, &mnl->csg_n, VOLUME/2);
 
       /* Y -> w_fields[0]  */
       Q_minus_psi(mnl->w_fields[0], mnl->w_fields[1]);

--- a/monomial/det_monomial.c
+++ b/monomial/det_monomial.c
@@ -70,11 +70,11 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
     if(mnl->solver==BICGSTAB) 
     {      
 	  fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (det_monomial.c)\n");
-	  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->maxiter, mnl->forceprec, 
+	  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->forceprec, 
 			 g_relative_precision_flag, VOLUME/2, mnl->Qsq, CG);
     }
     else{
-	  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->maxiter, mnl->forceprec, 
+	  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->forceprec, 
 			 g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
     }
 
@@ -110,7 +110,7 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
       /* X -> w_fields[1] */
       chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		               mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
-      mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, 
 			                               mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
 			                               VOLUME, &Q_pm_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
@@ -125,7 +125,7 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
       /* Y -> w_fields[0]  */
       chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_plus_psi);
-      mnl->iter1 += solve_degenerate(mnl->w_fields[0], mnl->pf, 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
 				     VOLUME, &Q_plus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[0], mnl->csg_field, mnl->csg_index_array,
@@ -136,7 +136,7 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
       
       chrono_guess(mnl->w_fields[1], mnl->w_fields[0], mnl->csg_field2, 
 		   mnl->csg_index_array2, mnl->csg_N2, mnl->csg_n2, VOLUME/2, &Q_minus_psi);
-      mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[0], 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[0], mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
 				     VOLUME, &Q_minus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field2, mnl->csg_index_array2,
@@ -220,7 +220,7 @@ double det_acc(const int id, hamiltonian_field_t * const hf) {
     chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
     	 mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
     g_sloppy_precision_flag = 0;
-    mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->maxiter, mnl->accprec, g_relative_precision_flag,
+    mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->accprec, g_relative_precision_flag,
     			VOLUME/2, mnl->Qsq, mnl->solver);
     mnl->Qm(mnl->w_fields[1], mnl->w_fields[0]);
     g_sloppy_precision_flag = save_sloppy;
@@ -231,7 +231,7 @@ double det_acc(const int id, hamiltonian_field_t * const hf) {
     if((mnl->solver == CG) || (mnl->solver == MIXEDCG)) {
       chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
-      mnl->iter0 = solve_degenerate(mnl->w_fields[1], mnl->pf, 
+      mnl->iter0 = solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, 
 			  mnl->maxiter, mnl->accprec, g_relative_precision_flag, 
 			  VOLUME, &Q_pm_psi, mnl->solver);
       Q_minus_psi(mnl->w_fields[0], mnl->w_fields[1]);
@@ -241,7 +241,7 @@ double det_acc(const int id, hamiltonian_field_t * const hf) {
     else {
       chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_plus_psi);
-      mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->pf, 
+      mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
 				     VOLUME,  &Q_plus_psi, mnl->solver);
       mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME, 1);

--- a/monomial/detratio_monomial.c
+++ b/monomial/detratio_monomial.c
@@ -79,14 +79,14 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
     chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 		 mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, &Qtm_pm_psi);
     
-    if((mnl->solver != CG) && (mnl->solver != MIXEDCG)) {
+    if(mnl->solver == BICGSTAB) {
       fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (detratio_monomial.c)\n"); 
        mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
-			 mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, CG);
+			                                mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, CG);
     }
     else{
        mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
-			 mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, mnl->solver);      
+			                                mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, mnl->solver);      
     }
     chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 			mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -136,7 +136,7 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
     Q_plus_psi(mnl->w_fields[2], mnl->pf);
     g_mu = mnl->mu;
     boundary(mnl->kappa);
-    if((mnl->solver == CG) || (mnl->solver == MIXEDCG)) {
+    if((mnl->solver == CG) || (mnl->solver == MIXEDCG) || (mnl->solver == RGMIXEDCG)) {
       /* If CG is used anyhow */
       /*       gamma5(mnl->w_fields[1], mnl->w_fields[2], VOLUME/2); */
       /* Invert Q_{+} Q_{-} */

--- a/monomial/detratio_monomial.c
+++ b/monomial/detratio_monomial.c
@@ -81,11 +81,11 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
     
     if(mnl->solver == BICGSTAB) {
       fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (detratio_monomial.c)\n"); 
-       mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
+       mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, mnl->maxiter, 
 			                                mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, CG);
     }
     else{
-       mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
+       mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, mnl->maxiter, 
 			                                mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, mnl->solver);      
     }
     chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
@@ -143,7 +143,7 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
       /* X_W -> w_fields[1] */
       chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 		   mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
-      mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, 
 			   mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
 			   VOLUME, &Q_pm_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
@@ -159,7 +159,7 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
       chrono_guess(mnl->w_fields[0], mnl->w_fields[2], mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_plus_psi);
       gamma5(mnl->w_fields[0], mnl->w_fields[0], VOLUME);
-      mnl->iter1 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[2], 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[2], mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
 				     VOLUME, Q_plus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[0], mnl->csg_field, mnl->csg_index_array,
@@ -171,7 +171,7 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
       chrono_guess(mnl->w_fields[1], mnl->w_fields[0], mnl->csg_field2, 
 		   mnl->csg_index_array2, mnl->csg_N2, mnl->csg_n2, VOLUME/2, &Q_minus_psi);
       gamma5(mnl->w_fields[1], mnl->w_fields[1], VOLUME);
-      mnl->iter1 += solve_degenerate(mnl->w_fields[1],mnl->w_fields[0], 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[1],mnl->w_fields[0], mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
 				     VOLUME, Q_minus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field2, mnl->csg_index_array2,
@@ -220,8 +220,9 @@ void detratio_heatbath(const int id, hamiltonian_field_t * const hf) {
     g_mu = mnl->mu2;
     boundary(mnl->kappa2);
     zero_spinor_field(mnl->w_fields[0], VOLUME/2);
-    mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec, g_relative_precision_flag,
-    			VOLUME/2, mnl->Qsq, mnl->solver);
+    mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params,
+                                  mnl->maxiter, mnl->accprec, g_relative_precision_flag,
+    			                        VOLUME/2, mnl->Qsq, mnl->solver);
     mnl->Qm(mnl->pf, mnl->w_fields[0]);
     chrono_add_solution(mnl->w_fields[0], mnl->csg_field, mnl->csg_index_array,
 			mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -235,13 +236,14 @@ void detratio_heatbath(const int id, hamiltonian_field_t * const hf) {
     boundary(mnl->kappa2);
     zero_spinor_field(mnl->pf,VOLUME);
     if((mnl->solver == CG) || (mnl->solver == MIXEDCG)){
-      mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec, 
-				    g_relative_precision_flag, VOLUME, Q_pm_psi, mnl->solver);
+      mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params,
+                                    mnl->maxiter, mnl->accprec, 
+				                            g_relative_precision_flag, VOLUME, Q_pm_psi, mnl->solver);
       Q_minus_psi(mnl->pf, mnl->w_fields[0]);
       chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);      
     }else{
-      mnl->iter0 += solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->maxiter, mnl->accprec, 
+      mnl->iter0 += solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec, 
 				    g_relative_precision_flag, VOLUME, Q_plus_psi, mnl->solver);
       chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -277,7 +279,7 @@ double detratio_acc(const int id, hamiltonian_field_t * const hf) {
     chrono_guess(mnl->w_fields[0], mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array, 
 		 mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
     g_sloppy_precision_flag = 0;
-    mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec, g_relative_precision_flag,
+    mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec, g_relative_precision_flag,
 			 VOLUME/2, mnl->Qsq, mnl->solver);
     mnl->Qm(mnl->w_fields[1], mnl->w_fields[0]);
     g_sloppy_precision_flag = save_sloppy;
@@ -293,7 +295,7 @@ double detratio_acc(const int id, hamiltonian_field_t * const hf) {
     g_sloppy_precision_flag = 0;
     if((mnl->solver == CG) || (mnl->solver == MIXEDCG)){
       
-      mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec, g_relative_precision_flag,
+      mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec, g_relative_precision_flag,
 			 VOLUME, &Q_pm_psi, mnl->solver); 
       Q_minus_psi(mnl->w_fields[1], mnl->w_fields[0]);
       g_sloppy_precision_flag = save_sloppy;
@@ -301,7 +303,7 @@ double detratio_acc(const int id, hamiltonian_field_t * const hf) {
       mnl->energy1 = square_norm(mnl->w_fields[1], VOLUME, 1);      
     }
     else{
-      mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], 
+      mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, 
 				   mnl->maxiter, mnl->accprec, g_relative_precision_flag, 
 				   VOLUME, Q_plus_psi, mnl->solver); 
     

--- a/monomial/detratio_monomial.c
+++ b/monomial/detratio_monomial.c
@@ -36,6 +36,7 @@
 #include "operator/Hopping_Matrix.h"
 #include "solver/chrono_guess.h"
 #include "solver/solver.h"
+#include "solver/monomial_solve.h"
 #include "read_input.h"
 #include "gamma.h"
 #include "monomial/monomial.h"
@@ -77,8 +78,16 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
     /* X_W -> w_fields[1] */
     chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 		 mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, &Qtm_pm_psi);
-    mnl->iter1 += cg_her(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
-			 mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi);
+    
+    if((mnl->solver != CG) && (mnl->solver != MIXEDCG)) {
+      fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (detratio_monomial.c)\n"); 
+       mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
+			 mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, CG);
+    }
+    else{
+       mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->maxiter, 
+			 mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, mnl->solver);      
+    }
     chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 			mnl->csg_N, &mnl->csg_n, VOLUME/2);
     /* Y_W -> w_fields[0]  */
@@ -127,16 +136,16 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
     Q_plus_psi(mnl->w_fields[2], mnl->pf);
     g_mu = mnl->mu;
     boundary(mnl->kappa);
-    if(mnl->solver == CG) {
+    if((mnl->solver == CG) || (mnl->solver == MIXEDCG)) {
       /* If CG is used anyhow */
       /*       gamma5(mnl->w_fields[1], mnl->w_fields[2], VOLUME/2); */
       /* Invert Q_{+} Q_{-} */
       /* X_W -> w_fields[1] */
       chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 		   mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
-      mnl->iter1 += cg_her(mnl->w_fields[1], mnl->w_fields[2], 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], 
 			   mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-			   VOLUME, &Q_pm_psi);
+			   VOLUME, &Q_pm_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
       
@@ -150,24 +159,24 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
       chrono_guess(mnl->w_fields[0], mnl->w_fields[2], mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_plus_psi);
       gamma5(mnl->w_fields[0], mnl->w_fields[0], VOLUME);
-      mnl->iter1 += bicgstab_complex(mnl->w_fields[0], mnl->w_fields[2], 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[2], 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME, Q_plus_psi);
+				     VOLUME, Q_plus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[0], mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
 
       /* Now Q_- */
       /* X_o -> w_fields[1] */
-      g_mu = -g_mu;
+      
       chrono_guess(mnl->w_fields[1], mnl->w_fields[0], mnl->csg_field2, 
 		   mnl->csg_index_array2, mnl->csg_N2, mnl->csg_n2, VOLUME/2, &Q_minus_psi);
       gamma5(mnl->w_fields[1], mnl->w_fields[1], VOLUME);
-      mnl->iter1 += bicgstab_complex(mnl->w_fields[1],mnl->w_fields[0], 
+      mnl->iter1 += solve_degenerate(mnl->w_fields[1],mnl->w_fields[0], 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME, Q_minus_psi);
+				     VOLUME, Q_minus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field2, mnl->csg_index_array2,
 			  mnl->csg_N2, &mnl->csg_n2, VOLUME/2);
-      g_mu = -g_mu;   
+        
     }
 
     /* \delta Q sandwitched by Y^\dagger and X */
@@ -211,8 +220,8 @@ void detratio_heatbath(const int id, hamiltonian_field_t * const hf) {
     g_mu = mnl->mu2;
     boundary(mnl->kappa2);
     zero_spinor_field(mnl->w_fields[0], VOLUME/2);
-    mnl->iter0 = cg_her(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec, g_relative_precision_flag,
-    			VOLUME/2, mnl->Qsq);
+    mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec, g_relative_precision_flag,
+    			VOLUME/2, mnl->Qsq, mnl->solver);
     mnl->Qm(mnl->pf, mnl->w_fields[0]);
     chrono_add_solution(mnl->w_fields[0], mnl->csg_field, mnl->csg_index_array,
 			mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -225,13 +234,19 @@ void detratio_heatbath(const int id, hamiltonian_field_t * const hf) {
     g_mu = mnl->mu2;
     boundary(mnl->kappa2);
     zero_spinor_field(mnl->pf,VOLUME);
-    mnl->iter0 += bicgstab_complex(mnl->pf, mnl->w_fields[1], mnl->maxiter, mnl->accprec, 
-				   g_relative_precision_flag, VOLUME, Q_plus_psi);
-    chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
-			mnl->csg_N, &mnl->csg_n, VOLUME/2);
-    if(mnl->solver != CG) {
+    if((mnl->solver == CG) || (mnl->solver == MIXEDCG)){
+      mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec, 
+				    g_relative_precision_flag, VOLUME, Q_pm_psi, mnl->solver);
+      Q_minus_psi(mnl->pf, mnl->w_fields[0]);
+      chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
+			  mnl->csg_N, &mnl->csg_n, VOLUME/2);      
+    }else{
+      mnl->iter0 += solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->maxiter, mnl->accprec, 
+				    g_relative_precision_flag, VOLUME, Q_plus_psi, mnl->solver);
+      chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
+			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
       chrono_add_solution(mnl->pf, mnl->csg_field2, mnl->csg_index_array2,
-			  mnl->csg_N2, &mnl->csg_n2, VOLUME/2);
+			    mnl->csg_N2, &mnl->csg_n2, VOLUME/2);           
     }
   }
   etime = gettime();
@@ -262,8 +277,8 @@ double detratio_acc(const int id, hamiltonian_field_t * const hf) {
     chrono_guess(mnl->w_fields[0], mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array, 
 		 mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
     g_sloppy_precision_flag = 0;
-    mnl->iter0 += cg_her(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec, g_relative_precision_flag,
-			 VOLUME/2, mnl->Qsq);
+    mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec, g_relative_precision_flag,
+			 VOLUME/2, mnl->Qsq, mnl->solver);
     mnl->Qm(mnl->w_fields[1], mnl->w_fields[0]);
     g_sloppy_precision_flag = save_sloppy;
     /* Compute the energy contr. from second field */
@@ -275,11 +290,25 @@ double detratio_acc(const int id, hamiltonian_field_t * const hf) {
     boundary(mnl->kappa);
     chrono_guess(mnl->w_fields[0], mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array, 
 		 mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_plus_psi);
-    mnl->iter0 += bicgstab_complex(mnl->w_fields[0], mnl->w_fields[1], 
+    g_sloppy_precision_flag = 0;
+    if((mnl->solver == CG) || (mnl->solver == MIXEDCG)){
+      
+      mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->maxiter, mnl->accprec, g_relative_precision_flag,
+			 VOLUME, &Q_pm_psi, mnl->solver); 
+      Q_minus_psi(mnl->w_fields[1], mnl->w_fields[0]);
+      g_sloppy_precision_flag = save_sloppy;
+      /* Compute the energy contr. from second field */
+      mnl->energy1 = square_norm(mnl->w_fields[1], VOLUME, 1);      
+    }
+    else{
+      mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], 
 				   mnl->maxiter, mnl->accprec, g_relative_precision_flag, 
-				   VOLUME, Q_plus_psi); 
-    /* Compute the energy contr. from second field */
-    mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME, 1);
+				   VOLUME, Q_plus_psi, mnl->solver); 
+    
+      /* Compute the energy contr. from second field */
+      mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME, 1); 
+    }
+    
   }
   g_mu = g_mu1;
   boundary(g_kappa);

--- a/monomial/monomial.c
+++ b/monomial/monomial.c
@@ -104,6 +104,7 @@ int add_monomial(const int type) {
   else{
     monomial_list[no_monomials].solver = _default_solver_flag;
   }
+  monomial_list[no_monomials].solver_params.mcg_delta = _default_mixcg_innereps;
   monomial_list[no_monomials].even_odd_flag = _default_even_odd_flag;
   monomial_list[no_monomials].forcefactor = 1.;
   monomial_list[no_monomials].use_rectangles = 0;

--- a/monomial/monomial.c
+++ b/monomial/monomial.c
@@ -32,7 +32,9 @@
 #include "su3adj.h"
 #include "su3spinor.h"
 #include "operator/tm_operators.h"
+#include "operator/tm_operators_32.h"
 #include "operator/clovertm_operators.h"
+#include "operator/clovertm_operators_32.h"
 #include "operator/clover_leaf.h"
 #include "ranlxd.h"
 #include "sse.h"
@@ -92,7 +94,16 @@ int add_monomial(const int type) {
   monomial_list[no_monomials].accprec = _default_g_eps_sq_acc;
   monomial_list[no_monomials].forceprec = _default_g_eps_sq_force;
   monomial_list[no_monomials].maxiter = _default_max_solver_iterations;
-  monomial_list[no_monomials].solver = _default_solver_flag;
+  if((monomial_list[no_monomials].type == NDRAT) ||
+     (monomial_list[no_monomials].type == NDRATCOR) ||
+     (monomial_list[no_monomials].type == NDCLOVERRAT) ||
+     (monomial_list[no_monomials].type == NDCLOVERRATCOR)
+  ) {
+    monomial_list[no_monomials].solver = _default_nd_solver_flag;    
+  }
+  else{
+    monomial_list[no_monomials].solver = _default_solver_flag;
+  }
   monomial_list[no_monomials].even_odd_flag = _default_even_odd_flag;
   monomial_list[no_monomials].forcefactor = 1.;
   monomial_list[no_monomials].use_rectangles = 0;
@@ -180,6 +191,7 @@ int init_monomials(const int V, const int even_odd_flag) {
 	monomial_list[i].accfunction = &det_acc;
 	monomial_list[i].derivativefunction = &det_derivative;
 	monomial_list[i].Qsq = &Qtm_pm_psi;
+	monomial_list[i].Qsq32 = &Qtm_pm_psi_32;	
 	monomial_list[i].Qp = &Qtm_plus_psi;
 	monomial_list[i].Qm = &Qtm_minus_psi;
 	if(g_proc_id == 0 && g_debug_level > 1) {
@@ -219,6 +231,7 @@ int init_monomials(const int V, const int even_odd_flag) {
 	monomial_list[i].accfunction = &detratio_acc;
 	monomial_list[i].derivativefunction = &detratio_derivative;
 	monomial_list[i].Qsq = &Qtm_pm_psi;
+	monomial_list[i].Qsq32 = &Qtm_pm_psi_32;	
 	monomial_list[i].Qp = &Qtm_plus_psi;
 	monomial_list[i].Qm = &Qtm_minus_psi;
 	if(g_proc_id == 0 && g_debug_level > 1) {

--- a/monomial/monomial.h
+++ b/monomial/monomial.h
@@ -116,6 +116,7 @@ typedef struct {
   void (*derivativefunction) (const int no, hamiltonian_field_t * const hf);
   /* the operator definitions */
   void (*Qsq) (spinor * const, spinor * const);
+  void (*Qsq32) (spinor32 * const, spinor32 * const);  
   void (*Qp) (spinor * const, spinor * const);
   void (*Qm) (spinor * const, spinor * const);
 } monomial;

--- a/monomial/monomial.h
+++ b/monomial/monomial.h
@@ -25,6 +25,7 @@
 #include "su3spinor.h"
 #include "hamiltonian_field.h"
 #include "rational/rational.h"
+#include "solver/solver_params.h"
 
 #define DET 0
 #define DETRATIO 1
@@ -82,6 +83,7 @@ typedef struct {
   double epsilon;
   double forceprec;
   double accprec;
+  solver_params_t solver_params;
   /* force normalisation */
   double forcefactor;
   /* some book-keeping */

--- a/operator.c
+++ b/operator.c
@@ -344,13 +344,13 @@ void op_invert(const int op_id, const int index_start, const int write_prop) {
       optr->iterations = invert_doublet_eo( optr->prop0, optr->prop1, optr->prop2, optr->prop3,
                                             optr->sr0, optr->sr1, optr->sr2, optr->sr3,
                                             optr->eps_sq, optr->maxiter,
-                                            optr->solver, optr->rel_prec,
+                                            optr->solver, optr->rel_prec, optr->solver_params,
                                             optr->external_inverter, optr->sloppy_precision, optr->compression_type);
     } else {
       optr->iterations = invert_cloverdoublet_eo( optr->prop0, optr->prop1, optr->prop2, optr->prop3,
                                                   optr->sr0, optr->sr1, optr->sr2, optr->sr3,
                                                   optr->eps_sq, optr->maxiter,
-                                                  optr->solver, optr->rel_prec,
+                                                  optr->solver, optr->rel_prec, optr->solver_params,
                                                   optr->external_inverter, optr->sloppy_precision, optr->compression_type);
       }
       g_mu = optr->mubar;

--- a/operator.c
+++ b/operator.c
@@ -337,6 +337,8 @@ void op_invert(const int op_id, const int index_start, const int write_prop) {
       init_sw_fields(VOLUME);
       sw_term( (const su3**) g_gauge_field, optr->kappa, optr->c_sw); 
       sw_invert_nd(optr->mubar*optr->mubar-optr->epsbar*optr->epsbar);
+      /* now copy double sw and sw_inv fields to 32bit versions */
+      copy_32_sw_fields();
     }
 
     for(i = 0; i < SourceInfo.no_flavours; i++) {

--- a/operator.c
+++ b/operator.c
@@ -108,6 +108,8 @@ int add_operator(const int type) {
   optr->conf_input = _default_gauge_input_filename;
   optr->no_extra_masses = 0;
 
+  (optr->solver_params).mcg_delta = _default_mixcg_innereps;
+
   optr->applyM = &dummy_D;
   optr->applyQ = &dummy_D;
   optr->applyQp = &dummy_D;
@@ -156,66 +158,59 @@ int init_operators() {
       /* This is a hack, it should be set on an operator basis. */
       optr->rel_prec = g_relative_precision_flag;
       if(optr->type == TMWILSON || optr->type == WILSON) {
-  if(optr->c_sw > 0) {
-    init_sw_fields();
-  }
-  if(optr->even_odd_flag) {
-    optr->applyQp = &Qtm_plus_psi;
-    optr->applyQm = &Qtm_minus_psi;
-    optr->applyQsq = &Qtm_pm_psi;
-    optr->applyMp = &Mtm_plus_psi;
-    optr->applyMm = &Mtm_minus_psi;
-  }
-  else {
-    optr->applyQp = &Q_plus_psi;
-    optr->applyQm = &Q_minus_psi;
-    optr->applyQsq = &Q_pm_psi;
-    optr->applyMp = &D_psi;
-    optr->applyMm = &D_psi;
-  }
-  if(optr->solver == CGMMS) {
-    if (g_cart_id == 0 && optr->even_odd_flag == 1)
-      fprintf(stderr, "CG Multiple mass solver works only without even/odd! Forcing!\n");
-    optr->even_odd_flag = 0;
-    if (g_cart_id == 0 && optr->DownProp)
-      fprintf(stderr, "CGMMS doesn't need AddDownPropagator! Switching Off!\n");
-    optr->DownProp = 0;
-  }
-        
-  if(optr->solver == INCREIGCG){
-    if (g_cart_id == 0 && optr->DownProp){
-       fprintf(stderr,"Warning: When even-odd preconditioning is used, the eigenvalues for +mu and -mu will be little different\n");
-       fprintf(stderr,"Incremental EigCG solver will still work however.\n");
-    }
-
-
-    if (g_cart_id == 0 && optr->even_odd_flag == 0)
-       fprintf(stderr,"Incremental EigCG solver is added only with Even-Odd preconditioning!. Forcing\n");
-    optr->even_odd_flag = 1;
-  }
-
-
+        if(optr->c_sw > 0) {
+          init_sw_fields();
+        }
+        if(optr->even_odd_flag) {
+          optr->applyQp = &Qtm_plus_psi;
+          optr->applyQm = &Qtm_minus_psi;
+          optr->applyQsq = &Qtm_pm_psi;
+          optr->applyMp = &Mtm_plus_psi;
+          optr->applyMm = &Mtm_minus_psi;
+        }
+        else {
+          optr->applyQp = &Q_plus_psi;
+          optr->applyQm = &Q_minus_psi;
+          optr->applyQsq = &Q_pm_psi;
+          optr->applyMp = &D_psi;
+          optr->applyMm = &D_psi;
+        }
+        if(optr->solver == CGMMS) {
+          if (g_cart_id == 0 && optr->even_odd_flag == 1)
+            fprintf(stderr, "CG Multiple mass solver works only without even/odd! Forcing!\n");
+          optr->even_odd_flag = 0;
+          if (g_cart_id == 0 && optr->DownProp)
+            fprintf(stderr, "CGMMS doesn't need AddDownPropagator! Switching Off!\n");
+          optr->DownProp = 0;
+        }
+         
+        if(optr->solver == INCREIGCG){
+          if (g_cart_id == 0 && optr->DownProp){
+             fprintf(stderr,"Warning: When even-odd preconditioning is used, the eigenvalues for +mu and -mu will be little different\n");
+             fprintf(stderr,"Incremental EigCG solver will still work however.\n");
+          }
+          if (g_cart_id == 0 && optr->even_odd_flag == 0)
+            fprintf(stderr,"Incremental EigCG solver is added only with Even-Odd preconditioning!. Forcing\n");
+          optr->even_odd_flag = 1;
+        }
+      }else if(optr->type == OVERLAP) {
+        optr->even_odd_flag = 0;
+        optr->applyM = &Dov_psi;
+        optr->applyQ = &Qov_psi;
+      }else if(optr->type == DBTMWILSON) {
+        optr->even_odd_flag = 1;
+        optr->applyDbQsq = &Qtm_pm_ndpsi;
+        /* TODO: this should be here!       */
+        /* Chi`s-spinors  memory allocation */
+        /*       if(init_chi_spinor_field(VOLUMEPLUSRAND/2, 20) != 0) { */
+        /*   fprintf(stderr, "Not enough memory for 20 NDPHMC Chi fields! Aborting...\n"); */
+        /*   exit(0); */
+        /*       } */
+      }else if(optr->type == DBCLOVER) {
+        optr->even_odd_flag = 1;
+        optr->applyDbQsq = &Qtm_pm_ndpsi;
       }
-      else if(optr->type == OVERLAP) {
-  optr->even_odd_flag = 0;
-  optr->applyM = &Dov_psi;
-  optr->applyQ = &Qov_psi;
-      }
-      else if(optr->type == DBTMWILSON) {
-  optr->even_odd_flag = 1;
-  optr->applyDbQsq = &Qtm_pm_ndpsi;
-  /* TODO: this should be here!       */
-  /* Chi`s-spinors  memory allocation */
-  /*       if(init_chi_spinor_field(VOLUMEPLUSRAND/2, 20) != 0) { */
-  /*   fprintf(stderr, "Not enough memory for 20 NDPHMC Chi fields! Aborting...\n"); */
-  /*   exit(0); */
-  /*       } */
-      }
-      else if(optr->type == DBCLOVER) {
-  optr->even_odd_flag = 1;
-  optr->applyDbQsq = &Qtm_pm_ndpsi;
-      }
-    }
+    } /* loop over operators */
 
     if(optr->external_inverter==QUDA_INVERTER ) {
 #ifdef QUDA
@@ -279,37 +274,35 @@ void op_invert(const int op_id, const int index_start, const int write_prop) {
         printf("#\n# 2 kappa mu = %e, kappa = %e, c_sw = %e\n", g_mu, g_kappa, g_c_sw);
       }
       if(optr->type != CLOVER) {
-  if(use_preconditioning){
-    g_precWS=(void*)optr->precWS;
-  }
-  else {
-    g_precWS=NULL;
-  }
-  optr->iterations = invert_eo( optr->prop0, optr->prop1, optr->sr0, optr->sr1,
-                                  optr->eps_sq, optr->maxiter,
-                                  optr->solver, optr->rel_prec,
-                                  0, optr->even_odd_flag,optr->no_extra_masses,
-                                  optr->extra_masses, optr->solver_params, optr->id,
-                                  optr->external_inverter, optr->sloppy_precision, optr->compression_type);
-
-  /* check result */
-  M_full(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1], optr->prop0, optr->prop1);
-      }
-      else {
-  /* this must be EE here!   */
-  /* to match clover_inv in Qsw_psi */
-  sw_invert(EE, optr->mu);
-  /* now copy double sw and sw_inv fields to 32bit versions */
-  copy_32_sw_fields();
-
-  optr->iterations = invert_clover_eo(optr->prop0, optr->prop1, optr->sr0, optr->sr1,
+        if(use_preconditioning){
+          g_precWS=(void*)optr->precWS;
+        } else {
+          g_precWS=NULL;
+        }
+        optr->iterations = invert_eo( optr->prop0, optr->prop1, optr->sr0, optr->sr1,
                                       optr->eps_sq, optr->maxiter,
-                                      optr->solver, optr->rel_prec,optr->solver_params,
-                                      &g_gauge_field, &Qsw_pm_psi, &Qsw_minus_psi,
+                                      optr->solver, optr->rel_prec,
+                                      0, optr->even_odd_flag,optr->no_extra_masses,
+                                      optr->extra_masses, optr->solver_params, optr->id,
                                       optr->external_inverter, optr->sloppy_precision, optr->compression_type);
-
-  /* check result */
-   Msw_full(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1], optr->prop0, optr->prop1);
+      
+        /* check result */
+        M_full(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1], optr->prop0, optr->prop1);
+      } else {
+        /* this must be EE here!   */
+        /* to match clover_inv in Qsw_psi */
+        sw_invert(EE, optr->mu);
+        /* now copy double sw and sw_inv fields to 32bit versions */
+        copy_32_sw_fields();
+      
+        optr->iterations = invert_clover_eo(optr->prop0, optr->prop1, optr->sr0, optr->sr1,
+                                            optr->eps_sq, optr->maxiter,
+                                            optr->solver, optr->rel_prec,optr->solver_params,
+                                            &g_gauge_field, &Qsw_pm_psi, &Qsw_minus_psi,
+                                            optr->external_inverter, optr->sloppy_precision, optr->compression_type);
+      
+        /* check result */
+         Msw_full(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1], optr->prop0, optr->prop1);
       }
 
       diff(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI], optr->sr0, VOLUME / 2);
@@ -332,8 +325,7 @@ void op_invert(const int op_id, const int index_start, const int write_prop) {
       } else 
         break;
     }
-  }
-  else if(optr->type == DBTMWILSON || optr->type == DBCLOVER) {
+  } else if(optr->type == DBTMWILSON || optr->type == DBCLOVER) {
     g_mubar = optr->mubar;
     g_epsbar = optr->epsbar;
     g_c_sw = 0.;
@@ -354,8 +346,7 @@ void op_invert(const int op_id, const int index_start, const int write_prop) {
                                             optr->eps_sq, optr->maxiter,
                                             optr->solver, optr->rel_prec,
                                             optr->external_inverter, optr->sloppy_precision, optr->compression_type);
-    }
-    else {
+    } else {
       optr->iterations = invert_cloverdoublet_eo( optr->prop0, optr->prop1, optr->prop2, optr->prop3,
                                                   optr->sr0, optr->sr1, optr->sr2, optr->sr3,
                                                   optr->eps_sq, optr->maxiter,
@@ -364,20 +355,18 @@ void op_invert(const int op_id, const int index_start, const int write_prop) {
       }
       g_mu = optr->mubar;
       if(optr->type != DBCLOVER) {
-  M_full(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI+2], optr->prop0, optr->prop1);
-      }
-      else {
-  Msw_full(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI+2], optr->prop0, optr->prop1);
+        M_full(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI+2], optr->prop0, optr->prop1);
+      } else {
+        Msw_full(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI+2], optr->prop0, optr->prop1);
       }
       assign_add_mul_r(g_spinor_field[DUM_DERI+1], optr->prop2, -optr->epsbar, VOLUME/2);
       assign_add_mul_r(g_spinor_field[DUM_DERI+2], optr->prop3, -optr->epsbar, VOLUME/2);
 
       g_mu = -g_mu;
       if(optr->type != DBCLOVER) {
-  M_full(g_spinor_field[DUM_DERI+3], g_spinor_field[DUM_DERI+4], optr->prop2, optr->prop3);
-      }
-      else {
-  Msw_full(g_spinor_field[DUM_DERI+3], g_spinor_field[DUM_DERI+4], optr->prop2, optr->prop3);
+        M_full(g_spinor_field[DUM_DERI+3], g_spinor_field[DUM_DERI+4], optr->prop2, optr->prop3);
+      } else {
+        Msw_full(g_spinor_field[DUM_DERI+3], g_spinor_field[DUM_DERI+4], optr->prop2, optr->prop3);
       }
       assign_add_mul_r(g_spinor_field[DUM_DERI+3], optr->prop0, -optr->epsbar, VOLUME/2);
       assign_add_mul_r(g_spinor_field[DUM_DERI+4], optr->prop1, -optr->epsbar, VOLUME/2);
@@ -427,13 +416,11 @@ void op_invert(const int op_id, const int index_start, const int write_prop) {
 
         mul_one_pm_itau2(optr->sr0, optr->sr2, g_spinor_field[DUM_DERI+2], g_spinor_field[DUM_DERI], +1., VOLUME/2);
         mul_one_pm_itau2(optr->sr1, optr->sr3, g_spinor_field[DUM_DERI+3], g_spinor_field[DUM_DERI+1], +1., VOLUME/2);
-
       }
       /* volume sources need only one inversion */
       else if(SourceInfo.type == 1) i++;
     }
-  }
-  else if(optr->type == OVERLAP) {
+  } else if(optr->type == OVERLAP) {
     g_mu = 0.;
     m_ov=optr->m;
     eigenvalues(&optr->no_ev, 5000, optr->ev_prec, 0, optr->ev_readwrite, nstore, optr->even_odd_flag);
@@ -502,7 +489,7 @@ void op_write_prop(const int op_id, const int index_start, const int append_) {
   construct_writer(&writer, filename, append);
   if (PropInfo.splitted || SourceInfo.ix == index_start) {
     inverterInfo = construct_paramsInverterInfo(optr->reached_prec, optr->iterations, 
-            optr->solver, optr->no_flavours);
+                                                optr->solver, optr->no_flavours);
     write_spinor_info(writer, PropInfo.format, inverterInfo, append);
     free(inverterInfo);
   }
@@ -512,10 +499,10 @@ void op_write_prop(const int op_id, const int index_start, const int append_) {
     sourceFormat = construct_paramsSourceFormat(SourceInfo.precision, optr->no_flavours, 4, 3);
     write_source_format(writer, sourceFormat);
     status = write_spinor(writer, &operator_list[op_id].sr0, &operator_list[op_id].sr1, 
-        1, SourceInfo.precision);
+                          1, SourceInfo.precision);
     if(optr->no_flavours == 2) {
       status = write_spinor(writer, &operator_list[op_id].sr2, &operator_list[op_id].sr3, 
-          1, SourceInfo.precision);
+                            1, SourceInfo.precision);
     }
     free(sourceFormat);
   }

--- a/operator.c
+++ b/operator.c
@@ -173,7 +173,7 @@ int init_operators() {
     optr->applyMp = &D_psi;
     optr->applyMm = &D_psi;
   }
-  if(optr->solver == 12) {
+  if(optr->solver == CGMMS) {
     if (g_cart_id == 0 && optr->even_odd_flag == 1)
       fprintf(stderr, "CG Multiple mass solver works only without even/odd! Forcing!\n");
     optr->even_odd_flag = 0;
@@ -263,7 +263,13 @@ void op_invert(const int op_id, const int index_start, const int write_prop) {
   printf("#\n# csw = %e, computing clover leafs\n", g_c_sw);
       }
       init_sw_fields(VOLUME);
-      sw_term( (const su3**) g_gauge_field, optr->kappa, optr->c_sw);
+      
+      sw_term( (const su3**) g_gauge_field, optr->kappa, optr->c_sw); 
+      /* this must be EE here!   */
+      /* to match clover_inv in Qsw_psi */
+      sw_invert(EE, optr->mu);
+      /* now copy double sw and sw_inv fields to 32bit versions */
+      copy_32_sw_fields();
     }
 
     for(i = 0; i < 2; i++) {
@@ -334,7 +340,7 @@ void op_invert(const int op_id, const int index_start, const int write_prop) {
     if(optr->type == DBCLOVER) {
       g_c_sw = optr->c_sw;
       if (g_cart_id == 0 && g_debug_level > 1) {
-  printf("#\n# csw = %e, computing clover leafs\n", g_c_sw);
+        printf("#\n# csw = %e, computing clover leafs\n", g_c_sw);
       }
       init_sw_fields(VOLUME);
       sw_term( (const su3**) g_gauge_field, optr->kappa, optr->c_sw); 

--- a/operator.h
+++ b/operator.h
@@ -94,7 +94,6 @@ typedef struct {
   double extra_masses[MAX_EXTRA_MASSES];
   int no_extra_masses;
 
-
   /* chebyshef coefficients for the overlap */
   double * coefs;
   /* various versions of the Dirac operator */

--- a/operator/Hopping_Matrix_32_nocom.c
+++ b/operator/Hopping_Matrix_32_nocom.c
@@ -48,6 +48,7 @@
 #include "operator/Hopping_Matrix_32.h"
 
 #define Hopping_Matrix_32 Hopping_Matrix_32_nocom
+#define Hopping_Matrix_32_orphaned Hopping_Matrix_32_orphaned_nocom
 #define _NO_COMM 1
 
 #include "Hopping_Matrix_32.c"

--- a/operator/clovertm_operators_32.h
+++ b/operator/clovertm_operators_32.h
@@ -41,4 +41,28 @@ void clover_gamma5_32(const int ieo,
 		   spinor32 * const l, const spinor32 * const k, const spinor32 * const j,
 		   const double mu);
 
+void assign_mul_one_sw_pm_imu_eps_32(const int ieo, 
+          spinor32 * const k_s, spinor32 * const k_c, 
+          const spinor32 * const l_s, const spinor32 * const l_c,
+          const float mu, const float eps);
+void assign_mul_one_sw_pm_imu_eps_32_orphaned(const int ieo, 
+          spinor32 * const k_s, spinor32 * const k_c, 
+          const spinor32 * const l_s, const spinor32 * const l_c,
+          const float mu, const float eps);
+
+void clover_gamma5_nd_32(const int ieo,
+          spinor32 * const l_c, spinor32 * const l_s,
+          const spinor32 * const k_c, const spinor32 * const k_s,
+          const spinor32 * const j_c, const spinor32 * const j_s,
+          const float mubar, const float epsbar);
+void clover_gamma5_nd_32_orphaned(const int ieo,
+          spinor32 * const l_c, spinor32 * const l_s,
+          const spinor32 * const k_c, const spinor32 * const k_s,
+          const spinor32 * const j_c, const spinor32 * const j_s,
+          const float mubar, const float epsbar);
+
+void clover_inv_nd_32(const int ieo, spinor32 * const l_c, spinor32 * const l_s);
+void clover_inv_nd_32_orphaned(const int ieo, spinor32 * const l_c, spinor32 * const l_s);
+
 #endif
+

--- a/operator/tm_operators_nd_32.h
+++ b/operator/tm_operators_nd_32.h
@@ -25,4 +25,6 @@ void Q_pm_ndpsi_32(spinor32 * const l_strange, spinor32 * const l_charm, spinor3
 
 void Qtm_pm_ndpsi_32(spinor32 * const l_strange, spinor32 * const l_charm,
 		  spinor32 * const k_strange, spinor32 * const k_charm);
+void Qsw_pm_ndpsi_32(spinor32 * const l_strange, spinor32 * const l_charm,
+      spinor32 * const k_strange, spinor32 * const k_charm);
 #endif

--- a/prepare_source.c
+++ b/prepare_source.c
@@ -151,7 +151,7 @@ void prepare_source(const int nstore, const int isample, const int ix, const int
     /* If the solver is _not_ CG we might read in */
     /* here some better guess                     */
     /* This also works for re-iteration           */
-    if (optr->solver != CG && optr->solver != PCG && optr->solver != MIXEDCG) {
+    if (optr->solver != CG && optr->solver != PCG && optr->solver != MIXEDCG && optr->solver != RGMIXEDCG) {
       ifs = fopen(source_filename, "r");
       if (ifs != NULL) {
         if (g_cart_id == 0) {

--- a/read_input.l
+++ b/read_input.l
@@ -1393,12 +1393,17 @@ static inline void rmQuotes(char *str){
 <MSOLVER>{
   CG {
     if(myverbose) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
-    mnl->solver = 1;
+    mnl->solver = CG;
+    BEGIN(solver_caller);
+  }
+  mixedCG {
+    if(myverbose) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
+    mnl->solver = MIXEDCG;
     BEGIN(solver_caller);
   }
   bicgstab {
     if(myverbose) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
-    mnl->solver = 0;
+    mnl->solver = BICGSTAB;
     BEGIN(solver_caller);
   }
 }

--- a/read_input.l
+++ b/read_input.l
@@ -585,6 +585,11 @@ static inline void rmQuotes(char *str){
     optr->rel_prec = 0;
     if(myverbose) printf("  SolverRelativePrecision set to NO line %d operator %d\n",  line_of_file, current_operator);
   }
+  {SPC}*mcgdelta{EQL}{FLT} {
+    sscanf(yytext, " %[a-zA-Z1] = %lf", name, &c);
+    (optr->solver_params).mcg_delta = c;
+    if(myverbose) printf("  mcg_delta set to %lf line %d operator %d\n", c, line_of_file, current_operator);
+  }
   {SPC}*EigCGnrhs{EQL}{DIGIT}+ {
     sscanf(yytext, " %[a-zA-Z] = %d", name, &a);
     (optr->solver_params).eigcg_nrhs = a;
@@ -613,12 +618,12 @@ static inline void rmQuotes(char *str){
   {SPC}*EigCGtolsq1{EQL}{FLT} {
     sscanf(yytext, " %[a-zA-Z1] = %lf", name, &c);
     (optr->solver_params).eigcg_tolsq1 = c;
-    if(myverbose) printf("  EigCGtolsq1 set to %lf line %d operator %d\n", a, line_of_file, current_operator);
+    if(myverbose) printf("  EigCGtolsq1 set to %lf line %d operator %d\n", c, line_of_file, current_operator);
   }
   {SPC}*EigCGrestolsq{EQL}{FLT} {
     sscanf(yytext, " %[a-zA-Z] = %lf", name, &c);
     (optr->solver_params).eigcg_restolsq = c;
-    if(myverbose) printf("  EigCGrestolsq set to %lf line %d operator %d\n", a, line_of_file, current_operator);
+    if(myverbose) printf("  EigCGrestolsq set to %lf line %d operator %d\n", c, line_of_file, current_operator);
   }
   {SPC}*EigCGRandGuessOpt{EQL}{DIGIT}+ {
     sscanf(yytext, " %[a-zA-Z] = %d", name, &a);
@@ -1201,6 +1206,11 @@ static inline void rmQuotes(char *str){
     sscanf(yytext, " %[a-zA-Z] = %d", name, &a);
     mnl->maxiter = a;
     if(myverbose) printf("  MaxSolverIterations set to %d line %d monomial %d\n", a, line_of_file, current_monomial);
+  }
+  {SPC}*mcgdelta{EQL}{FLT} {
+    sscanf(yytext, " %[a-zA-Z1] = %lf", name, &c);
+    (mnl->solver_params).mcg_delta = c;
+    if(myverbose) printf("  mcg_delta set to %lf line %d monomial %d\n", c, line_of_file, current_monomial);
   }
 }
 

--- a/read_input.l
+++ b/read_input.l
@@ -1206,6 +1206,12 @@ static inline void rmQuotes(char *str){
   }
 }
 
+<NDRATMONOMIAL,NDRATCORMONOMIAL,NDCLRATMONOMIAL,NDCLRATCORMONOMIAL>{
+  {SPC}*Solver{EQL} {
+   solver_caller=YY_START;
+   BEGIN(NDMSOLVER);
+  }
+}
 
 <DETMONOMIAL,POLYMONOMIAL,CLDETMONOMIAL,CLDETRATMONOMIAL>{
   {SPC}*2KappaMu{EQL}{FLT} {
@@ -1421,6 +1427,19 @@ static inline void rmQuotes(char *str){
   bicgstab {
     if(myverbose) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
     mnl->solver = BICGSTAB;
+    BEGIN(solver_caller);
+  }
+}
+
+<NDMSOLVER>{
+  cgmmsnd {
+    if(myverbose) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
+    mnl->solver = CGMMSND;
+    BEGIN(solver_caller);
+  }
+  mixedCGmmsnd {
+    if(myverbose) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
+    mnl->solver = MIXEDCGMMSND;
     BEGIN(solver_caller);
   }
 }

--- a/read_input.l
+++ b/read_input.l
@@ -865,7 +865,7 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  Solver set to MixedCG line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
-  rgmixedg {
+  rgmixedcg {
     optr->solver=RGMIXEDCG;
     if(myverbose) printf("  Solver set to RGMixedCG line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);

--- a/read_input.l
+++ b/read_input.l
@@ -865,6 +865,11 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  Solver set to MixedCG line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
+  rgmixedg {
+    optr->solver=RGMIXEDCG;
+    if(myverbose) printf("  Solver set to RGMixedCG line %d operator %d\n", line_of_file, current_operator);
+    BEGIN(name_caller);
+  }
   bicgstab {
     optr->solver=BICGSTAB;
     if(myverbose) printf("  Solver set to BiCGstab line %d operator %d\n", line_of_file, current_operator);
@@ -940,6 +945,11 @@ static inline void rmQuotes(char *str){
   mixedcg {
     optr->solver=MIXEDCG;
     if(myverbose) printf("  Solver set to MixedCG line %d operator %d\n", line_of_file, current_operator);
+    BEGIN(name_caller);
+  }
+  rgmixedcg {
+    optr->solver=RGMIXEDCG;
+    if(myverbose) printf("  Solver set to RGMixedCG line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
 }
@@ -1399,6 +1409,11 @@ static inline void rmQuotes(char *str){
   mixedCG {
     if(myverbose) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
     mnl->solver = MIXEDCG;
+    BEGIN(solver_caller);
+  }
+  rgmixedCG {
+    if(myverbose) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
+    mnl->solver = RGMIXEDCG;
     BEGIN(solver_caller);
   }
   bicgstab {

--- a/read_input.l
+++ b/read_input.l
@@ -862,17 +862,17 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  Solver set to CG line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
+  rgmixedcg {
+    optr->solver=RGMIXEDCG;
+    if(myverbose) printf("  Solver set to RGMixedCG line %d operator %d\n", line_of_file, current_operator);
+    BEGIN(name_caller);
+  }
 }
 
 <TMSOLVER>{
   mixedcg {
     optr->solver=MIXEDCG;
     if(myverbose) printf("  Solver set to MixedCG line %d operator %d\n", line_of_file, current_operator);
-    BEGIN(name_caller);
-  }
-  rgmixedcg {
-    optr->solver=RGMIXEDCG;
-    if(myverbose) printf("  Solver set to RGMixedCG line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
   bicgstab {
@@ -952,15 +952,7 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  Solver set to MixedCG line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
-  rgmixedcg {
-    optr->solver=RGMIXEDCG;
-    if(myverbose) printf("  Solver set to RGMixedCG line %d operator %d\n", line_of_file, current_operator);
-    BEGIN(name_caller);
-  }
 }
-
-
-
 
 
 

--- a/solver/Makefile.in
+++ b/solver/Makefile.in
@@ -34,14 +34,15 @@ libsolver_TARGETS = bicgstab_complex gmres incr_eigcg eigcg restart_X ortho \
 	            bicgstabell bicgstab2 eigenvalues fgmres \
 	            gcr gcr4complex diagonalise_general_matrix \
 	            quicksort gmres_dr lu_solve jdher Msap \
-                    jdher_bi gram-schmidt eigenvalues_bi \
-                    bicgstab_complex_bi cg_her_bi pcg_her \
-                    sub_low_ev cg_her_nd poly_precon \
-                    generate_dfl_subspace dfl_projector \
-                    cg_mms_tm cg_mms_tm_nd mixed_cg_mms_tm_nd \
-                    solver_field sumr mixed_cg_her rg_mixed_cg_her index_jd \
-                    dirac_operator_eigenvectors	spectral_proj \
-                    jdher_su3vect cg_her_su3vect eigenvalues_Jacobi monomial_solve
+              jdher_bi gram-schmidt eigenvalues_bi \
+              bicgstab_complex_bi cg_her_bi pcg_her \
+              sub_low_ev cg_her_nd poly_precon \
+              generate_dfl_subspace dfl_projector \
+              cg_mms_tm cg_mms_tm_nd mixed_cg_mms_tm_nd \
+              solver_field sumr mixed_cg_her index_jd \
+							rg_mixed_cg_her rg_mixed_cg_her_nd \
+              dirac_operator_eigenvectors	spectral_proj \
+              jdher_su3vect cg_her_su3vect eigenvalues_Jacobi monomial_solve
 
 libsolver_OBJECTS = $(addsuffix .o, ${libsolver_TARGETS})
 

--- a/solver/Makefile.in
+++ b/solver/Makefile.in
@@ -41,7 +41,7 @@ libsolver_TARGETS = bicgstab_complex gmres incr_eigcg eigcg restart_X ortho \
                     cg_mms_tm cg_mms_tm_nd mixed_cg_mms_tm_nd \
                     solver_field sumr mixed_cg_her index_jd \
                     dirac_operator_eigenvectors	spectral_proj \
-                    jdher_su3vect cg_her_su3vect eigenvalues_Jacobi
+                    jdher_su3vect cg_her_su3vect eigenvalues_Jacobi monomial_solve
 
 libsolver_OBJECTS = $(addsuffix .o, ${libsolver_TARGETS})
 

--- a/solver/Makefile.in
+++ b/solver/Makefile.in
@@ -39,7 +39,7 @@ libsolver_TARGETS = bicgstab_complex gmres incr_eigcg eigcg restart_X ortho \
                     sub_low_ev cg_her_nd poly_precon \
                     generate_dfl_subspace dfl_projector \
                     cg_mms_tm cg_mms_tm_nd mixed_cg_mms_tm_nd \
-                    solver_field sumr mixed_cg_her index_jd \
+                    solver_field sumr mixed_cg_her rg_mixed_cg_her index_jd \
                     dirac_operator_eigenvectors	spectral_proj \
                     jdher_su3vect cg_her_su3vect eigenvalues_Jacobi monomial_solve
 

--- a/solver/mixed_cg_her.c
+++ b/solver/mixed_cg_her.c
@@ -51,6 +51,7 @@
 #include "start.h"
 #include "operator/tm_operators_32.h"
 #include "solver/matrix_mult_typedef.h"
+#include "solver/solver_params.h"
 #include "read_input.h"
 
 #include "solver_field.h"
@@ -61,8 +62,9 @@
 
 
 /* P output = solution , Q input = source */
-int mixed_cg_her(spinor * const P, spinor * const Q, const int max_iter, 
-		 double eps_sq, const int rel_prec, const int N, matrix_mult f, matrix_mult32 f32) {
+int mixed_cg_her(spinor * const P, spinor * const Q, solver_params_t solver_params, 
+                 const int max_iter, double eps_sq, const int rel_prec, const int N,
+                 matrix_mult f, matrix_mult32 f32) {
 
   int i = 0, iter = 0, j = 0;
   float sqnrm = 0., sqnrm2, squarenorm;

--- a/solver/mixed_cg_her.h
+++ b/solver/mixed_cg_her.h
@@ -21,9 +21,11 @@
 
 #include"operator/tm_operators_32.h"
 #include"solver/matrix_mult_typedef.h"
+#include"solver/solver_params.h"
 #include"su3.h"
 
-int mixed_cg_her(spinor * const P, spinor * const Q, const int max_iter, 
-		 double eps_sq, const int rel_prec, const int N, matrix_mult f, matrix_mult32 f32);
+int mixed_cg_her(spinor * const P, spinor * const Q, solver_params_t solver_params, 
+                 const int max_iter, double eps_sq, const int rel_prec, const int N,
+                 matrix_mult f, matrix_mult32 f32);
 
 #endif

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -1,0 +1,155 @@
+/***********************************************************************
+ *
+ * Copyright (C) 2014 Florian Burger
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  
+ * File: monomial_solve.c
+ *
+ * solver wrapper for monomials
+ *
+ * The externally accessible functions are
+ *
+ *
+ *   int solve_degenerate(spinor * const P, spinor * const Q, const int max_iter, 
+           double eps_sq, const int rel_prec, const int N, matrix_mult f)
+ *   int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn, 
+ *                    spinor * const Qup, spinor * const Qdn, 
+ *                    solver_pm_t * solver_pm)  
+ *
+ **************************************************************************/
+
+
+#ifdef HAVE_CONFIG_H
+# include<config.h>
+#endif
+#include "global.h"
+#include "read_input.h"
+#include "solver/solver.h"
+#include "solver/matrix_mult_typedef.h"
+#include "solver/solver_types.h"
+#include "operator/tm_operators.h"
+#include "operator/tm_operators_32.h"
+#include "operator/tm_operators_nd.h"
+#include "operator/tm_operators_nd_32.h"
+#include "operator/clovertm_operators.h"
+#include "operator/clovertm_operators_32.h"
+#include "monomial_solve.h"
+
+
+#ifdef HAVE_GPU
+#include"../GPU/cudadefs.h"
+extern  int linsolve_eo_gpu (spinor * const P, spinor * const Q, const int max_iter, 
+                            double eps, const int rel_prec, const int N, matrix_mult f);
+extern int dev_cg_mms_tm_nd(spinor ** const Pup, spinor ** const Pdn, 
+		 spinor * const Qup, spinor * const Qdn, 
+		 solver_pm_t * solver_pm);
+   #ifdef TEMPORALGAUGE
+     #include "../temporalgauge.h" 
+   #endif
+#include "read_input.h" 
+#endif
+
+
+
+
+int solve_degenerate(spinor * const P, spinor * const Q, const int max_iter, 
+           double eps_sq, const int rel_prec, const int N, matrix_mult f, int solver_type){
+  int iteration_count = 0;
+  int use_solver = solver_type;
+  // the default mixed solver is rg_mixed_cg_her
+  int (*msolver_fp)(spinor * const, spinor * const, const int, double, const int, const int, matrix_mult, matrix_mult32) = rg_mixed_cg_her;
+  
+  if(use_solver == MIXEDCG || use_solver == RGMIXEDCG){
+    // but it might be necessary at some point to use the old version
+    if(use_solver == MIXEDCG){
+      msolver_fp = mixed_cg_her;
+    }
+
+    if(usegpu_flag){   
+      #ifdef HAVE_GPU     
+	      #ifdef TEMPORALGAUGE
+          to_temporalgauge(g_gauge_field, Q , P);
+        #endif          
+        iteration_count = linsolve_eo_gpu(P, Q, max_iter, eps_sq, rel_prec, N, f);			     
+        #ifdef TEMPORALGAUGE
+          from_temporalgauge(Q, P);
+        #endif
+      #endif
+      return(iteration_count);
+    }
+    else{
+      if(f==Qtm_pm_psi){   
+        iteration_count =  msolver_fp(P, Q, max_iter, eps_sq, rel_prec, N, f, &Qtm_pm_psi_32);
+        return(iteration_count);
+      }
+      else if(f==Q_pm_psi){     
+	      iteration_count =  msolver_fp(P, Q, max_iter, eps_sq, rel_prec, N, f, &Q_pm_psi_32);
+	      return(iteration_count);      
+      } else if(f==Qsw_pm_psi){
+        copy_32_sw_fields();
+        iteration_count = msolver_fp(P, Q, max_iter, eps_sq, rel_prec, N, f, &Qsw_pm_psi_32);
+        return(iteration_count);
+      } else {
+        if(g_proc_id==0) printf("Warning: 32 bit matrix not available. Falling back to CG in 64 bit\n"); 
+        use_solver = CG;
+      }
+    }
+  } 
+  if(use_solver == CG){
+     iteration_count =  cg_her(P, Q, max_iter, eps_sq, rel_prec, N, f);   
+  }
+  else if(use_solver == BICGSTAB){
+     iteration_count =  bicgstab_complex(P, Q, max_iter, eps_sq, rel_prec, N, f);     
+  }
+  else{
+    if(g_proc_id==0) printf("Error: solver not allowed for degenerate solve. Aborting...\n");
+    exit(2);
+  }
+  return(iteration_count);
+}
+
+
+int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn, 
+                 spinor * const Qup, spinor * const Qdn, 
+                 solver_pm_t * solver_pm){ 
+  int iteration_count = 0; 
+    if(solver_pm->type==MIXEDCGMMSND){
+      if(usegpu_flag){
+	#ifdef HAVE_GPU      
+	  #ifdef TEMPORALGAUGE
+	    to_temporalgauge_mms(g_gauge_field , Qup, Qdn, Pup, Pdn, solver_pm->no_shifts);
+	  #endif        
+	  iteration_count = dev_cg_mms_tm_nd(Pup, Pdn, Qup, Qdn, solver_pm);  
+	  #ifdef TEMPORALGAUGE
+	    from_temporalgauge_mms(Qup, Qdn, Pup, Pdn, solver_pm->no_shifts);
+	  #endif 
+	#endif
+      }
+      else{
+	iteration_count = mixed_cg_mms_tm_nd(Pup, Pdn, Qup, Qdn, solver_pm);
+      }
+    }
+    else if (solver_pm->type==CGMMSND){
+      iteration_count = cg_mms_tm_nd(Pup, Pdn, Qup, Qdn, solver_pm);
+    }
+    else{
+      if(g_proc_id==0) printf("Error: solver not allowed for ND mms solve. Aborting...\n");
+      exit(2);      
+    }
+  return(iteration_count);
+}

--- a/solver/monomial_solve.h
+++ b/solver/monomial_solve.h
@@ -1,5 +1,5 @@
 /***********************************************************************
- * Copyright (C) 2002,2003,2004,2005,2006,2007,2008 Carsten Urbach
+ * Copyright (C) 2014 Florian Burger
  *
  * This file is part of tmLQCD.
  *
@@ -16,15 +16,16 @@
  * You should have received a copy of the GNU General Public License
  * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
  ***********************************************************************/
+#ifndef _MONOMIAL_SOLVE_H
+#define _MONOMIAL_SOLVE_H
 
-#ifndef _ASSIGN_H
-#define _ASSIGN_H
 
-#include "su3.h"
-
-/* Assign (*R) = (*S) */
-void assign(spinor * const R, spinor * const S, const int N);
-void assign_32(spinor32 * const R, spinor32 * const S, const int N);
-void assign_su3vect(su3_vector * const R, su3_vector * const S, const int N);
+#include"solver/matrix_mult_typedef.h"
+#include"su3.h"
+    int solve_degenerate(spinor * const P, spinor * const Q, const int max_iter, 
+           double eps_sq, const int rel_prec, const int N, matrix_mult f, int solver_type);
+    int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn, 
+                     spinor * const Qup, spinor * const Qdn, 
+                     solver_pm_t * solver_pm);
 
 #endif

--- a/solver/monomial_solve.h
+++ b/solver/monomial_solve.h
@@ -21,8 +21,9 @@
 
 
 #include"solver/matrix_mult_typedef.h"
+#include"solver/solver_params.h"
 #include"su3.h"
-    int solve_degenerate(spinor * const P, spinor * const Q, const int max_iter, 
+    int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_params, const int max_iter, 
            double eps_sq, const int rel_prec, const int N, matrix_mult f, int solver_type);
     int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn, 
                      spinor * const Qup, spinor * const Qdn, 

--- a/solver/rg_mixed_cg_her.c
+++ b/solver/rg_mixed_cg_her.c
@@ -218,7 +218,11 @@ int rg_mixed_cg_her(spinor * const P, spinor * const Q, const int max_iter,
   
   // compute the maximum number of maximum iterations based on the expected reduction 
   int N_outer = (int)ceil(log10( delta/eps_sq ))+4; // +4 is an arbitrary choice which seems to avoid switching to DP
-  int max_inner_it = mixcg_maxinnersolverit;
+  // this seems to provide a very good cut-off for the number of inner iterations
+  // in principle it should be possible to calculate this by considering the number of multiplications
+  // and additions actually involved in each iteration and propagating the effect to the
+  // residual, thus setting the maximum number of iterations that can be done... 
+  int max_inner_it = 2800;
   if(g_debug_level > 0 && g_proc_id==0) 
     printf("#RG_Mixed CG: max_inner_it: %d N_outer: %d \n", max_inner_it, N_outer);
   

--- a/solver/rg_mixed_cg_her.c
+++ b/solver/rg_mixed_cg_her.c
@@ -69,7 +69,7 @@
 #include "solver/rg_mixed_cg_her.h"
 #include "gettime.h"
 
-void output_flops(const double seconds, const unsigned int N, const unsigned int iter_out, const unsigned int iter_in_sp, const unsigned int iter_in_dp, const double eps_sq);
+static void output_flops(const double seconds, const unsigned int N, const unsigned int iter_out, const unsigned int iter_in_sp, const unsigned int iter_in_dp, const double eps_sq);
 
 static inline unsigned int inner_loop_high(spinor * const x, spinor * const p, spinor * const q, spinor * const r, double * const rho1, const double delta,
                                            matrix_mult f, const double eps_sq, const unsigned int N, const unsigned int iter ){

--- a/solver/rg_mixed_cg_her.c
+++ b/solver/rg_mixed_cg_her.c
@@ -217,7 +217,7 @@ int rg_mixed_cg_her(spinor * const P, spinor * const Q, const int max_iter,
   }
   
   // compute the maximum number of maximum iterations based on the expected reduction 
-  int N_outer = (int)ceil(log10( delta/eps_sq ))+1;
+  int N_outer = (int)ceil(log10( delta/eps_sq ))+4; // +4 is an arbitrary choice which seems to avoid switching to DP
   int max_inner_it = mixcg_maxinnersolverit;
   if(g_debug_level > 0 && g_proc_id==0) 
     printf("#RG_Mixed CG: max_inner_it: %d N_outer: %d \n", max_inner_it, N_outer);

--- a/solver/rg_mixed_cg_her.c
+++ b/solver/rg_mixed_cg_her.c
@@ -302,22 +302,27 @@ int rg_mixed_cg_her(spinor * const P, spinor * const Q, const int max_iter,
       rho_sp = rho_dp; // not sure if it's fine to truncate this or whether one should calculate it in SP directly
 
       // if the inner loop was successful at reducing the residual, reuse the search direction to some extent
-      if(beta_dp < 1.0) {
+      //if(beta_dp < 1.0) {
         // if we just came out of a high precision loop (high_control==1), phigh currently contains the search vector
         // and there is no need to copy it over
-        if(high_control==0){
-          assign_to_64(phigh,p,N);
-        }else{
-          high_control = 0;
-        }
+        //if(high_control==0){
+        //  assign_to_64(phigh,p,N);
+        //}else{
+        //  high_control = 0;
+        //}
         // attempt to make a new search vector, as conjugate as possible to the previous one
         // trying to enforce conjugacy (phigh^+ M p) = 0 directly by computing p' = rhigh - (rhigh^+ M p) / (p^+ M p) * p
         // does not work in general due to limited precision (it fails on lattices L>24)
-        assign_mul_add_r(phigh,beta_dp,rhigh,N);
+        f(qhigh,phigh);
+        _Complex double gamma = 1.0/scalar_prod(phigh,qhigh,N,1);
+        gamma *= scalar_prod(rhigh,qhigh,N,1);
+        if(g_proc_id==0) printf("gamma: %g %g\n",creal(gamma),cimag(gamma));
+        assign_mul_add(phigh,-gamma,rhigh,N);
+        //assign_mul_add_r(phigh,beta_dp,rhigh,N);
         assign_to_32(p,phigh,N);
-      }else{
-        assign_to_32(p,rhigh,N);
-      }
+      //}else{
+      //  assign_to_32(p,rhigh,N);
+      //}
     }
 
     zero_spinor_field_32(x,N);

--- a/solver/rg_mixed_cg_her.c
+++ b/solver/rg_mixed_cg_her.c
@@ -1,0 +1,350 @@
+/***********************************************************************
+ * Copyright (C) 2015 Bartosz Kostrzewa, Florian Burger
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * File: rg_mixed_cg_her.c
+ *
+ * CG solver for hermitian f only!
+ *
+ * The externally accessible functions are
+ *
+ *   Q: source
+ * inout:
+ *   P: initial guess and result
+ * 
+ *
+ **************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+# include<config.h>
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include "global.h"
+#include "su3.h"
+#include "linalg_eo.h"
+#include "start.h"
+#include "operator/tm_operators_32.h"
+#include "operator/clovertm_operators_32.h"
+#include "solver/matrix_mult_typedef.h"
+#include "read_input.h"
+
+#include "solver_field.h"
+#include "solver/rg_mixed_cg_her.h"
+#include "gettime.h"
+
+#define DELTA 1.0e-2f
+#define PR 0
+
+void output_flops(const double seconds, const unsigned int N, const unsigned int iter_out, const unsigned int iter_in_sp, const unsigned int iter_in_dp, const double eps_sq);
+
+static inline unsigned int inner_loop_high(spinor * const x, spinor * const p, spinor * const q, spinor * const r, double * const rho1, double delta,
+                              matrix_mult f, const double eps_sq, const unsigned int max_inner_it, const unsigned int N, const unsigned int iter ){
+
+  static double alpha, beta, rho, rhomax;
+  static unsigned int j;
+
+  rho = *rho1;
+  rhomax = *rho1;
+
+  for(j = 0; j < max_inner_it; ++j){
+
+    f(q,p);
+    alpha = rho/scalar_prod_r(p,q,N,1);
+    assign_add_mul_r(x, p, alpha, N);
+    assign_add_mul_r(r, q, -alpha, N);
+    rho = square_norm(r,N,1);
+    beta = rho / *rho1;
+    *rho1 = rho;
+    assign_mul_add_r(p, beta, r, N);
+    
+    /* break out of inner loop if iterated residual goes below some fraction of the maximum observed
+     * iterated residual since the last update or if the target precision has been reached 
+     * enforce convergence more strictly by a factor of 1.3 to avoid unnecessary restarts 
+     * if the real residual is still a bit too large */
+    if( rho < delta*rhomax || 1.3*rho < eps_sq ) break;
+    if( rho > rhomax ) rhomax = rho;
+    
+    if(g_debug_level > 2 && g_proc_id == 0) {
+      printf("DP_inner CG: %d res^2 %g\t\n", j+iter, rho);
+    }
+  }
+
+  return j;
+}
+
+static inline unsigned int inner_loop(spinor32 * const x, spinor32 * const p, spinor32 * const q, spinor32 * const r, float * const rho1, float delta,
+                              matrix_mult32 f32, const float eps_sq, const unsigned int max_inner_it, const unsigned int N, const unsigned int iter,
+                              float alpha, float beta, int pipelined, int pr ){
+
+  static float rho, rhomax, pro;
+  static unsigned int j;
+
+  rho = *rho1;
+  rhomax = *rho1;
+
+  if(pipelined==0){
+    for(j = 0; j < max_inner_it; ++j){
+      f32(q,p);
+      pro = scalar_prod_r_32(p,q,N,1);
+      alpha = rho/pro;
+      assign_add_mul_r_32(x, p, alpha, N);
+      assign_add_mul_r_32(r, q, -alpha, N);
+      rho = square_norm_32(r,N,1);
+      // Polak-Ribiere computation of beta, claimed to be self-stabilising, positive effect so far not observed or required
+      if(pr==1){
+        beta = alpha*(alpha*square_norm_32(q,N,1)-pro) / *rho1;
+      }else{
+        beta = rho / *rho1;
+      }
+      *rho1 = rho;
+      assign_mul_add_r_32(p, beta, r, N);
+      if(g_debug_level > 2 && g_proc_id == 0) {
+        printf("SP_inner CG: %d res^2 %g\t\n", j+iter, rho);
+      }
+      /* break out of inner loop if iterated residual goes below some fraction of the maximum observed
+       * iterated residual since the last update or if the target precision has been reached 
+       * enforce convergence more strictly by a factor of 1.3 to avoid unnecessary restarts 
+       * if the real residual is still a bit too large */
+      if( rho < delta*rhomax || 1.3*rho < eps_sq ) break;
+      // "groupwise update"  
+      if( rho > rhomax ) rhomax = rho;
+    }
+  }else{
+    // pipelined cg requires one more scalar product but may allow optimisations to be made
+    // e.g.: one could do the collective communication for sqrnrm(r) while other stuff is being computed
+    // it is also self-initialising (alpha=0, beta=0 will work)
+    for(j = 0; j < max_inner_it; ++j){
+      assign_add_mul_r_32(x, p, alpha, N);
+      assign_add_mul_r_32(r, q, -alpha, N);
+      assign_mul_add_r_32(p, beta, r, N);
+      f32(q,p);
+  
+      rho = square_norm_32(r,N,1);
+      pro = scalar_prod_r_32(p,q,N,1);
+      alpha = rho/pro;
+      if(pr==1){
+        beta = alpha*(alpha*square_norm_32(q,N,1)-pro)/rho;
+      }else{
+        beta = rho/ *rho1;
+      }
+      *rho1=rho;
+
+      if(g_debug_level > 2 && g_proc_id == 0) {
+        printf("SP_inner CG: %d res^2 %g\t\n", j+iter, rho);
+      }
+      if( rho < delta*rhomax || 1.3*rho < eps_sq ) break;
+      if( rho > rhomax ) rhomax = rho;
+    }
+  }
+
+  return j;
+}
+
+
+/* P output = solution , Q input = source */
+int rg_mixed_cg_her(spinor * const P, spinor * const Q, const int max_iter, 
+		 double eps_sq, const int rel_prec, const int N, matrix_mult f, matrix_mult32 f32) {
+
+  int iter_in_sp = 0, iter_in_dp = 0, iter_out = 0, i;
+  float rho_sp;
+  double beta_dp, rho_dp;
+  double sourcesquarenorm, target_eps_sq;
+
+  spinor *xhigh, *rhigh, *qhigh, *phigh;
+  spinor32 *x, *p, *q, *r;
+
+  spinor ** solver_field = NULL;
+  spinor32 ** solver_field32 = NULL;  
+  const int nr_sf = 4;
+  const int nr_sf32 = 4;
+  
+  // for now use constant residual reduction factor, 0.01 seems to work very well in general
+  float delta = DELTA;
+
+  int high_control = 0;
+
+  double atime, etime, flops;
+  
+  if(N == VOLUME) {
+    init_solver_field(&solver_field, VOLUMEPLUSRAND, nr_sf);    
+    init_solver_field_32(&solver_field32, VOLUMEPLUSRAND, nr_sf32);
+  }
+  else {
+    init_solver_field(&solver_field, VOLUMEPLUSRAND/2, nr_sf);
+    init_solver_field_32(&solver_field32, VOLUMEPLUSRAND/2, nr_sf32);    
+  }
+
+  atime = gettime();
+
+  // we could get away with using fewer fields, of course
+  phigh = solver_field[3];
+  xhigh = solver_field[2];
+  rhigh = solver_field[1];
+  qhigh = solver_field[0];
+
+  x = solver_field32[3];
+  r = solver_field32[2];
+  p = solver_field32[1];
+  q = solver_field32[0];
+
+  // we always want to apply the full precision operator
+  int save_sloppy = g_sloppy_precision_flag;
+  g_sloppy_precision_flag = 0;
+
+  sourcesquarenorm = square_norm(Q,N,1);
+  if( rel_prec == 1 ) {
+    target_eps_sq = eps_sq*sourcesquarenorm;
+    if(g_debug_level > 0 && g_proc_id==0) 
+      printf("#RG_Mixed CG: Using relative precision! eps_sq: %.6g target_eps_sq: %.6g \n",eps_sq,target_eps_sq);
+  }else{
+    target_eps_sq = eps_sq;
+  }
+  
+  // compute the maximum number of maximum iterations based on the expected reduction 
+  int N_outer = (int)ceil(log10( delta/eps_sq ))+1;
+  int max_inner_it = mixcg_maxinnersolverit;
+  if(g_debug_level > 0 && g_proc_id==0) 
+    printf("#RG_Mixed CG: max_inner_it: %d N_outer: %d \n", max_inner_it, N_outer);
+  
+  // should compute real residual here, for now we always use a zero guess
+  zero_spinor_field_32(x,N);
+  zero_spinor_field(P,N);
+  assign(phigh,Q,N);
+  assign(rhigh,Q,N);
+  
+  rho_dp = square_norm(rhigh,N,1);
+  assign_to_32(r,rhigh,N);
+  rho_sp = rho_dp;
+  assign_32(p,r,N);
+  
+  iter_in_sp += inner_loop(x, p, q, r, &rho_sp, delta, f32, (float)target_eps_sq, max_inner_it, 
+                           N, iter_out+iter_in_sp+iter_in_dp, 0.0, 0.0, 0, PR);
+
+  for(i = 0; i < N_outer; i++) {
+     
+    ++iter_out;
+
+    // prepare for defect correction
+    // update high precision solution 
+    if(high_control==0) {
+      // accumulate solution (sp -> dp) 
+      addto_32(P,x,N);
+      // compute real residual
+      f(qhigh,P);
+      diff(rhigh,Q,qhigh,N);
+      beta_dp = 1/rho_dp;
+      rho_dp = square_norm(rhigh,N,1);
+      beta_dp *= rho_dp;
+    }
+    
+    // if it seems like we're diverging, let's do a couple of iterations in full precision
+    if( high_control==2 ) {
+      assign(phigh,rhigh,N);
+      zero_spinor_field(xhigh,N);
+      beta_dp = 1/rho_dp;
+      iter_in_dp += inner_loop_high(xhigh, phigh, qhigh, rhigh, &rho_dp, delta, f, 
+                                    target_eps_sq, max_inner_it, N, iter_out+iter_in_sp+iter_in_dp);
+      rho_sp = rho_dp;
+      // accumulate solution
+      add(P,P,xhigh,N);
+      // compute real residual
+      f(qhigh,P);
+      diff(rhigh,Q,qhigh,N);
+      rho_dp = square_norm(rhigh,N,1);
+      beta_dp *= rho_dp;
+      high_control = 1;
+    }
+
+    if(g_debug_level > 2 && g_proc_id == 0) {
+      printf("RG_mixed CG last inner residue:       %17g\n", rho_sp);
+      printf("RG_mixed CG true residue:             %6d %10g\n", iter_in_sp+iter_in_dp+iter_out, rho_dp); fflush(stdout);
+      printf("RG_mixed CG residue reduction factor: %6d %10g\n", iter_in_sp+iter_in_dp+iter_out, beta_dp);
+    }
+    if( rho_dp <= target_eps_sq ) {
+      etime = gettime();
+      output_flops(etime-atime, N, iter_out, iter_in_sp, iter_in_dp, eps_sq);
+      
+      g_sloppy_precision_flag = save_sloppy;
+      finalize_solver(solver_field, nr_sf);
+      finalize_solver_32(solver_field32, nr_sf32); 
+      return(iter_in_sp+iter_in_dp+iter_out);
+    }
+
+    // if it seems like we're stuck or reaching the iteration limit, we skip this correction and proceed in full precision above
+    if( i >= (N_outer-3) ){
+      if(g_proc_id==0) printf("mixed CG: Reaching iteration limit, switching to DP!\n");
+      high_control = 2;
+      continue;
+    }else{
+      // correct defect
+      assign_to_32(r,rhigh,N);
+      rho_sp = rho_dp; // not sure if it's fine to truncate this or whether one should calculate it in SP directly
+
+      // if the inner loop was successful at reducing the residual, reuse the search direction to some extent
+      if(beta_dp < 1.0) {
+        // if we just came out of a high precision loop (high_control==1), phigh currently contains the search vector
+        // and there is no need to copy it over
+        if(high_control==0){
+          assign_to_64(phigh,p,N);
+        }else{
+          high_control = 0;
+        }
+        // attempt to make a new search vector, as conjugate as possible to the previous one
+        // trying to enforce conjugacy (phigh M p) = 0 directly by computing p' = rhigh - (rhigh M p) / (p M p) * p
+        // does not work in general due to limited precision (it fails on lattices L>24)
+        assign_mul_add_r(phigh,beta_dp,rhigh,N);
+        assign_to_32(p,phigh,N);
+      }else{
+        assign_to_32(p,rhigh,N);
+      }
+    }
+
+    zero_spinor_field_32(x,N);
+    iter_in_sp += inner_loop(x, p, q, r, &rho_sp, delta, f32, (float)target_eps_sq, 
+                             max_inner_it, N, iter_out+iter_in_sp+iter_in_dp, 0.0, 0.0, 0, PR);
+  }
+  
+  // convergence failure...
+  g_sloppy_precision_flag = save_sloppy;
+  finalize_solver(solver_field, nr_sf);
+  finalize_solver_32(solver_field32, nr_sf32);
+  return -1; 
+}
+
+void output_flops(const double seconds, const unsigned int N, const unsigned int iter_out, const unsigned int iter_in_sp, const unsigned int iter_in_dp, const double eps_sq){
+  double flops;
+  // TODO: compute real number of flops...
+  int total_it = iter_in_sp+iter_in_dp+iter_out;
+  if(g_debug_level > 0 && g_proc_id == 0) {
+    printf("# mixed CG: iter_out: %d iter_in_sp: %d iter_in_dp: %d\n",iter_out,iter_in_sp,iter_in_dp);
+    printf("# FIXME: note the following flop counts are wrong!\n");
+  	if(N != VOLUME){
+  	  /* 2 A + 2 Nc Ns + N_Count ( 2 A + 10 Nc Ns ) */
+  	  /* 2*1608.0 because the linalg is over VOLUME/2 */
+  	  flops = (2*(2*1608.0+2*3*4) + 2*3*4 + total_it*(2.*(2*1608.0+2*3*4) + 10*3*4))*N/1.0e6f;
+  	}
+  	else{
+  	  /* 2 A + 2 Nc Ns + N_Count ( 2 A + 10 Nc Ns ) */
+  	  flops = (2*(1608.0+2*3*4) + 2*3*4 + total_it*(2.*(1608.0+2*3*4) + 10*3*4))*N/1.0e6f;      
+  	}
+  	printf("#RG_mixed CG: iter: %d eps_sq: %1.4e t/s: %1.4e\n", total_it, eps_sq, seconds); 
+  	printf("#RG_mixed CG: flopcount (for e/o tmWilson only): t/s: %1.4e mflops_local: %.1f mflops: %.1f\n", 
+  	      seconds, flops/(seconds), g_nproc*flops/(seconds));
+  }      
+}

--- a/solver/rg_mixed_cg_her.h
+++ b/solver/rg_mixed_cg_her.h
@@ -1,5 +1,5 @@
 /***********************************************************************
- * Copyright (C) 2002,2003,2004,2005,2006,2007,2008 Carsten Urbach
+ * Copyright (C) 2015 Bartosz Kostrzewa
  *
  * This file is part of tmLQCD.
  *
@@ -21,6 +21,7 @@
 
 #include"operator/tm_operators_32.h"
 #include"solver/matrix_mult_typedef.h"
+#include"solver/solver_params.h"
 #include"su3.h"
 
 typedef enum PolakRibiere_s {
@@ -39,7 +40,8 @@ typedef enum ResGuide_s {
   MCG_RESGUIDE
 } MCG_RESGUIDE_TYPE;
 
-int rg_mixed_cg_her(spinor * const P, spinor * const Q, const int max_iter, 
-		 double eps_sq, const int rel_prec, const int N, matrix_mult f, matrix_mult32 f32);
+int rg_mixed_cg_her(spinor * const P, spinor * const Q, solver_params_t solver_params,
+                    const int max_iter, const double eps_sq, const int rel_prec,
+                    const int N, matrix_mult f, matrix_mult32 f32);
 
 #endif

--- a/solver/rg_mixed_cg_her.h
+++ b/solver/rg_mixed_cg_her.h
@@ -16,15 +16,14 @@
  * You should have received a copy of the GNU General Public License
  * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
  ***********************************************************************/
+#ifndef _RG_MIXED_CG_HER_H
+#define _RG_MIXED_CG_HER_H
 
-#ifndef _ASSIGN_H
-#define _ASSIGN_H
+#include"operator/tm_operators_32.h"
+#include"solver/matrix_mult_typedef.h"
+#include"su3.h"
 
-#include "su3.h"
-
-/* Assign (*R) = (*S) */
-void assign(spinor * const R, spinor * const S, const int N);
-void assign_32(spinor32 * const R, spinor32 * const S, const int N);
-void assign_su3vect(su3_vector * const R, su3_vector * const S, const int N);
+int rg_mixed_cg_her(spinor * const P, spinor * const Q, const int max_iter, 
+		 double eps_sq, const int rel_prec, const int N, matrix_mult f, matrix_mult32 f32);
 
 #endif

--- a/solver/rg_mixed_cg_her.h
+++ b/solver/rg_mixed_cg_her.h
@@ -19,26 +19,11 @@
 #ifndef _RG_MIXED_CG_HER_H
 #define _RG_MIXED_CG_HER_H
 
-#include"operator/tm_operators_32.h"
-#include"solver/matrix_mult_typedef.h"
-#include"solver/solver_params.h"
-#include"su3.h"
-
-typedef enum PolakRibiere_s {
-  MCG_NO_PR=0,
-  MCG_PR=1
-} MCG_PR_TYPE;
-
-typedef enum Pipelined_s {
-  MCG_NO_PIPELINED=0,
-  MCG_PIPELINED
-} MCG_PIPELINED_TYPE;
-
-// currently not used
-typedef enum ResGuide_s {
-  MCG_NO_RESGUIDE=0,
-  MCG_RESGUIDE
-} MCG_RESGUIDE_TYPE;
+#include "operator/tm_operators_32.h"
+#include "solver/rg_mixed_cg_typedef.h"
+#include "solver/matrix_mult_typedef.h"
+#include "solver/solver_params.h"
+#include "su3.h"
 
 int rg_mixed_cg_her(spinor * const P, spinor * const Q, solver_params_t solver_params,
                     const int max_iter, const double eps_sq, const int rel_prec,

--- a/solver/rg_mixed_cg_her.h
+++ b/solver/rg_mixed_cg_her.h
@@ -23,6 +23,22 @@
 #include"solver/matrix_mult_typedef.h"
 #include"su3.h"
 
+typedef enum PolakRibiere_s {
+  MCG_NO_PR=0,
+  MCG_PR=1
+} MCG_PR_TYPE;
+
+typedef enum Pipelined_s {
+  MCG_NO_PIPELINED=0,
+  MCG_PIPELINED
+} MCG_PIPELINED_TYPE;
+
+// currently not used
+typedef enum ResGuide_s {
+  MCG_NO_RESGUIDE=0,
+  MCG_RESGUIDE
+} MCG_RESGUIDE_TYPE;
+
 int rg_mixed_cg_her(spinor * const P, spinor * const Q, const int max_iter, 
 		 double eps_sq, const int rel_prec, const int N, matrix_mult f, matrix_mult32 f32);
 

--- a/solver/rg_mixed_cg_her_nd.c
+++ b/solver/rg_mixed_cg_her_nd.c
@@ -1,0 +1,359 @@
+/***********************************************************************
+ * Copyright (C) 2016 Bartosz Kostrzewa, Florian Burger
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************
+ * rg_mixed_cg_her_nd *
+ **********************
+ *
+ * Mixed precision solver which uses true reliable updates and has a double
+ * precision fail-safe mechanism. The Polak-Ribiere computation of beta is
+ * implemented but currently not used because the extra scalar product is
+ * more expensive than the gain from the self-stabilisation as far as has 
+ * been tested.
+ *
+ * in:
+ *   Q: source
+ * inout:
+ *   P: result (initial guess currently not supported)
+ *
+ * POSSIBLE IMPROVEMENTS
+ * There are still quite a few things that can be tried to make it better,
+ * the most significant of which would be to guide the search direction
+ * using the previous one upon restart. However, it seems that for the number
+ * non-zero entries in the Dirac operator and usual lattice sizes, the
+ * requisite projection 
+ *
+ *   p' = r - <r,Ap>/<p,Ap> p
+ *
+ * cannot be computed with sufficient precision in 64 bit arithmetic. It should
+ * be noted that for L < 24 in general, this does work and produces
+ * a mixed solver which converges at the same rate as a double solver, but it's
+ * not generally useable... For point sources, it also works for larger lattice 
+ * volumes. Might be introduced as an optional mode in the future with some
+ * fail-safe mechanism which detects if the search direction begins to diverge.
+ *
+ **************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+# include<config.h>
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include "global.h"
+#include "su3.h"
+#include "linalg_eo.h"
+#include "start.h"
+#include "operator/tm_operators_32.h"
+#include "operator/clovertm_operators_32.h"
+#include "solver/matrix_mult_typedef_nd.h"
+#include "solver/solver_params.h"
+#include "read_input.h"
+
+#include "solver_field.h"
+#include "solver/rg_mixed_cg_her.h"
+#include "gettime.h"
+
+static void output_flops(const double seconds, const unsigned int N, const unsigned int iter_out, 
+                  const unsigned int iter_in_sp, const unsigned int iter_in_dp, const double eps_sq);
+
+static inline unsigned int inner_loop_high(spinor * const x_up, spinor * const x_dn, 
+                                           spinor * const p_up, spinor * const p_dn,
+                                           spinor * const q_up, spinor * const q_dn,
+                                           spinor * const r_up, spinor * const r_dn, 
+                                           double * const rho1, const double delta,
+                                           matrix_mult_nd f, const double eps_sq, const unsigned int N, const unsigned int iter ){
+
+  static double alpha, beta, rho, rhomax;
+  unsigned int j = 0;
+
+  rho = *rho1;
+  rhomax = *rho1;
+
+  /* break out of inner loop if iterated residual goes below some fraction of the maximum observed
+  * iterated residual since the last update or if the target precision has been reached 
+  * enforce convergence more strictly by a factor of 1.3 to avoid unnecessary restarts 
+  * if the real residual is still a bit too large */
+  while( rho > delta*rhomax ){
+    ++j;
+    f(q_up,q_dn,p_up,p_dn);
+    alpha = rho/( scalar_prod_r(p_up,q_up,N,1) + scalar_prod_r(p_dn,q_dn,N,1) );
+    assign_add_mul_r(x_up, p_up, alpha, N); assign_add_mul_r(x_dn, p_dn, alpha, N);
+    assign_add_mul_r(r_up, q_up, -alpha, N); assign_add_mul_r(r_dn, q_dn, -alpha, N);
+    rho = ( square_norm(r_up,N,1) + square_norm(r_dn,N,1) );
+    beta = rho / *rho1;
+    *rho1 = rho;
+    assign_mul_add_r(p_up, beta, r_up, N); assign_mul_add_r(p_dn, beta, r_dn, N);
+    
+    if( 1.3*rho < eps_sq ) break;
+    if( rho > rhomax ) rhomax = rho;
+    
+    if(g_debug_level > 2 && g_proc_id == 0) {
+      printf("DP_inner CG: %d res^2 %g\t\n", j+iter, rho);
+    }
+  }
+
+  return j;
+}
+
+static inline unsigned int inner_loop(spinor32 * const x_up, spinor32 * const x_dn, 
+                                      spinor32 * const p_up, spinor32 * const p_dn, 
+                                      spinor32 * const q_up, spinor32 * const q_dn,
+                                      spinor32 * const r_up, spinor32 * const r_dn,
+                                      float * const rho1, const float delta,
+                                      matrix_mult_nd32 f32, const float eps_sq, const unsigned int N, const unsigned int iter,
+                                      float alpha, float beta, MCG_PIPELINED_TYPE pipelined, MCG_PR_TYPE pr ){
+
+  static float rho, rhomax, pro;
+  unsigned int j = 0;
+
+  rho = *rho1;
+  rhomax = *rho1;
+
+  if(pipelined==MCG_NO_PIPELINED){
+    /* break out of inner loop if iterated residual goes below some fraction of the maximum observed
+    * iterated residual since the last update */ 
+    while( rho > delta*rhomax ){
+      ++j;
+      f32(q_up,q_dn,p_up,p_dn);
+      pro = ( scalar_prod_r_32(p_up,q_up,N,1) + scalar_prod_r_32(p_dn,q_dn,N,1) );
+      alpha = rho/pro;
+      assign_add_mul_r_32(x_up, p_up, alpha, N); assign_add_mul_r_32(x_dn, p_dn, alpha, N);
+      assign_add_mul_r_32(r_up, q_up, -alpha, N); assign_add_mul_r_32(r_dn, q_dn, -alpha, N);
+      rho = ( square_norm_32(r_up,N,1) + square_norm_32(r_dn,N,1) );
+      // Polak-Ribiere computation of beta, claimed to be self-stabilising, positive effect so far not observed or required
+      if(pr==MCG_PR){
+        beta = alpha*(alpha*(square_norm_32(q_up,N,1)+square_norm_32(q_dn,N,1)) - pro) / *rho1;
+      }else{
+        beta = rho / *rho1;
+      }
+      *rho1 = rho;
+      assign_mul_add_r_32(p_up, beta, r_up, N); assign_mul_add_r_32(p_dn, beta, r_dn, N);
+      if(g_debug_level > 2 && g_proc_id == 0) {
+        printf("SP_inner CG: %d res^2 %g\t\n", j+iter, rho);
+      }
+       /* enforce convergence more strictly by a factor of 1.3 to avoid unnecessary restarts 
+       * if the real residual is still a bit too large */
+      if( 1.3*rho < eps_sq ) break;
+      if( rho > rhomax ) rhomax = rho;
+    }
+  }else{
+    // pipelined cg requires one more scalar product but may allow optimisations to be made
+    // e.g.: one could do the collective communication for sqrnrm(r) while other stuff is being computed
+    // it is also self-initialising (alpha=0, beta=0 will work)
+    while( rho > delta*rhomax ){
+      ++j;
+      assign_add_mul_r_32(x_up, p_up, alpha, N); assign_add_mul_r_32(x_dn, p_dn, alpha, N);
+      assign_add_mul_r_32(r_up, q_up, -alpha, N); assign_add_mul_r_32(r_dn, q_dn, -alpha, N);
+      assign_mul_add_r_32(p_up, beta, r_up, N); assign_mul_add_r_32(p_dn, beta, r_dn, N);
+      f32(q_up,q_dn,p_up,p_dn);
+  
+      rho = ( square_norm_32(r_up,N,1) + square_norm_32(r_dn,N,1) );
+      pro = ( scalar_prod_r_32(p_up,q_up,N,1) + scalar_prod_r_32(p_dn,q_dn,N,1) );
+      alpha = rho/pro;
+      if(pr==MCG_PR){
+        beta = alpha*(alpha*(square_norm_32(q_up,N,1)+square_norm_32(q_dn,N,1))-pro)/rho;
+      }else{
+        beta = rho/ *rho1;
+      }
+      *rho1=rho;
+
+      if(g_debug_level > 2 && g_proc_id == 0) {
+        printf("SP_inner CG: %d res^2 %g\t\n", j+iter, rho);
+      }
+      if( 1.3*rho < eps_sq ) break;
+      if( rho > rhomax ) rhomax = rho;
+    }
+  }
+
+  return j;
+}
+
+
+/* P output = solution , Q input = source */
+int rg_mixed_cg_her_nd(spinor * const P_up, spinor * const P_dn, spinor * const Q_up, spinor * const Q_dn, 
+                       solver_params_t solver_params, const int max_iter, const double eps_sq, const int rel_prec,
+                       const int N, matrix_mult_nd f, matrix_mult_nd32 f32) {
+
+  int iter_in_sp = 0, iter_in_dp = 0, iter_out = 0;
+  float rho_sp, delta = solver_params.mcg_delta;
+  double beta_dp, rho_dp;
+  double sourcesquarenorm, target_eps_sq;
+
+  spinor *xhigh_up, *xhigh_dn, *rhigh_up, *rhigh_dn, *qhigh_up, *qhigh_dn, *phigh_up, *phigh_dn;
+  spinor32 *x_up, *x_dn, *p_up, *p_dn, *q_up, *q_dn, *r_up, *r_dn;
+
+  spinor ** solver_field = NULL;
+  spinor32 ** solver_field32 = NULL;  
+  const int nr_sf = 8;
+  const int nr_sf32 = 8;
+  
+  int high_control = 0;
+
+  double atime, etime, flops;
+  
+  if(N == VOLUME) {
+    init_solver_field(&solver_field, VOLUMEPLUSRAND, nr_sf);    
+    init_solver_field_32(&solver_field32, VOLUMEPLUSRAND, nr_sf32);
+  }
+  else {
+    init_solver_field(&solver_field, VOLUMEPLUSRAND/2, nr_sf);
+    init_solver_field_32(&solver_field32, VOLUMEPLUSRAND/2, nr_sf32);    
+  }
+
+  atime = gettime();
+
+  // we could get away with using fewer fields, of course
+  phigh_up = solver_field[7]; phigh_dn = solver_field[6];
+  xhigh_up = solver_field[5]; xhigh_dn = solver_field[4];
+  rhigh_up = solver_field[3]; rhigh_dn = solver_field[2];
+  qhigh_up = solver_field[1]; qhigh_dn = solver_field[0];
+
+  x_up = solver_field32[7]; x_dn = solver_field32[6];
+  r_up = solver_field32[5]; r_dn = solver_field32[4];
+  p_up = solver_field32[3]; p_dn = solver_field32[2];
+  q_up = solver_field32[1]; q_dn = solver_field32[0];
+
+  // we always want to apply the full precision operator in double
+  int save_sloppy = g_sloppy_precision_flag;
+  g_sloppy_precision_flag = 0;
+
+  sourcesquarenorm = ( square_norm(Q_up,N,1) + square_norm(Q_dn,N,1) );
+  if( rel_prec == 1 ) {
+    target_eps_sq = eps_sq*sourcesquarenorm;
+    if(g_debug_level > 0 && g_proc_id==0) 
+      printf("#RG_Mixed CG_ND: Using relative precision! eps_sq: %.6g target_eps_sq: %.6g \n",eps_sq,target_eps_sq);
+  }else{
+    target_eps_sq = eps_sq;
+  }
+  
+  // compute the maximum number of outer iterations based on the expected reduction
+  // of the residual at each run of the inner solver
+  int N_outer = (int)ceil(log10( delta/eps_sq ))+4; // +4 is an arbitrary choice which seems to avoid switching to DP
+  if(g_debug_level > 0 && g_proc_id==0) 
+    printf("#RG_Mixed CG_ND: N_outer: %d \n", N_outer);
+  
+  // should compute real residual here, for now we always use a zero guess
+  zero_spinor_field_32(x_up,N); zero_spinor_field_32(x_dn,N);
+  zero_spinor_field(P_up,N); zero_spinor_field(P_dn,N);
+  assign(phigh_up,Q_up,N); assign(phigh_dn,Q_dn,N);
+  assign(rhigh_up,Q_up,N); assign(rhigh_dn,Q_dn,N);
+  
+  rho_dp = ( square_norm(rhigh_up,N,1) + square_norm(rhigh_dn,N,1) );
+  assign_to_32(r_up,rhigh_up,N); assign_to_32(r_dn,rhigh_dn,N);
+  rho_sp = rho_dp;
+  assign_32(p_up,r_up,N); assign_32(p_dn,r_dn,N);
+  
+  iter_in_sp += inner_loop(x_up, x_dn, p_up, p_dn, q_up, q_dn, r_up, r_dn, &rho_sp, delta, 
+                           f32, (float)target_eps_sq, 
+                           N, iter_out+iter_in_sp+iter_in_dp, 0.0, 0.0, MCG_NO_PIPELINED, MCG_NO_PR);
+
+  for(iter_out = 1; iter_out < N_outer; iter_out++) {
+
+    // prepare for defect correction
+    // update high precision solution 
+    if(high_control==0) {
+      // accumulate solution (sp -> dp) 
+      addto_32(P_up,x_up,N); addto_32(P_dn,x_dn,N);
+      // compute real residual
+      f(qhigh_up,qhigh_dn,P_up,P_dn);
+      diff(rhigh_up,Q_up,qhigh_up,N); diff(rhigh_dn,Q_dn,qhigh_dn,N);
+      beta_dp = 1/rho_dp;
+      rho_dp = ( square_norm(rhigh_up,N,1) + square_norm(rhigh_dn,N,1) );
+      beta_dp *= rho_dp;
+    }
+   
+    // the iteration limit was reached in the previous iteration, let's try to save the day using double precision
+    if( high_control==1 ) {
+      assign(phigh_up,rhigh_up,N); assign(phigh_dn,rhigh_dn,N);
+      zero_spinor_field(xhigh_up,N); zero_spinor_field(xhigh_dn,N);
+      beta_dp = 1/rho_dp;
+      iter_in_dp += inner_loop_high(xhigh_up, xhigh_dn, phigh_up, phigh_dn,
+                                    qhigh_up, qhigh_dn, rhigh_up, rhigh_dn, &rho_dp, delta, f, 
+                                    target_eps_sq, N, iter_out+iter_in_sp+iter_in_dp);
+      rho_sp = rho_dp;
+      // accumulate solution
+      add(P_up,P_up,xhigh_up,N); add(P_dn, P_dn, xhigh_dn, N);
+      // compute real residual
+      f(qhigh_up, qhigh_dn, P_up, P_dn);
+      diff(rhigh_up,Q_up,qhigh_up,N); diff(rhigh_dn,Q_dn,qhigh_dn,N);
+      rho_dp = ( square_norm(rhigh_up,N,1) + square_norm(rhigh_dn,N,1) );
+      beta_dp *= rho_dp;
+    }
+
+    if(g_debug_level > 2 && g_proc_id == 0) {
+      printf("RG_mixed CG_ND last inner residue:       %17g\n", rho_sp);
+      printf("RG_mixed CG_ND true residue:             %6d %10g\n", iter_in_sp+iter_in_dp+iter_out, rho_dp);
+      printf("RG_mixed CG_ND residue reduction factor: %6d %10g\n", iter_in_sp+iter_in_dp+iter_out, beta_dp); fflush(stdout);
+    }
+
+    if( rho_dp <= target_eps_sq ) {
+      etime = gettime();
+      output_flops(etime-atime, N, iter_out, iter_in_sp, iter_in_dp, eps_sq);
+      
+      g_sloppy_precision_flag = save_sloppy;
+      finalize_solver(solver_field, nr_sf);
+      finalize_solver_32(solver_field32, nr_sf32); 
+      return(iter_in_sp+iter_in_dp+iter_out);
+    }
+
+    // if it seems like we're stuck and reaching the iteration limit, we skip this correction and proceed in full precision above
+    if( iter_out >= (N_outer-3) ){
+      if(g_proc_id==0) printf("RG_mixed CG_ND: Reaching iteration limit, switching to DP!\n");
+      high_control = 1;
+      continue;
+    }else{
+      // correct defect
+      assign_to_32(r_up,rhigh_up,N); assign_to_32(r_dn,rhigh_dn,N);
+      rho_sp = rho_dp; // not sure if it's fine to truncate this or whether one should calculate it in SP directly, it seems to work fine though
+      assign_32(p_up,r_up,N); assign_32(p_dn,r_dn,N);
+    }
+
+    zero_spinor_field_32(x_up,N); zero_spinor_field_32(x_dn,N);
+    iter_in_sp += inner_loop(x_up, x_dn, p_up, p_dn, q_up, q_dn, r_up, r_dn, &rho_sp, delta, f32, (float)target_eps_sq, 
+                             N, iter_out+iter_in_sp+iter_in_dp, 0.0, 0.0, MCG_NO_PIPELINED, MCG_NO_PR);
+  }
+  
+  // convergence failure...
+  g_sloppy_precision_flag = save_sloppy;
+  finalize_solver(solver_field, nr_sf);
+  finalize_solver_32(solver_field32, nr_sf32);
+  return -1; 
+}
+
+void output_flops(const double seconds, const unsigned int N, const unsigned int iter_out, const unsigned int iter_in_sp, const unsigned int iter_in_dp, const double eps_sq){
+  double flops;
+  // TODO: compute real number of flops...
+  int total_it = iter_in_sp+iter_in_dp+iter_out;
+  if(g_debug_level > 0 && g_proc_id == 0) {
+    printf("# RG_mixed CG_ND: iter_out: %d iter_in_sp: %d iter_in_dp: %d\n",iter_out,iter_in_sp,iter_in_dp);
+  	if(N != VOLUME){
+  	  /* 2 A + 2 Nc Ns + N_Count ( 2 A + 10 Nc Ns ) */
+  	  /* 2*1608.0 because the linalg is over VOLUME/2 */
+  	  flops = 2*(2*(2*1608.0+2*3*4) + 2*3*4 + total_it*(2.*(2*1608.0+2*3*4) + 10*3*4))*N/1.0e6f;
+  	}
+  	else{
+  	  /* 2 A + 2 Nc Ns + N_Count ( 2 A + 10 Nc Ns ) */
+  	  flops = 2*(2*(1608.0+2*3*4) + 2*3*4 + total_it*(2.*(1608.0+2*3*4) + 10*3*4))*N/1.0e6f;      
+  	}
+  	printf("#RG_mixed CG_ND: iter: %d eps_sq: %1.4e t/s: %1.4e\n", total_it, eps_sq, seconds); 
+    printf("# FIXME: note the following flop counts are wrong! Consider only the time to solution!\n");
+  	printf("#RG_mixed CG_ND: flopcount (for e/o tmWilson only): t/s: %1.4e mflops_local: %.1f mflops: %.1f\n", 
+  	       seconds, flops/(seconds), g_nproc*flops/(seconds));
+  }      
+}

--- a/solver/rg_mixed_cg_her_nd.h
+++ b/solver/rg_mixed_cg_her_nd.h
@@ -1,6 +1,5 @@
 /***********************************************************************
- *
- * Copyright (C) 2007 Andreas Nube
+ * Copyright (C) 2016 Bartosz Kostrzewa
  *
  * This file is part of tmLQCD.
  *
@@ -16,19 +15,18 @@
  * 
  * You should have received a copy of the GNU General Public License
  * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Typedefinition of the pointer to the function
- * which contains the matrix multiplication.
- *
- * Author: Andreas Nube
- *         annube@ifh.de
- *
- ************************************************************************/
+ ***********************************************************************/
+#ifndef _RG_MIXED_CG_HER_ND_H
+#define _RG_MIXED_CG_HER_ND_H
 
-#ifndef _MATRIX_MULT_TYPEDEF_ND_H
-#define _MATRIX_MULT_TYPEDEF_ND_H
+#include "operator/tm_operators_32.h"
+#include "solver/matrix_mult_typedef_nd.h"
+#include "solver/solver_params.h"
+#include "solver/rg_mixed_cg_typedef.h"
+#include "su3.h"
 
-typedef void (*matrix_mult_nd)(spinor * const, spinor * const,spinor * const, spinor * const);
-typedef void (*matrix_mult_nd32)(spinor32 * const, spinor32 * const, spinor32 * const, spinor32 * const);
+int rg_mixed_cg_her_nd(spinor * const Pup, spinor * const Pdn, spinor * const Qup, spinor * const Qdn,
+                    solver_params_t solver_params, const int max_iter, const double eps_sq, const int rel_prec,
+                    const int N, matrix_mult_nd f, matrix_mult_nd32 f32);
 
 #endif

--- a/solver/rg_mixed_cg_typedef.h
+++ b/solver/rg_mixed_cg_typedef.h
@@ -1,0 +1,21 @@
+#ifndef _RG_MIXED_CG_HER_TYPEDEF_H
+#define _RG_MIXED_CG_HER_TYPEDEF_H
+
+typedef enum MCG_PR_TYPE {
+  MCG_NO_PR=0,
+  MCG_PR
+} MCG_PR_TYPE;
+
+typedef enum MCG_PIPELINED_TYPE {
+  MCG_NO_PIPELINED=0,
+  MCG_PIPELINED
+} MCG_PIPELINED_TYPE;
+
+// currently not used
+typedef enum MCG_RESGUIDE_TYPE {
+  MCG_NO_RESGUIDE=0,
+  MCG_RESGUIDE
+} MCG_RESGUIDE_TYPE;
+     
+
+#endif

--- a/solver/solver.h
+++ b/solver/solver.h
@@ -77,6 +77,7 @@ typedef struct {
 #include "solver/cg_her_bi.h"
 
 #include "solver/cg_her_nd.h"
+#include "solver/rg_mixed_cg_her_nd.h"
 #include"solver/cg_mms_tm_nd.h"
 #include"solver/mixed_cg_mms_tm_nd.h"
 

--- a/solver/solver.h
+++ b/solver/solver.h
@@ -67,6 +67,7 @@ typedef struct {
 #include"solver/eigenvalues.h"
 #include"solver/cg_mms_tm.h"
 #include"solver/mixed_cg_her.h"
+#include "solver/rg_mixed_cg_her.h"
 
 #include"solver/sub_low_ev.h"
 #include"solver/gmres_precon.h"

--- a/solver/solver_params.h
+++ b/solver/solver_params.h
@@ -49,11 +49,14 @@ typedef struct {
                              Example, to solve the linear systems to squared residual 1e-16, one chooses eigcg_restolsq=1e-8 or smaller 
                              This will specify how many times deflated CG restaretd in the second phase (after eigenvectors has been computed)*/
   int eigcg_rand_guess_opt; /*set to 0 to use 0 initial guesses or non-zero values if you want to use random initial guess as a volume source */
+
+  /* factor below which iterated resdiual has to drop to trigger a 
+     reliable update in the mixed solver
+       if(<r,r>) < delta * max( <r,r> )
+     where the maximum is over the iterated residuals since the last update */  
+  float mcg_delta; 
+
 } solver_params_t;
 
-
-
 #endif
-
-
  

--- a/solver/solver_types.h
+++ b/solver/solver_types.h
@@ -1,23 +1,26 @@
 #ifndef _SOLVER_TYPES_H
 #define _SOLVER_TYPES_H
 
-#define BICGSTAB 0
-#define CG 1
-#define GMRES 2
-#define CGS 3
-#define MR 4
-#define BICGSTABELL 5
-#define FGMRES 6
-#define GCR 7
-#define GMRESDR 8
-#define PCG 9
-#define DFLGCR 10
-#define DFLFGMRES 11
-#define CGMMS 12
-#define MIXEDCG 13
-#define CGMMSND 14
-#define INCREIGCG 15
-#define MIXEDCGMMSND 16
-#define SUMR 17
+typedef enum SOLVER_TYPE_s {
+ BICGSTAB = 0,
+ CG,
+ GMRES,
+ CGS,
+ MR,
+ BICGSTABELL,
+ FGMRES,
+ GCR,
+ GMRESDR,
+ PCG,
+ DFLGCR,
+ DFLFGMRES,
+ CGMMS,
+ MIXEDCG,
+ RGMIXEDCG,
+ CGMMSND,
+ INCREIGCG,
+ MIXEDCGMMSND,
+ SUMR
+} SOLVER_TYPE;
 
 #endif

--- a/solver/solver_types.h
+++ b/solver/solver_types.h
@@ -1,7 +1,7 @@
 #ifndef _SOLVER_TYPES_H
 #define _SOLVER_TYPES_H
 
-typedef enum SOLVER_TYPE_s {
+typedef enum SOLVER_TYPE {
  BICGSTAB = 0,
  CG,
  GMRES,

--- a/temporalgauge.h
+++ b/temporalgauge.h
@@ -20,6 +20,10 @@
 #ifndef _TEMPORALGAUGE_H
 #define _TEMPORALGAUGE_H
 
+typedef enum GTRAFO_TYPE {
+  GTRAFO_APPLY = 0,
+  GTRAFO_REVERT } GTRAFO_TYPE;
+
 int init_temporalgauge_trafo(const int V, su3** gfield);
 void apply_gtrafo(su3 ** gfield, su3 * trafofield);
 void apply_gtrafo_spinor(spinor * spin, su3 * trafofield);
@@ -31,6 +35,12 @@ void apply_gtrafo_spinor_odd(spinor * spin, su3 * trafofield);
 void apply_inv_gtrafo_spinor_odd(spinor * spin, su3 * trafofield);
 void apply_gtrafo_spinor_even(spinor * spin, su3 * trafofield);
 void apply_inv_gtrafo_spinor_even(spinor * spin, su3 * trafofield);
+
+void gtrafo_eo_nd(spinor * const Even_s, spinor * const Odd_s, spinor * const Even_c, spinor * const Odd_c, 
+                  spinor * const Even_new_s, spinor * const Odd_new_s, spinor * const Even_new_c, spinor * const Odd_new_c,
+                  GTRAFO_TYPE type);
+
+void gtrafo_eo(spinor * const Even, spinor * const Odd, GTRAFO_TYPE type);
 
 void copy_gauge_field(su3** to, su3** from);
 

--- a/update_gauge.c
+++ b/update_gauge.c
@@ -38,6 +38,7 @@
 #include "xchange/xchange.h"
 #include "hamiltonian_field.h"
 #include "update_gauge.h"
+#include "init/init_gauge_field.h"
 
 
 /*******************************************************
@@ -92,12 +93,18 @@ void update_gauge(const double step, hamiltonian_field_t * const hf) {
   /* for parallelization */
   xchange_gauge(hf->gaugefield);
 #endif
+  
+  /*Convert to a 32 bit gauge field, after xchange*/
+  convert_32_gauge_field(g_gauge_field_32, hf->gaugefield, VOLUMEPLUSRAND + g_dbw2rand);
+  
   /*
    * The backward copy of the gauge field
    * is not updated here!
    */
   hf->update_gauge_copy = 1;
   g_update_gauge_copy = 1;
+  g_update_gauge_copy_32 = 1;
+
   etime = gettime();
   if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time gauge update: %e s\n", etime-atime); 

--- a/update_tm.c
+++ b/update_tm.c
@@ -329,9 +329,14 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
   }
   hf.update_gauge_copy = 1;
   g_update_gauge_copy = 1;
+  g_update_gauge_copy_32 = 1;  
 #ifdef MPI
   xchange_gauge(hf.gaugefield);
 #endif
+  
+  /*Convert to a 32 bit gauge field, after xchange*/
+  convert_32_gauge_field(g_gauge_field_32, hf.gaugefield, VOLUMEPLUSRAND + g_dbw2rand); 
+  
   etime=gettime();
 
   /* printing data in the .data file */


### PR DESCRIPTION
Components to use mixed solvers for all determinant and non-degenerate rational approximation type monomials. Note that in its current form it significantly increases memory usage because the single precision fields are always allocated.