### PR TITLE
Bug fix

### DIFF
--- a/hmc_tm.c
+++ b/hmc_tm.c
@@ -518,12 +518,22 @@ int main(int argc,char *argv[]) {
     }
 
     /* online measurements */
+#ifdef DDalphaAMG
+    // When the configuration is rejected, we have to update it in the MG and redo the setup.
+    int mg_update = accepted ? 0:1;
+#endif
     for(imeas = 0; imeas < no_measurements; imeas++){
       meas = &measurement_list[imeas];
       if(trajectory_counter%meas->freq == 0){
         if (g_proc_id == 0) {
           fprintf(stdout, "#\n# Beginning online measurement.\n");
         }
+#ifdef DDalphaAMG
+        if( mg_update ) {
+          mg_update = 0;
+          MG_reset();
+        }
+#endif
         meas->measurefunc(trajectory_counter, imeas, even_odd_flag);
       }
     }

--- a/read_input.l
+++ b/read_input.l
@@ -674,7 +674,7 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  MGBlockT set to %d line %d operator %d\n", mg_blk[0], line_of_file, current_operator);
   }
   {SPC}*MGSetup2KappaMu{EQL}{FLT}+ {
-    sscanf(yytext, " %[a-zA-Z] = %lf", name, &c);
+    sscanf(yytext, " %[2a-zA-Z] = %lf", name, &c);
     mg_setup_mu=c;
     mg_setup_mu_set=1;
     if(myverbose) printf("  MGSetup2KappaMu set to %f line %d operator %d\n", mg_setup_mu, line_of_file, current_operator);
@@ -685,12 +685,12 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  MGCoarseMuFactor set to %f line %d operator %d\n", mg_cmu_factor, line_of_file, current_operator);
   }
   {SPC}*MGMixedPrecision{EQL}yes {
-    sscanf(yytext, " %[2a-zA-Z] = %lf", name, &c);
+    sscanf(yytext, " %[a-zA-Z] = %lf", name, &c);
     mg_mixed_prec = 1;
     if(myverbose) printf("  MGMixedPrecision set to YES line %d operator %d\n",  line_of_file, current_operator);
   }
   {SPC}*MGMixedPrecision{EQL}no {
-    sscanf(yytext, " %[2a-zA-Z] = %lf", name, &c);
+    sscanf(yytext, " %[a-zA-Z] = %lf", name, &c);
     mg_mixed_prec = 0;
     if(myverbose) printf("  MGMixedPrecision set to NO line %d operator %d\n",  line_of_file, current_operator);
   }


### PR DESCRIPTION
- Fixed input reading of MGSetup2KappaMu ( issue #344 ) 
- Fixed MG inversion in inlinemeasurment when the configuration is rejected (the new conf wasn't updated in the interface and MGTEST was failing there).