### PR TITLE
correct trajectory metadata when reversibility check is performed

### DIFF
--- a/update_tm.c
+++ b/update_tm.c
@@ -181,7 +181,7 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
     }
     if(accept) {
       /* save gauge file to disk before performing reversibility check */
-      xlfInfo = construct_paramsXlfInfo((*plaquette_energy)/(6.*VOLUME*g_nproc), -1);
+      xlfInfo = construct_paramsXlfInfo((*plaquette_energy)/(6.*VOLUME*g_nproc), traj_counter);
       // Should write this to temporary file first, and then check
       if(g_proc_id == 0 && g_debug_level > 0) {
         fprintf(stdout, "# Writing gauge field to file %s.\n", tmp_filename);


### PR DESCRIPTION
When a reversibility check is performed, write the correct trajectory metadata into the configuration. Up to now this was set to -1 for some reason.