### PR TITLE
consistent iteration counts for determinant monomial when reversibility check is done

### DIFF
--- a/monomial/cloverdet_monomial.c
+++ b/monomial/cloverdet_monomial.c
@@ -197,7 +197,7 @@ double cloverdet_acc(const int id, hamiltonian_field_t * const hf) {
   chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 	       mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
   g_sloppy_precision_flag = 0;
-  mnl->iter0 = cg_her(mnl->w_fields[0], mnl->pf, mnl->maxiter, mnl->accprec,  
+  mnl->iter0 += cg_her(mnl->w_fields[0], mnl->pf, mnl->maxiter, mnl->accprec,  
 		      g_relative_precision_flag, VOLUME/2, mnl->Qsq); 
   mnl->Qm(mnl->w_fields[0], mnl->w_fields[0]);
   

--- a/monomial/det_monomial.c
+++ b/monomial/det_monomial.c
@@ -212,7 +212,7 @@ double det_acc(const int id, hamiltonian_field_t * const hf) {
     chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
     	 mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
     g_sloppy_precision_flag = 0;
-    mnl->iter0 = cg_her(mnl->w_fields[0], mnl->pf, mnl->maxiter, mnl->accprec, g_relative_precision_flag,
+    mnl->iter0 += cg_her(mnl->w_fields[0], mnl->pf, mnl->maxiter, mnl->accprec, g_relative_precision_flag,
     			VOLUME/2, mnl->Qsq);
     mnl->Qm(mnl->w_fields[1], mnl->w_fields[0]);
     g_sloppy_precision_flag = save_sloppy;
@@ -223,7 +223,7 @@ double det_acc(const int id, hamiltonian_field_t * const hf) {
     if(mnl->solver == CG) {
       chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
-      mnl->iter0 = cg_her(mnl->w_fields[1], mnl->pf, 
+      mnl->iter0 += cg_her(mnl->w_fields[1], mnl->pf, 
 			  mnl->maxiter, mnl->accprec, g_relative_precision_flag, 
 			  VOLUME, &Q_pm_psi);
       Q_minus_psi(mnl->w_fields[0], mnl->w_fields[1]);


### PR DESCRIPTION
*det_acc: increment rather than assign iteration count for acceptance step to get consistent counts across all monomials when reversitibility check is run