### PR TITLE
read_spinor: add new flag 'DisableSourceIOChecks' 

### DIFF
--- a/global.h
+++ b/global.h
@@ -75,6 +75,7 @@ EXTERN int g_update_gauge_copy_32;
 EXTERN int g_relative_precision_flag;
 EXTERN int g_debug_level;
 EXTERN int g_disable_IO_checks;
+EXTERN int g_disable_src_IO_checks;
 
 EXTERN int T_global;
 #ifndef FIXEDVOLUME

--- a/io/spinor_read.c
+++ b/io/spinor_read.c
@@ -19,6 +19,7 @@
 
 #include "spinor.ih"
 #include "default_input_values.h"
+#include "global.h"
 
 paramsPropInfo PropInfo = {_default_propagator_splitted, _default_source_format_flag, _default_prop_precision_flag, NULL};
 paramsSourceInfo SourceInfo = {0, _default_propagator_splitted, _default_source_format_flag, _default_prop_precision_flag, 0, 0, 0, 0, 0, 0, 0, 1, NULL};
@@ -110,37 +111,37 @@ int read_spinor(spinor * const s, spinor * const r, char * filename, const int p
     }
   }
 
-  // we search for a scidac-checksum directly after the binary data
-  // but only until more binary data is found
-  while ((status = ReaderNextRecord(reader)) != LIME_EOF) {
-    if (status != LIME_SUCCESS) {
-      fprintf(stderr, "ReaderNextRecord returned status %d.\n", status);
-      break;
+  if( g_disable_src_IO_checks != 1 ){
+    // we search for a scidac-checksum directly after the binary data
+    // but only until more binary data is found
+    while ((status = ReaderNextRecord(reader)) != LIME_EOF) {
+      if (status != LIME_SUCCESS) {
+        fprintf(stderr, "ReaderNextRecord returned status %d.\n", status);
+        break;
+      }
+      header_type = ReaderType(reader);
+      if (strcmp("scidac-checksum", header_type) == 0) {
+        read_message(reader, &checksum_string);
+        DML_read_flag = parse_checksum_xml(checksum_string, &checksum_read);
+        free(checksum_string);
+        break;
+      }
+      if (strcmp("scidac-binary-data", header_type) == 0 || strcmp("ildg-binary-data", header_type) == 0) {
+        break;
+      }
     }
-    header_type = ReaderType(reader);
-    if (strcmp("scidac-checksum", header_type) == 0) {
-      read_message(reader, &checksum_string);
-      DML_read_flag = parse_checksum_xml(checksum_string, &checksum_read);
-      free(checksum_string);
-      break;
-    }
-    if (strcmp("scidac-binary-data", header_type) == 0 || strcmp("ildg-binary-data", header_type) == 0) {
-      break;
-    }
-  }
-
-  if (!g_disable_IO_checks){
+  
     if (!DML_read_flag) {
       fprintf(stderr, "LIME record with name: \"scidac-checksum\", in gauge file %s either missing or malformed.\n", filename);
-      fprintf(stderr, "Unable to verify integrity of spinor field data.\n");
+      fprintf(stderr, "Unable to verify integrity of gauge field data.\n");
       return(-1);
     }
-  }
-
-  if (g_cart_id == 0 && g_debug_level >= 0) {
-    printf("# Scidac checksums for DiracFermion field %s position %d:\n", filename, position);
-    printf("#   Calculated            : A = %#010x B = %#010x.\n", checksum.suma, checksum.sumb);
-    printf("#   Read from LIME headers: A = %#010x B = %#010x.\n", checksum_read.suma, checksum_read.sumb);
+  
+    if (g_cart_id == 0 && g_debug_level >= 0) {
+      printf("# Scidac checksums for DiracFermion field %s position %d:\n", filename, position);
+      printf("#   Calculated            : A = %#010x B = %#010x.\n", checksum.suma, checksum.sumb);
+      printf("#   Read from LIME headers: A = %#010x B = %#010x.\n", checksum_read.suma, checksum_read.sumb);
+    }
   }
 
   destruct_reader(reader);

--- a/read_input.l
+++ b/read_input.l
@@ -124,8 +124,6 @@ static inline void rmQuotes(char *str){
   int return_check_flag, return_check_interval;
   int gauge_precision_read_flag;
   int gauge_precision_write_flag;
-  int g_disable_IO_checks;
-  int g_disable_src_IO_checks;
   int gmres_m_parameter, gmresdr_nr_ev;
   int reproduce_randomnumber_flag;
   double stout_rho;

--- a/read_input.l
+++ b/read_input.l
@@ -125,6 +125,7 @@ static inline void rmQuotes(char *str){
   int gauge_precision_read_flag;
   int gauge_precision_write_flag;
   int g_disable_IO_checks;
+  int g_disable_src_IO_checks;
   int gmres_m_parameter, gmresdr_nr_ev;
   int reproduce_randomnumber_flag;
   double stout_rho;
@@ -213,6 +214,7 @@ static inline void rmQuotes(char *str){
 %x GAUGERPREC
 %x GAUGEWPREC
 %x DSBLIOCHECK
+%x DSBLSRCIOCHECK
 %x PRECON
 %x WRITECP
 %x CPINT
@@ -395,6 +397,8 @@ static inline void rmQuotes(char *str){
 ^GaugeConfigReadPrecision{EQL}     BEGIN(GAUGERPREC);
 ^GaugeConfigWritePrecision{EQL}    BEGIN(GAUGEWPREC);
 ^DisableIOChecks{EQL}              BEGIN(DSBLIOCHECK);
+^DisableGaugeIOChecks{EQL}         BEGIN(DSBLIOCHECK);
+^DisableSourceIOChecks{EQL}        BEGIN(DSBLSRCIOCHECK);
 ^ReproduceRandomNumbers{EQL}       BEGIN(REPRORND);
 ^UseSloppyPrecision{EQL}           BEGIN(SLOPPYPREC);
 ^UseStoutSmearing{EQL}             BEGIN(USESTOUT);
@@ -2142,6 +2146,14 @@ static inline void rmQuotes(char *str){
   g_disable_IO_checks = 0;
   if(myverbose!=0) printf("Enable IO checks (and readback in case of Lemon IO)\n");
 }
+<DSBLSRCIOCHECK>yes {
+  g_disable_src_IO_checks = 1;
+  if(myverbose!=0) printf("Disable IO checks for sources\n");
+}
+<DSBLSRCIOCHECK>no {
+  g_disable_src_IO_checks = 0;
+  if(myverbose!=0) printf("Enable IO checks for sources\n");
+}
 <CPINT>{DIGIT}+   {
   cp_interval=atoi(yytext);
   if(myverbose!=0) printf("Write Checkpoint all %s measurements\n",yytext);
@@ -2606,6 +2618,7 @@ int read_input(char * conf_file){
   gauge_precision_read_flag = _default_gauge_precision_read_flag;
   gauge_precision_write_flag = _default_gauge_precision_write_flag;
   g_disable_IO_checks = _default_g_disable_IO_checks;
+  g_disable_src_IO_checks = _default_g_disable_IO_checks;
   reproduce_randomnumber_flag = _default_reproduce_randomnumber_flag;
   g_sloppy_precision_flag = _default_g_sloppy_precision_flag;
   use_stout_flag = _default_use_stout_flag;


### PR DESCRIPTION
Allow the user to disable the IO check for the reading of sources, 
independently from the gauge IO checks. 

'DisableGaugeIOChecks' parameter added for consistency and
'DisableIOChecks' retained for backwards compatibility. The latter
disables only gauge IO checks, as it used to be.
