### PR TITLE
Improvements to correction monomial

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,7 +50,7 @@ MODULES = read_input gamma measure_gauge_action start \
 	geometry_eo invert_overlap aligned_malloc \
 	prepare_source chebyshev_polynomial_nd Ptilde_nd  \
 	reweighting_factor_nd rnd_gauge_trafo \
-        update_momenta integrator  phmc \
+        update_momenta update_momenta_fg integrator  phmc \
 	little_D block operator \
 	temporalgauge spinor_fft X_psi P_M_eta \
 	jacobi fatal_error invert_clover_eo gettime @SPI_FILES@ \

--- a/doc/rational.tex
+++ b/doc/rational.tex
@@ -117,13 +117,13 @@ force.
 The rational approximation has a finite precision. In the HMC one can
 account for this effect by estimating
 \[
-1 - |\hat Q_h| R\,,
+1 - |\hat Q_h| \mathcal{R}\,,
 \]
 which can be done in different ways:
 \begin{itemize}
 \item we include an additional monomial for
   \[
-  \det (|\hat Q_h| R)
+  \det (|\hat Q_h| \mathcal{R})
   \]
   in the Hamiltonian. If the rational apprximation is precise enough,
   it is sufficient to only include this in the heatbath and acceptance
@@ -159,6 +159,49 @@ which can be done in different ways:
   \frac{3}{8}Z^2 - \frac{5}{16}Z^3 + ...) \phi\, .
   \]
   Also here the series can be truncated after the first few terms.
+  Since the correction monomial is not used in the force computation of MD,
+  its final purpose for the HMC is to compute the energy difference
+  \[
+  dH_{corr} = R^\dagger \left(1-(1+Z_{old})^{1/4}(1+Z_{new})^{-1/2}(1+Z_{old})^{1/4}\right)R\,.
+  \]
+  Considering $\mathcal{O}(Z_{old}) = \mathcal{O}(Z_{new}) = \mathcal{O}(Z)$ and
+  using the previous series expansions, we obtain
+  \begin{align*}
+  dH_{corr} & =  R^\dagger \left( \frac{1}{2} Z_{old} - \frac{1}{2} Z_{new} \right)R\\
+  & + R^\dagger \left( - \frac{1}{8} Z_{old}^2 - \frac{1}{8} \left\{Z_{old} , Z_{new} \right\}  + \frac{3}{8} Z_{new}^2 \right)R\\
+  & + R^\dagger \left( \frac{1}{16} Z_{old}^3 + \frac{3}{64} \left\{ Z_{old}^2 , Z_{new} \right\} - \frac{1}{32} Z_{old} Z_{new} Z_{old} + \frac{3}{32} \left\{ Z_{old} , Z_{new}^2 \right\} - \frac{5}{16} Z_{new}^3 \right)R\\
+  & + \mathcal{O}(Z^4).
+  \end{align*}
+  The coefficients in front of the terms $R^\dagger Z_{old}^n R$ are given by the series of
+  \[
+  (1+Z_{old})^{1/2} -1 =  \frac{1}{2} Z_{old} - \frac{1}{8} Z_{old}^2 + \frac{1}{16} Z_{old}^3 + ...
+  \]
+  For this reason, computing $\phi = B(Z_{old})\cdot R$, we use as a stopping criterium
+  \[
+  c_n R^\dagger Z_{old}^n R < \text{tolerance}
+  \]
+  where $c_n$ are the coefficients from the series of $(1+Z_{old})^{1/2}$.
+  Since $Z$ is hermitian, we can compute in advance the next order correction of the series evaluating
+  \[
+  c_n (R Z_{old})^\dagger\cdot (Z_{old}^{n-1} R) < \text{tolerance}\,;
+  \]
+  in this way we save an application of Z in the evaluation of $\phi = B(Z_{old})\cdot R$.
+  
+  Exploting the hermiticity of $Z$, we can also save applications of it in the computation of
+  \[
+  dH_{corr} = R^\dagger R - \phi^\dagger\left((1+Z_{new})^{-1/2}\right)\phi\,,
+  \]
+  which is done in the acceptance step. Indeed defining $\chi_i = Z_{new}^i\phi$, $dH_{corr}$ reads as
+  \[
+  dH_{corr} = R^\dagger R - \phi^\dagger\phi + \frac{1}{2}\phi^\dagger\chi_1\phi - \frac{3}{8}\chi_1^\dagger\chi_1 + \frac{5}{16} \chi_1^\dagger\chi_2 - ...\,,
+  \]
+  that requires $n$ applications of $Z_{new}$ for computing $dH_{corr}$ up to $\mathcal{O}(Z_{new}^{2n})$.
+  Here we use as stopping criterium,
+  \[
+  c_n \phi^\dagger Z_{new}^{n} \phi < \text{tolerance}\,;
+  \]
+  where $c_n$ are the coefficients from the series of $(1+Z_{new})^{-1/2}$.
+
 \item the second possibility is to include this correction as a
   reweighting factor.
 \item the third is to use a more precise rational approximation for

--- a/hmc_tm.c
+++ b/hmc_tm.c
@@ -203,6 +203,8 @@ int main(int argc,char *argv[]) {
   /* need temporary gauge field for gauge reread checks and in update_tm */
   status += init_gauge_tmp(VOLUME);
 
+  status += init_gauge_fg(VOLUME);
+
   if (status != 0) {
     fprintf(stderr, "Not enough memory for gauge_fields! Aborting...\n");
     exit(0);
@@ -522,11 +524,11 @@ int main(int argc,char *argv[]) {
     // When the configuration is rejected, we have to update it in the MG and redo the setup.
     int mg_update = accept ? 0:1;
 #endif
-    for(imeas = 0; imeas < no_measurements; imeas++){
-      meas = &measurement_list[imeas];
-      if(trajectory_counter%meas->freq == 0){
-        if (g_proc_id == 0) {
-          fprintf(stdout, "#\n# Beginning online measurement.\n");
+     for(imeas = 0; imeas < no_measurements; imeas++){
+       meas = &measurement_list[imeas];
+       if(trajectory_counter%meas->freq == 0){
+         if (g_proc_id == 0) {
+           fprintf(stdout, "#\n# Beginning online measurement.\n");
         }
 #ifdef DDalphaAMG
         if( mg_update ) {
@@ -534,9 +536,9 @@ int main(int argc,char *argv[]) {
           MG_reset();
         }
 #endif
-        meas->measurefunc(trajectory_counter, imeas, even_odd_flag);
-      }
-    }
+         meas->measurefunc(trajectory_counter, imeas, even_odd_flag);
+       }
+     }
 
     if(g_proc_id == 0) {
       verbose = 1;

--- a/init/Makefile.in
+++ b/init/Makefile.in
@@ -30,7 +30,7 @@ LDADD =
 COMPILE = ${CC} $(DEFS) ${INCLUDES} ${CFLAGS}
 
 LIBRARIES = libinit
-libinit_TARGETS = init_moment_field init_gauge_tmp init_gauge_field \
+libinit_TARGETS = init_moment_field init_gauge_tmp init_gauge_fg init_gauge_field \
 	init_geometry_indices init_spinor_field init_dirac_halfspinor \
 	init_chi_spinor_field init_bispinor_field init_jacobi_field \
 	init_omp_accumulators init_openmp

--- a/init/init_gauge_fg.c
+++ b/init/init_gauge_fg.c
@@ -17,26 +17,45 @@
  * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
  ***********************************************************************/
 
-#ifndef _INIT_H
-#define _INIT_H
+#ifdef HAVE_CONFIG_H
+# include<config.h>
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include "global.h"
+#include "su3.h"
+#include "sse.h"
+#include "init_gauge_fg.h"
 
-#include "init/init_bispinor_field.h"
-#include "init/init_chi_spinor_field.h"
-#include "init/init_dirac_halfspinor.h"
-#include "init/init_gauge_field.h"
-#include "init/init_gauge_tmp.h"
-#include "init/init_gauge_fg.h"
-#include "init/init_geometry_indices.h"
-#ifdef WITHLAP
-#  include "init/init_jacobi_field.h"
-#endif
-#include "init/init_moment_field.h"
-#include "init/init_spinor_field.h"
-#include "init/init_stout_smear_vars.h"
-#ifdef TM_USE_OMP
-# include <omp.h>
-# include "init/init_omp_accumulators.h"
-# include "init/init_openmp.h"
-#endif
+su3 * gauge_fg_ = NULL;
+su3 ** gauge_fg = NULL;
 
+int init_gauge_fg(const int V) {
+  int i=0;
+
+  if((void*)(gauge_fg = (su3**)calloc(V, sizeof(su3*))) == NULL) {
+    fprintf(stderr, "malloc errno : %d\n", errno);
+    errno = 0;
+    return(1);
+  }
+  if((void*)(gauge_fg_ = (su3*)calloc(4*V+1, sizeof(su3))) == NULL) {
+    fprintf(stderr, "malloc errno : %d\n", errno);
+    errno = 0;
+    return(1);
+  }
+#if (defined SSE || defined SSE2 || defined SSE3)
+  gauge_fg[0] = (su3*)(((unsigned long int)(gauge_fg_)+ALIGN_BASE)&~ALIGN_BASE);
+#else
+  gauge_fg[0] = gauge_fg_;
 #endif
+  for(i = 1; i < V; i++){
+    gauge_fg[i] = gauge_fg[i-1]+4;
+  }
+  return(0);
+}
+
+void free_gauge_fg() {
+  free(gauge_fg_);
+  free(gauge_fg);
+}

--- a/init/init_gauge_fg.h
+++ b/init/init_gauge_fg.h
@@ -16,27 +16,12 @@
  * You should have received a copy of the GNU General Public License
  * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
  ***********************************************************************/
+#ifndef _INIT_GAUGE_FG_H
+#define _INIT_GAUGE_FG_H
 
-#ifndef _INIT_H
-#define _INIT_H
+extern su3 ** gauge_fg;
 
-#include "init/init_bispinor_field.h"
-#include "init/init_chi_spinor_field.h"
-#include "init/init_dirac_halfspinor.h"
-#include "init/init_gauge_field.h"
-#include "init/init_gauge_tmp.h"
-#include "init/init_gauge_fg.h"
-#include "init/init_geometry_indices.h"
-#ifdef WITHLAP
-#  include "init/init_jacobi_field.h"
-#endif
-#include "init/init_moment_field.h"
-#include "init/init_spinor_field.h"
-#include "init/init_stout_smear_vars.h"
-#ifdef TM_USE_OMP
-# include <omp.h>
-# include "init/init_omp_accumulators.h"
-# include "init/init_openmp.h"
-#endif
+int init_gauge_fg(const int V);
+void free_gauge_fg();
 
 #endif

--- a/integrator.c
+++ b/integrator.c
@@ -40,13 +40,13 @@ static const double omf4_vartheta = 0.08398315262876693;
 static const double omf4_lamb = 0.6822365335719091;
 
 /* second order minimal norm integration scheme */
-void integrate_2mn(const double tau, const int S, const int halfstep);
+void integrate_2mn(const double tau, const int S, const int halfstep, const double tau2);
 /* second order minimal norm integration scheme in velocity version */
-void integrate_2mnp(const double tau, const int S, const int halfstep);
+void integrate_2mnp(const double tau, const int S, const int halfstep, const double tau2);
 /* Leap Frog integration scheme */
-void integrate_leap_frog(const double tau, const int S, const int halfstep);
+void integrate_leap_frog(const double tau, const int S, const int halfstep, const double tau2);
 /* fourth order OMF scheme */
-void integrate_omf4(const double tau, const int S, const int halfstep);
+void integrate_omf4(const double tau, const int S, const int halfstep,const double tau2 );
 /* half step function */
 void dohalfstep(const double tau, const int S);
 
@@ -120,16 +120,17 @@ void integrator_unset_fields() {
   return;
 }
 
-void integrate_omf4(const double tau, const int S, const int halfstep) {
+void integrate_omf4(const double tau, const int S, const int halfstep, const double tau2) {
   int i,j=0;
   integrator * itgr = &Integrator;
-  double eps;
+  double eps,eps2;
 
   if(S == itgr->no_timescales-1) {
     dohalfstep(tau, S);
   }
-  eps = tau/((double)itgr->n_int[S]);
-
+  eps  = tau/((double)itgr->n_int[S]);
+  eps2 = tau2/((double)itgr->n_int[S]);
+  
   if(S == 0) {
 
     for(j = 1; j < itgr->n_int[0]; j++) {
@@ -154,36 +155,36 @@ void integrate_omf4(const double tau, const int S, const int halfstep) {
     update_momenta(itgr->mnls_per_ts[0], omf4_lamb*eps, itgr->no_mnls_per_ts[0], &itgr->hf);
     update_gauge(omf4_rho*eps, &itgr->hf);
     if(halfstep != 1) {
-      update_momenta(itgr->mnls_per_ts[0], 2*omf4_vartheta*eps, itgr->no_mnls_per_ts[0], &itgr->hf);
+      update_momenta(itgr->mnls_per_ts[0], omf4_vartheta*(eps+eps2), itgr->no_mnls_per_ts[0], &itgr->hf);
     }
   }
   else {
     for(i = 1; i < itgr->n_int[S]; i++){
-      itgr->integrate[S-1](omf4_rho*eps, S-1, 0);
+      itgr->integrate[S-1](omf4_rho*eps, S-1, 0, omf4_theta*eps);
       update_momenta(itgr->mnls_per_ts[S], omf4_lamb*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
-      itgr->integrate[S-1](omf4_theta*eps, S-1, 0);
+      itgr->integrate[S-1](omf4_theta*eps, S-1, 0, (1-2.*(omf4_theta+omf4_rho))*eps);
       update_momenta(itgr->mnls_per_ts[S], 0.5*(1-2.*(omf4_lamb+omf4_vartheta))*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
-      itgr->integrate[S-1]((1-2.*(omf4_theta+omf4_rho))*eps, S-1, 0);
+      itgr->integrate[S-1]((1-2.*(omf4_theta+omf4_rho))*eps, S-1, 0, omf4_theta*eps);
       update_momenta(itgr->mnls_per_ts[S], 0.5*(1-2.*(omf4_lamb+omf4_vartheta))*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
-      itgr->integrate[S-1](omf4_theta*eps, S-1, 0);
+      itgr->integrate[S-1](omf4_theta*eps, S-1, 0, omf4_rho*eps);
       update_momenta(itgr->mnls_per_ts[S], omf4_lamb*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
-      itgr->integrate[S-1](omf4_rho*eps, S-1, 0);
+      itgr->integrate[S-1](omf4_rho*eps, S-1, 0, omf4_rho*eps);
       update_momenta(itgr->mnls_per_ts[S], 2*omf4_vartheta*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
     }
-    itgr->integrate[S-1](omf4_rho*eps, S-1, 0);
+    itgr->integrate[S-1](omf4_rho*eps, S-1, 0, omf4_theta*eps);
     update_momenta(itgr->mnls_per_ts[S], omf4_lamb*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
-    itgr->integrate[S-1](omf4_theta*eps, S-1, 0);
+    itgr->integrate[S-1](omf4_theta*eps, S-1, 0, (1-2.*(omf4_theta+omf4_rho))*eps);
     update_momenta(itgr->mnls_per_ts[S], 0.5*(1-2.*(omf4_lamb+omf4_vartheta))*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
-    itgr->integrate[S-1]((1-2.*(omf4_theta+omf4_rho))*eps, S-1, 0);
+    itgr->integrate[S-1]((1-2.*(omf4_theta+omf4_rho))*eps, S-1, 0, omf4_theta*eps);
     update_momenta(itgr->mnls_per_ts[S], 0.5*(1-2.*(omf4_lamb+omf4_vartheta))*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
-    itgr->integrate[S-1](omf4_theta*eps, S-1, 0);
+    itgr->integrate[S-1](omf4_theta*eps, S-1, 0, omf4_rho*eps);
     update_momenta(itgr->mnls_per_ts[S], omf4_lamb*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
     if(S == itgr->no_timescales-1) {
-      itgr->integrate[S-1](omf4_rho*eps, S-1, 1);
+      itgr->integrate[S-1](omf4_rho*eps, S-1, 1, omf4_rho*eps);
     }
-    else itgr->integrate[S-1](omf4_rho*eps, S-1, halfstep);
+    else itgr->integrate[S-1](omf4_rho*eps, S-1, halfstep, omf4_rho*eps2);
     if(halfstep != 1 && S != itgr->no_timescales-1) {
-      update_momenta(itgr->mnls_per_ts[S], 2*omf4_vartheta*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
+      update_momenta(itgr->mnls_per_ts[S], omf4_vartheta*(eps+eps2), itgr->no_mnls_per_ts[S], &itgr->hf);
     }
   }
 
@@ -195,17 +196,17 @@ void integrate_omf4(const double tau, const int S, const int halfstep) {
 
 /* the following are only needed locally */
 
-void integrate_2mn(const double tau, const int S, const int halfstep) {
+void integrate_2mn(const double tau, const int S, const int halfstep, const double tau2) {
   int i,j=0;
   integrator * itgr = &Integrator;
-  double eps,
-    oneminus2lambda = (1.-2.*itgr->lambda[S]);
+  double eps,eps2, oneminus2lambda = (1.-2.*itgr->lambda[S]);
 
   if(S == itgr->no_timescales-1) {
     dohalfstep(tau, S);
   }
   
-  eps = tau/((double)itgr->n_int[S]);
+  eps  = tau/((double)itgr->n_int[S]);
+  eps2 = tau2/((double)itgr->n_int[S]);
   if(S == 0) {
 
     for(j = 1; j < itgr->n_int[0]; j++) {
@@ -218,24 +219,24 @@ void integrate_2mn(const double tau, const int S, const int halfstep) {
     update_momenta(itgr->mnls_per_ts[0], oneminus2lambda*eps, itgr->no_mnls_per_ts[0], &itgr->hf);
     update_gauge(0.5*eps, &itgr->hf);
     if(halfstep != 1) {
-      update_momenta(itgr->mnls_per_ts[0], 2*itgr->lambda[0]*eps, itgr->no_mnls_per_ts[0], &itgr->hf);
+      update_momenta(itgr->mnls_per_ts[0], itgr->lambda[0]*(eps+eps2), itgr->no_mnls_per_ts[0], &itgr->hf);
     }
   }
   else {
     for(i = 1; i < itgr->n_int[S]; i++){
-      itgr->integrate[S-1](eps/2., S-1, 0);
+      itgr->integrate[S-1](eps/2., S-1, 0, eps/2.);
       update_momenta(itgr->mnls_per_ts[S], oneminus2lambda*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
-      itgr->integrate[S-1](eps/2., S-1, 0);
+      itgr->integrate[S-1](eps/2., S-1, 0, eps/2.);
       update_momenta(itgr->mnls_per_ts[S], 2*itgr->lambda[S]*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
     }
-    itgr->integrate[S-1](eps/2., S-1, 0);
+    itgr->integrate[S-1](eps/2., S-1, 0, eps/2.);
     update_momenta(itgr->mnls_per_ts[S], oneminus2lambda*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
     if(S == itgr->no_timescales-1) {
-      itgr->integrate[S-1](eps/2., S-1, 1);
+      itgr->integrate[S-1](eps/2., S-1, 1, eps/2.);
     }
-    else itgr->integrate[S-1](eps/2., S-1, halfstep);
+    else itgr->integrate[S-1](eps/2., S-1, halfstep, eps2/2.);
     if(halfstep != 1 && S != itgr->no_timescales-1) {
-      update_momenta(itgr->mnls_per_ts[S], 2*itgr->lambda[S]*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
+      update_momenta(itgr->mnls_per_ts[S], itgr->lambda[S]*(eps+eps2), itgr->no_mnls_per_ts[S], &itgr->hf);
     }
   }
 
@@ -244,10 +245,11 @@ void integrate_2mn(const double tau, const int S, const int halfstep) {
   }
 }
 
-void integrate_2mnp(const double tau, const int S, const int halfstep) {
+void integrate_2mnp(const double tau, const int S, const int halfstep, const double tau2) {
   int i;
   integrator * itgr = &Integrator;
-  double eps = tau/((double)itgr->n_int[S]);
+  double eps  = tau/((double)itgr->n_int[S]);
+  double eps2 = tau2/((double)itgr->n_int[S]); // dummy stepsize
   double oneminus2lambda = (1.-2.*itgr->lambda[S]);
   
   if(S == 0) {
@@ -265,50 +267,51 @@ void integrate_2mnp(const double tau, const int S, const int halfstep) {
   }
   else {
     for(i = 0; i < itgr->n_int[S]; i++) {
-      integrate_2mnp(itgr->lambda[S]*eps, S-1, halfstep);
+      integrate_2mnp(itgr->lambda[S]*eps, S-1, halfstep,oneminus2lambda*eps);
       update_momenta(itgr->mnls_per_ts[S], 0.5*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
 
-      integrate_2mnp(oneminus2lambda*eps, S-1, halfstep);
+      integrate_2mnp(oneminus2lambda*eps, S-1, halfstep,itgr->lambda[S]*eps);
       update_momenta(itgr->mnls_per_ts[S], 0.5*eps, itgr->no_mnls_per_ts[S], &itgr->hf);
 
-      integrate_2mnp(itgr->lambda[S]*eps, S-1, halfstep);
+      integrate_2mnp(itgr->lambda[S]*eps, S-1, halfstep,itgr->lambda[S]*eps);
     }
   }
 }
 
 
-void integrate_leap_frog(const double tau, const int S, const int halfstep) {
+void integrate_leap_frog(const double tau, const int S, const int halfstep,const double tau2) {
   int i;
   integrator * itgr = &Integrator;
-  double eps, eps0;
+  double eps, eps0, eps2;
 
   if(S == itgr->no_timescales-1) {
     dohalfstep(tau, S);
   }
 
   eps = tau/((double)itgr->n_int[S]);
+  eps2 = tau2/((double)itgr->n_int[S]);
   if(S == 0) {
-    eps0 = tau/((double)itgr->n_int[0]);
+    eps0 = tau/((double)itgr->n_int[0]); //what is the meaning of this variable ??
     for(i = 1; i < itgr->n_int[0]; i++) {
       update_gauge(eps0, &itgr->hf);
       update_momenta(itgr->mnls_per_ts[0], eps0, itgr->no_mnls_per_ts[0], &itgr->hf);
     }
     update_gauge(eps0, &itgr->hf);
     if(halfstep != 1) {
-      update_momenta(itgr->mnls_per_ts[0], eps0, itgr->no_mnls_per_ts[0], &itgr->hf);
+      update_momenta(itgr->mnls_per_ts[0], 0.5*(eps0+eps2), itgr->no_mnls_per_ts[0], &itgr->hf);
     }
   }
   else {
     for(i = 1; i < itgr->n_int[S]; i++){
-      itgr->integrate[S-1](eps, S-1, 0);
+      itgr->integrate[S-1](eps, S-1, 0, eps);
       update_momenta(itgr->mnls_per_ts[S], eps, itgr->no_mnls_per_ts[S], &itgr->hf);
     }
     if(S == itgr->no_timescales-1) {
-      itgr->integrate[S-1](eps, S-1, 1);
+      itgr->integrate[S-1](eps, S-1, 1, eps);
     }
-    else itgr->integrate[S-1](eps, S-1, halfstep);
+    else itgr->integrate[S-1](eps, S-1, halfstep, eps2);
     if(halfstep != 1 && S != itgr->no_timescales-1) {
-      update_momenta(itgr->mnls_per_ts[S], eps, itgr->no_mnls_per_ts[S], &itgr->hf);
+      update_momenta(itgr->mnls_per_ts[S], 0.5*(eps+eps2), itgr->no_mnls_per_ts[S], &itgr->hf);
     }
   }
 

--- a/integrator.h
+++ b/integrator.h
@@ -32,7 +32,7 @@
 #define MN2p 7
 #define OMF4 8
 
-typedef void (*integratefk)(const double, const int, const int);
+typedef void (*integratefk)(const double, const int, const int, const double);
 
 typedef struct {
   /* gauge, momenta and derivative fields to be used during integration */

--- a/integrator.h
+++ b/integrator.h
@@ -31,6 +31,7 @@
 #define MN2 6
 #define MN2p 7
 #define OMF4 8
+#define MN2FG 9
 
 typedef void (*integratefk)(const double, const int, const int, const double);
 

--- a/monomial/ndratcor_monomial.c
+++ b/monomial/ndratcor_monomial.c
@@ -56,10 +56,10 @@ void check_C_ndpsi(spinor * const k_up, spinor * const k_dn,
 		   solver_pm_t * solver_pm);
 
 // applies (Q^2 R^2 -1) phi
-double apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
-		     spinor * const l_up, spinor * const l_dn,
-		     const int id, hamiltonian_field_t * const hf,
-		     solver_pm_t * solver_pm);
+void apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
+                   spinor * const l_up, spinor * const l_dn,
+                   const int id, hamiltonian_field_t * const hf,
+                   solver_pm_t * solver_pm);
 
 
 
@@ -67,8 +67,9 @@ void ndratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
   solver_pm_t solver_pm;
   double atime, etime, delta;
-  spinor * up0, * dn0, * up1, * dn1, * tup, * tdn;
-  double coefs[6] = {1./4., -3./32., 7./128., -77./2048., 231./8192., -1463./65536.};
+  spinor * up0, * dn0, * up1, * dn1, * tup, * tdn, * Zup, * Zdn;
+  double coefs[6] = {1./4., -3./32., 7./128., -77./2048., 231./8192., -1463./65536.}; // series of (1+x)^(1/4)
+  double coefs_check[6] = {1./2., -1./8., 1./16., -5./128., 7./256., -21./1024.}; // series of (1+x)^(1/2)
   atime = gettime();
   nd_set_global_parameter(mnl);
   g_mu3 = 0.;
@@ -108,19 +109,57 @@ void ndratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   solver_pm.rel_prec = g_relative_precision_flag;
 
   // apply B to the random field to generate pseudo-fermion fields
-  assign(mnl->w_fields[0], mnl->pf, VOLUME/2);
-  assign(mnl->w_fields[1], mnl->pf2, VOLUME/2);
   up0 = mnl->w_fields[0]; dn0 = mnl->w_fields[1];
   up1 = mnl->w_fields[2]; dn1 = mnl->w_fields[3];
-	 
-  for(int i = 1; i < 8; i++) {
-    delta = apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &solver_pm);
-    assign_add_mul_r(mnl->pf, up1, coefs[i-1], VOLUME/2);
-    assign_add_mul_r(mnl->pf2, dn1, coefs[i-1], VOLUME/2);
-    if(delta < mnl->accprec) break;
-    tup = up0; tdn = dn0;
-    up0 = up1; dn0 = dn1;
-    up1 = tup; dn1 = tdn;
+  Zup = mnl->w_fields[4]; Zdn = mnl->w_fields[5];
+
+  apply_Z_ndpsi(up0, dn0, mnl->pf, mnl->pf2, id, hf, &solver_pm);
+  // computing correction to energy1
+  delta = coefs_check[0]*(scalar_prod_r(mnl->pf, up0, VOLUME/2, 1) + scalar_prod_r(mnl->pf2, dn0, VOLUME/2, 1));
+  if(g_debug_level > 2 && g_proc_id == 0)
+    printf("# NDRATCOR heatbath: c_%d*(R * Z^%d * R) = %e\n", 1, 1, delta);
+  // debug for showing that the old check was giving a smaller delta
+  if(g_debug_level > 3) {
+    double delta_old = square_norm(up0, VOLUME/2, 1) + square_norm(dn0, VOLUME/2, 1);
+    if(g_proc_id == 0) {
+      printf("# NDRATCOR old check: || Z^%d * R ||^2 = %e\n", 1, delta_old);
+      printf("# NDRATCOR new check: (c_%d*(R * Z^%d * R))^2 = %e\n", 1, 1, delta*delta);
+    }
+  }
+
+  if(delta*delta > mnl->accprec) {
+    assign_add_mul_r(mnl->pf, up0, coefs[0], VOLUME/2);
+    assign_add_mul_r(mnl->pf2, dn0, coefs[0], VOLUME/2);
+    
+    // saving first application
+    assign(Zup, up0, VOLUME/2);
+    assign(Zdn, dn0, VOLUME/2);
+    
+    
+    for(int i = 2; i < 8; i++) {
+      // computing next order correction to energy1
+      delta = coefs_check[i-1]*(scalar_prod_r(Zup, up0, VOLUME/2, 1) + scalar_prod_r(Zup, dn0, VOLUME/2, 1)); 
+      if(g_debug_level > 2 && g_proc_id == 0)
+        printf("# NDRATCOR heatbath: c_%d*(R * Z^%d * R) = %e\n", i, i, delta);
+      // debug for showing that the old check was giving a smaller delta
+      if(g_debug_level > 3) {
+        double delta_old = square_norm(up0, VOLUME/2, 1) + square_norm(dn0, VOLUME/2, 1);
+        if(g_proc_id == 0) {
+          printf("# NDRATCOR old check: || Z^%d * R ||^2 = %e\n", 1, delta_old);
+          printf("# NDRATCOR new check: (c_%d*(R * Z^%d * R))^2 = %e\n", 1, 1, delta*delta);
+        }
+      }
+      if(delta*delta < mnl->accprec) break;
+
+      apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &solver_pm);
+      
+      assign_add_mul_r(mnl->pf, up1, coefs[i-1], VOLUME/2);
+      assign_add_mul_r(mnl->pf2, dn1, coefs[i-1], VOLUME/2);
+
+      tup = up0; tdn = dn0;
+      up0 = up1; dn0 = dn1;
+      up1 = tup; dn1 = tdn;
+    }
   }
   etime = gettime();
   if(g_proc_id == 0) {
@@ -149,7 +188,7 @@ double ndratcor_acc(const int id, hamiltonian_field_t * const hf) {
     sw_invert_nd(mnl->mubar*mnl->mubar - mnl->epsbar*mnl->epsbar);
     copy_32_sw_fields();
   }
-  mnl->energy1 = 0.;
+  mnl->energy1 = square_norm(mnl->pf, VOLUME/2, 1) + square_norm(mnl->pf2, VOLUME/2, 1);
 
   solver_pm.max_iter = mnl->maxiter;
   solver_pm.squared_solver_prec = mnl->accprec;
@@ -166,27 +205,37 @@ double ndratcor_acc(const int id, hamiltonian_field_t * const hf) {
   solver_pm.rel_prec = g_relative_precision_flag;
 
   // apply (Q R)^(-1) to pseudo-fermion fields
-  assign(mnl->w_fields[4], mnl->pf, VOLUME/2);
-  assign(mnl->w_fields[5], mnl->pf2, VOLUME/2);
   up0 = mnl->w_fields[0]; dn0 = mnl->w_fields[1];
   up1 = mnl->w_fields[2]; dn1 = mnl->w_fields[3];
 
-  delta = apply_Z_ndpsi(up0, dn0, mnl->pf, mnl->pf2, id, hf, &solver_pm);
-  assign_add_mul_r(mnl->w_fields[4], up0, coefs[0], VOLUME/2);
-  assign_add_mul_r(mnl->w_fields[5], dn0, coefs[0], VOLUME/2);
+  apply_Z_ndpsi(up0, dn0, mnl->pf, mnl->pf2, id, hf, &solver_pm);
+  delta = coefs[0]*(scalar_prod_r(mnl->pf, up0, VOLUME/2, 1) + scalar_prod_r(mnl->pf2, dn0, VOLUME/2, 1));
+  mnl->energy1 += delta;
+  if(g_debug_level > 2 && g_proc_id == 0)
+    printf("# NDRATCOR acc step: c_%d*(phi * Z^%d * phi) = %e\n", 1, 1, delta);
 
   for(int i = 2; i < 8; i++) {
-    if(delta < mnl->accprec) break;
-    delta = apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &solver_pm);
-    assign_add_mul_r(mnl->w_fields[4], up1, coefs[i-1], VOLUME/2);
-    assign_add_mul_r(mnl->w_fields[5], dn1, coefs[i-1], VOLUME/2);
+    if(delta*delta < mnl->accprec) break;
+
+    delta = coefs[i-1]*(square_norm(up0, VOLUME/2, 1) + square_norm(dn0, VOLUME/2, 1)); 
+    mnl->energy1 += delta;
+    if(g_debug_level > 2 && g_proc_id == 0)
+      printf("# NDRATCOR acc step: c_%d*(phi * Z^%d * phi) = %e\n", i, i, delta);
+    i++; //incrementing i
+    if(delta*delta < mnl->accprec) break;
+
+    apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &solver_pm);
+    delta = coefs[i-1]*(scalar_prod_r(up0, up1, VOLUME/2, 1) + scalar_prod_r(dn0, dn1, VOLUME/2, 1));
+    mnl->energy1 += delta;
+    if(g_debug_level > 2 && g_proc_id == 0)
+      printf("# NDRATCOR acc step: c_%d*(phi * Z^%d * phi) = %e\n", i, i, delta);
+
     tup = up0; tdn = dn0;
     up0 = up1; dn0 = dn1;
     up1 = tup; dn1 = tdn;
   }
 
-  mnl->energy1 = scalar_prod_r(mnl->pf, mnl->w_fields[4], VOLUME/2, 1);
-  mnl->energy1 += scalar_prod_r(mnl->pf2, mnl->w_fields[5], VOLUME/2, 1);
+
   etime = gettime();
   if(g_proc_id == 0) {
     if(g_debug_level > 1) {
@@ -200,11 +249,10 @@ double ndratcor_acc(const int id, hamiltonian_field_t * const hf) {
 }
 
 // applies ((Q_h\tau_1 * R)^2 - 1)
-
-double apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
-		     spinor * const l_up, spinor * const l_dn,
-		     const int id, hamiltonian_field_t * const hf,
-		     solver_pm_t * solver_pm) {
+void apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
+                   spinor * const l_up, spinor * const l_dn,
+                   const int id, hamiltonian_field_t * const hf,
+                   solver_pm_t * solver_pm) {
   monomial * mnl = &monomial_list[id];
 
   mnl->iter0 += solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
@@ -221,7 +269,7 @@ double apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
   }
 
   // apply R a second time
-  solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
+  mnl->iter0 += solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
 	       k_up, k_dn,
 	       solver_pm);
   for(int j = (mnl->rat.np-1); j > -1; j--) {
@@ -239,15 +287,10 @@ double apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
 		     g_chi_up_spinor_field[mnl->rat.np], g_chi_dn_spinor_field[mnl->rat.np]);
   diff(k_up, k_up, l_up, VOLUME/2);
   diff(k_dn, k_dn, l_dn, VOLUME/2);
-  double resi = square_norm(k_up, VOLUME/2, 1) + square_norm(k_dn, VOLUME/2, 1);
-  if(g_debug_level > 2 && g_proc_id == 0) {
-    printf("# NDRATCOR: ||Z * phi|| = %e\n", resi);
-  }
-  return(resi);
+  
 }
 
 // computes ||(1 - C^dagger R C) phi||
-
 void check_C_ndpsi(spinor * const k_up, spinor * const k_dn,
 		   spinor * const l_up, spinor * const l_dn,
 		   const int id, hamiltonian_field_t * const hf,

--- a/read_input.l
+++ b/read_input.l
@@ -1789,6 +1789,9 @@ static inline void rmQuotes(char *str){
     else if(strcmp(type, "OMF4")==0) {
       Integrator.type[a] = OMF4;
     }
+    else if(strcmp(type, "2MNFG")==0) {
+      Integrator.type[a] = MN2FG;
+    }
     else {
       fprintf(stderr, "Unknown integrator type %s in line %d\n", yytext, line_of_file);
       exit(1);

--- a/update_momenta_fg.c
+++ b/update_momenta_fg.c
@@ -1,0 +1,226 @@
+/***********************************************************************
+ *
+ * Copyright (C) 2001 Martin Hasebusch
+ *
+ * some changes by C. Urbach 2002-2008,2012
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ***********************************************************************/
+
+#ifdef HAVE_CONFIG_H
+# include<config.h>
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+
+#include <lime.h>
+#include "sighandler.h"
+#include "read_input.h"
+#include "monomial/monomial.h"
+#include "init/init_gauge_fg.h"
+#include "operator/clover_leaf.h"
+
+#include "global.h"
+#include "gettime.h"
+#include "su3.h"
+#include "su3adj.h"
+#include "su3spinor.h"
+#include "expo.h"
+#include "sse.h"
+#include "xchange/xchange.h"
+#include "hamiltonian_field.h"
+#include "init/init_gauge_field.h"
+#ifdef DDalphaAMG
+#include "DDalphaAMG_interface.h"
+#endif
+/*******************************************************
+ *
+ * Temporarily updates the gauge field corresponding to 
+ * the approximated force gradient term to finally update
+ * the momenta
+ *
+ *******************************************************/
+
+void update_momenta_fg(int * mnllist, double step, const int no,
+		       hamiltonian_field_t * const hf, double step0) {
+  double atime, etime;
+  atime = gettime();
+#ifdef DDalphaAMG
+  MG_update_gauge(0.0);
+#endif
+
+  /* #ifdef TM_USE_OMP
+     #define static
+     #pragma omp parallel
+     {
+     #endif
+  */
+
+  int i,mu;
+  double step_fg
+  static su3 v,w;
+  su3 *z;
+  su3 *ztmp;
+  static su3adj deriv;
+  su3adj *Fm;
+
+  step_fg=-step0*step0/24
+  /*
+     #ifdef _KOJAK_INST
+     #pragma pomp inst begin(updategauge)
+     #endif
+
+     #ifdef TM_USE_OMP
+     #pragma omp parallel for
+     #endif
+  */
+
+  for(int i = 0; i < (VOLUMEPLUSRAND + g_dbw2rand);i++) {
+    for(int mu=0;mu<4;mu++) {
+      _zero_su3adj(hf->derivative[i][mu]);
+    }
+  }
+
+  for(int k = 0; k < no; k++) {
+    if(monomial_list[ mnllist[k] ].derivativefunction != NULL) {
+      monomial_list[ mnllist[k] ].derivativefunction(mnllist[k], hf);
+    }
+  }
+
+#ifdef TM_USE_MPI
+  xchange_deri(hf->derivative);
+#endif
+
+
+  /* #ifdef TM_USE_OMP
+     #pragma omp parallel for
+     #endif
+  */
+
+  for(i = 0; i < VOLUME; i++) { 
+    for(mu = 0; mu < 4; mu++){
+      /* Cope gauge field to be temporarily updated */
+      z = &hf->gaugefield[i][mu];
+      ztmp = &gauge_fg[i][mu];
+      _su3_assign(*ztmp,*z);  
+ 
+      /* Calculate approximated force gradient term and update temporary gauge field */
+      Fm = &hf->derivative[i][mu];
+      _zero_su3adj(deriv);
+      _su3adj_assign_const_times_su3adj(deriv, step_fg, *Fm);
+      /*_su3adj_assign_const_times_su3adj(deriv, 0.0, *Fm);*/
+      exposu3(&w,&deriv);
+      restoresu3(&v,&w);
+      _su3_times_su3(w, v, *z);
+      _su3_assign(*z, w);
+    }
+  }
+
+#ifdef TM_USE_MPI
+     /* for parallelization */
+     xchange_gauge(hf->gaugefield);
+#endif
+#ifdef DDalphaAMG
+     MG_update_gauge(0.0);
+#endif
+
+   /*Convert to a 32 bit gauge field, after xchange*/
+   convert_32_gauge_field(g_gauge_field_32, hf->gaugefield, VOLUMEPLUSRAND + g_dbw2rand);
+
+   /* The backward copy of gaugefield is not updated here! */
+   hf->update_gauge_copy = 1;
+   g_update_gauge_copy = 1;
+   g_update_gauge_copy_32 = 1;
+
+
+   /* #ifdef TM_USE_OMP
+      #pragma omp parallel for
+      #endif
+   */
+   /* Calculate derivate based on the temporary updated
+      gauge field U'=ztmp:
+      1) Set derivative to zero
+      2) Recalcuate derivate
+   */
+    
+  for(int i = 0; i < (VOLUMEPLUSRAND + g_dbw2rand);i++) {
+    for(int mu=0;mu<4;mu++) {
+      _zero_su3adj(hf->derivative[i][mu]);
+    }
+  }
+
+  for(int k = 0; k < no; k++) {
+    if(monomial_list[ mnllist[k] ].derivativefunction != NULL) {
+      monomial_list[ mnllist[k] ].derivativefunction(mnllist[k], hf);
+    }
+  }
+
+#ifdef TM_USE_MPI
+  xchange_deri(hf->derivative);
+#endif
+
+  for(i = 0; i < VOLUME; i++) { 
+    for(mu = 0; mu < 4; mu++){
+      /* Update momenta (the minus comes from an extra minus in trace_lambda)
+	 and restore initial gauge field */
+      _su3adj_minus_const_times_su3adj(hf->momenta[i][mu], step, hf->derivative[i][mu]);
+
+      z = &hf->gaugefield[i][mu];
+      ztmp = &gauge_fg[i][mu];
+      _su3_assign(*z,*ztmp);
+
+    }
+  }
+
+  /* #ifdef TM_USE_OMP
+     } /* OpenMP parallel closing brace /
+     #endif
+  */
+  
+#ifdef TM_USE_MPI
+  /* for parallelization */
+  xchange_gauge(hf->gaugefield);
+#endif
+#ifdef DDalphaAMG
+  MG_update_gauge(0.0);
+#endif
+
+  /*Convert to a 32 bit gauge field, after xchange*/
+  convert_32_gauge_field(g_gauge_field_32, hf->gaugefield, VOLUMEPLUSRAND + g_dbw2rand);
+  
+  /*
+   * The backward copy of the gauge field
+   * is not updated here!
+   */
+  hf->update_gauge_copy = 1;
+  g_update_gauge_copy = 1;
+  g_update_gauge_copy_32 = 1;
+
+
+  etime = gettime();
+  if(g_debug_level > 1 && g_proc_id == 0) {
+    printf("# Time gauge update: %e s\n", etime-atime); 
+  } 
+  return;
+
+  /* #ifdef _KOJAK_INST
+     #pragma pomp inst end(updategauge)
+     #endif
+  */
+}

--- a/update_momenta_fg.c
+++ b/update_momenta_fg.c
@@ -73,14 +73,14 @@ void update_momenta_fg(int * mnllist, double step, const int no,
   */
 
   int i,mu;
-  double step_fg
+  double step_fg;
   static su3 v,w;
   su3 *z;
   su3 *ztmp;
   static su3adj deriv;
   su3adj *Fm;
 
-  step_fg=-step0*step0/24
+  step_fg=-step0*step0/24;
   /*
      #ifdef _KOJAK_INST
      #pragma pomp inst begin(updategauge)

--- a/update_momenta_fg.h
+++ b/update_momenta_fg.h
@@ -1,0 +1,26 @@
+/***********************************************************************
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008 Carsten Urbach
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ ***********************************************************************/
+#ifndef _UPDATE_MOMENTA_FG_H
+#define _UPDATE_MOMENTA_FG_H
+
+#include "hamiltonian_field.h"
+
+void update_momenta_fg(int * mnllist, double step, const int no, hamiltonian_field_t * const hf, double step_fg);
+
+#endif

--- a/update_tm.c
+++ b/update_tm.c
@@ -140,7 +140,7 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
   /* run the trajectory */
   if(Integrator.n_int[Integrator.no_timescales-1] > 0) {
     Integrator.integrate[Integrator.no_timescales-1](Integrator.tau, 
-                 Integrator.no_timescales-1, 1);
+                 Integrator.no_timescales-1, 1, Integrator.tau);
   }
 
   g_sloppy_precision = 0;
@@ -213,7 +213,7 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
     g_sloppy_precision = 1;
     /* run the trajectory back */
     Integrator.integrate[Integrator.no_timescales-1](-Integrator.tau, 
-                         Integrator.no_timescales-1, 1);
+                         Integrator.no_timescales-1, 1, -Integrator.tau);
     g_sloppy_precision = 0;
 
     /*   compute the energy contributions from the pseudo-fermions  */


### PR DESCRIPTION
Saved some applications of Z in both heatbath/acc step.
Improved the check of next order correction in both heatbath/acc step (which we should discuss if it was a bug; read following).
Added documentation for guiding the changes.

Everything tested and gives same results of before.
A test is running on supermuc for the ensemble 16c Nf=1+1 with changes included, using just DDalphaAMG. You can find it in /gpfs/work/pr74yo/di49saj/HMC_MG_nd_only_test.

@urbach @kostrzewa @Finkenrath 
-------------------

The improvements in the checks for next order correction are the following; 
we should discuss if it was a bug.

The old check for the order `n`th was
  `| Z^n R |^2 < acceptance^2`
which reads as `R^\dagger Z^{2n} R `.
The new check is
  `[ c_n R^\dagger Z^n R ]^2 < acceptance^2`
which is actually the correction to the energy given by the order `n`th.

About the old check we can say
  `| Z^n R |^2 < |Z|^{2n} |R|^2`
and about the new instead
  `[ R^\dagger Z^n R ]^2 < |Z|^{2n} |R|^4`.
So the upper limits differ of a factor |R|^2 between old and new.
The difference between the two checks is more relevant as much the lattice size increases, since |R|~V.

Indeed what we noticed now on the lattice 64c, is that the new check include terms of higher order compared to the old check (e.g. with the new check the terms of order Z^3 are included in the series; while with the old check they weren't).
On smaller lattices, as the 16c, there is no difference between old and new check because both of them cut the series at order Z^2.
