### PR TITLE
Source Seed

### DIFF
--- a/gen_sources.c
+++ b/gen_sources.c
@@ -267,7 +267,7 @@ int main(int argc,char *argv[]) {
       printf("Generating ext. pion source %s!\n", spinorfilename);
       extended_pion_source(g_spinor_field[2], g_spinor_field[3],
 			   g_spinor_field[0], g_spinor_field[1],
-			   t0, 0., 0., 0.);
+			   t0, (g_nproc_t*T)/2, 0., 0., 0.);
       if(!filenameflag) {
 	if(T_global > 99) sprintf(spinorfilename, "g%s.%.4d.%.4d.%.3d", filename, nstore, sample, t0); 
         else sprintf(spinorfilename, "g%s.%.4d.%.4d.%.2d", filename, nstore, sample, t0); 

--- a/gen_sources.c
+++ b/gen_sources.c
@@ -248,7 +248,7 @@ int main(int argc,char *argv[]) {
       printf("Generating source %s!\n", spinorfilename);
       fflush(stdout);
       source_generation_pion_only(g_spinor_field[0], g_spinor_field[1], 
-				  t0, sample, nstore);
+				  t0, sample, nstore, random_seed);
       
       co = scalar_prod(g_spinor_field[1], g_spinor_field[1], VOLUME/2, 1);
       write_source_type(0, spinorfilename);

--- a/invert.c
+++ b/invert.c
@@ -420,7 +420,7 @@ int main(int argc, char *argv[])
           /* we use g_spinor_field[0-7] for sources and props for the moment */
           /* 0-3 in case of 1 flavour  */
           /* 0-7 in case of 2 flavours */
-          prepare_source(nstore, isample, ix, op_id, read_source_flag, source_location);
+          prepare_source(nstore, isample, ix, op_id, read_source_flag, source_location, random_seed);
           //randmize initial guess for eigcg if needed-----experimental
           if( (operator_list[op_id].solver == INCREIGCG) && (operator_list[op_id].solver_params.eigcg_rand_guess_opt) ){ //randomize the initial guess
               gaussian_volume_source( operator_list[op_id].prop0, operator_list[op_id].prop1,isample,ix,0); //need to check this

--- a/meas/correlators.c
+++ b/meas/correlators.c
@@ -123,7 +123,7 @@ void correlators_measurement(const int traj, const int id, const int ieo) {
   Cp4 = (double*) calloc(T, sizeof(double));
 #endif
   source_generation_pion_only(g_spinor_field[0], g_spinor_field[1], 
-			      t0, 0, traj);
+			      t0, 0, traj, measurement_list[id].seed);
   optr->sr0 = g_spinor_field[0];
   optr->sr1 = g_spinor_field[1];
   optr->prop0 = g_spinor_field[2];

--- a/meas/measurements.c
+++ b/meas/measurements.c
@@ -57,6 +57,7 @@ int init_measurements(){
  int i;
   for(i = 0; i < no_measurements; i++) {
  
+    measurement_list[i].seed = random_seed;
     if(measurement_list[i].type == ONLINE) {
       measurement_list[i].measurefunc = &correlators_measurement;
       measurement_list[i].max_source_slice = g_nproc_t*T;

--- a/meas/measurements.h
+++ b/meas/measurements.h
@@ -44,7 +44,10 @@ typedef struct {
   int max_iter;
   /* for polyakov loop */
   int direction;
-  
+
+  // random seed
+  unsigned int seed;
+
   /* how it's usually called */
   char name[100];
 

--- a/prepare_source.c
+++ b/prepare_source.c
@@ -207,7 +207,7 @@ void prepare_source(const int nstore, const int isample, const int ix, const int
         exit(-1);
       }
       extended_pion_source(g_spinor_field[0], g_spinor_field[1], g_spinor_field[2], g_spinor_field[3], 
-                           SourceInfo.t, 0., 0., 0.);
+                           SourceInfo.t, (g_nproc_t*T)/2, 0., 0., 0.);
       sprintf(source_filename, "%s.%.4d.%.5d.%.2d.inverted", PropInfo.basename, nstore, isample, SourceInfo.t);
       // if the generalised pion propagator is to be written to the same file as the source, splitting must be disabled
       if( strcmp(PropInfo.basename,SourceInfo.basename) == 0 ) PropInfo.splitted = 0;

--- a/prepare_source.c
+++ b/prepare_source.c
@@ -47,7 +47,7 @@
 
 void prepare_source(const int nstore, const int isample, const int ix, const int op_id, 
                     const int read_source_flag,
-                    const int source_location) {
+                    const int source_location, const unsigned int seed) {
 
   FILE * ifs = NULL;
   int is = ix / 3, ic = ix %3, err = 0, rstat=0, t = 0;
@@ -174,7 +174,7 @@ void prepare_source(const int nstore, const int isample, const int ix, const int
       if(g_proc_id == 0 && g_debug_level > 0) {
         printf("# Preparing 1 flavour Pion TimeSlice at t = %d source\n", SourceInfo.t);
       }
-      source_generation_pion_only(g_spinor_field[0], g_spinor_field[1], SourceInfo.t, isample, nstore);
+      source_generation_pion_only(g_spinor_field[0], g_spinor_field[1], SourceInfo.t, isample, nstore, seed);
       sprintf(source_filename, "%s.%.4d.%.5d.%.2d.inverted", PropInfo.basename, nstore, isample, SourceInfo.t);
     }
     else if(source_type == SRC_TYPE_GEN_PION_TS) {

--- a/prepare_source.h
+++ b/prepare_source.h
@@ -22,7 +22,7 @@
 #define _PREPARE_SOURCE_H
 
 void prepare_source(const int nstore, const int isample, const int ix, const int op_id, 
-		    const int read_source_flag,
-		    const int source_location);
+		    const int read_source_flag, const int source_location,
+                    const unsigned int seed);
 
 #endif

--- a/source_generation.c
+++ b/source_generation.c
@@ -172,8 +172,8 @@ void extended_pion_source(spinor * const P, spinor * const Q,
 }
 
 void source_generation_pion_only(spinor * const P, spinor * const Q,
-				 const int t,
-				 const int sample, const int nstore) {
+				 const int t, const int sample, 
+                                 const int nstore, const unsigned int _seed) {
 
   int reset = 0, i, x, y, z, is, ic, lt, lx, ly, lz, id=0;
   int coords[4], seed, r;
@@ -192,7 +192,7 @@ void source_generation_pion_only(spinor * const P, spinor * const Q,
   }
 
   /* Compute the seed */
-  seed =(int) abs(1 + sample + t*10*97 + nstore*100*53);
+  seed =(int) abs(_seed + sample + t*10*97 + nstore*100*53);
 
   rlxd_init(2, seed);
 

--- a/source_generation.c
+++ b/source_generation.c
@@ -124,7 +124,7 @@ void gaussian_volume_source(spinor * const P, spinor * const Q,
 
 void extended_pion_source(spinor * const P, spinor * const Q,
 			  spinor * const R, spinor * const S,
-			  const int t0,
+			  const int t0, const int ts,
 			  const double px, const double py, const double pz) {
   int lt, lx, ly, lz, i, x, y, z, id=0, t;
   int coords[4];
@@ -134,7 +134,7 @@ void extended_pion_source(spinor * const P, spinor * const Q,
   zero_spinor_field(P,VOLUME/2);
   zero_spinor_field(Q,VOLUME/2);
   
-  t=((g_nproc_t*T)/2+t0)%(g_nproc_t*T);
+  t=(ts + t0)%(g_nproc_t*T);
   lt = t - g_proc_coords[0]*T;
   coords[0] = t / T;
   for(x = 0; x < LX*g_nproc_x; x++) {

--- a/source_generation.h
+++ b/source_generation.h
@@ -23,8 +23,8 @@ void gaussian_volume_source(spinor * const P, spinor * const Q,
 			    const int sample, const int nstore, const int f);
 
 void source_generation_pion_only(spinor * const P, spinor * const Q,
-				 const int t,
-				 const int sample, const int nstore);
+				 const int t, const int sample, 
+                                 const int nstore, const unsigned int _seed);
 
 void source_generation_nucleon(spinor * const P, spinor * const Q, 
 			       const int is, const int ic,

--- a/source_generation.h
+++ b/source_generation.h
@@ -34,7 +34,7 @@ void source_generation_nucleon(spinor * const P, spinor * const Q,
 
 void extended_pion_source(spinor * const P, spinor * const Q,
 			  spinor * const R, spinor * const S,
-			  const int t0,
+			  const int t0, const int ts,
 			  const double px, const double py, const double pz);
 
 void source_generation_pion_zdir(spinor * const P, spinor * const Q,


### PR DESCRIPTION
this is making the random numbers used in the function `source_generation_pion_only` depending on `random_seed`. Note that once this is merged, we loose reproducability to previous computations using pion times slice sources.