### PR TITLE
Some bug fix about MG_update.

### DIFF
--- a/DDalphaAMG_interface.c
+++ b/DDalphaAMG_interface.c
@@ -210,8 +210,10 @@ static int MG_pre_solve( su3 **gf )
   //  mg_dtau_update == 0.0  : updating at every change of configuration -> valid as well if configuration changed outside the HMC
   //  mg_rho_update < 0.0    : parameter ignore
   //  mg_rho_update == rho   : updating only if this condition and the others are satisfied
-  if ( mg_do_setup == 0 && mg_update_setup < mg_update_setup_iter && ( mg_dtau_update < dtau+1e-6 || (mg_dtau_update==0.0 && mg_update_gauge==1) ||
-                                                                       (mg_rho_update >= 0.0 && mg_rho_update == g_mu3) )) 
+  if ( mg_do_setup == 0 && mg_update_setup < mg_update_setup_iter && 
+       ( (mg_dtau_update > 0.0 && dtau > 0.0 && mg_dtau_update < dtau+1e-6) ||
+         (mg_dtau_update == 0.0 && mg_update_gauge == 1)         ||
+         (mg_rho_update >= 0.0 && mg_rho_update == g_mu3) )) 
     mg_update_setup = mg_update_setup_iter;
   
   if(g_debug_level > 0 && g_proc_id == 0)

--- a/hmc_tm.c
+++ b/hmc_tm.c
@@ -518,22 +518,12 @@ int main(int argc,char *argv[]) {
     }
 
     /* online measurements */
-#ifdef DDalphaAMG
-    // When the configuration is rejected, we have to update it in the MG and redo the setup.
-    int mg_update = accept ? 0:1;
-#endif
     for(imeas = 0; imeas < no_measurements; imeas++){
       meas = &measurement_list[imeas];
       if(trajectory_counter%meas->freq == 0){
         if (g_proc_id == 0) {
           fprintf(stdout, "#\n# Beginning online measurement.\n");
         }
-#ifdef DDalphaAMG
-        if( mg_update ) {
-          mg_update = 0;
-          MG_reset();
-        }
-#endif
         meas->measurefunc(trajectory_counter, imeas, even_odd_flag);
       }
     }

--- a/io/gauge_read.c
+++ b/io/gauge_read.c
@@ -19,6 +19,9 @@
  ***********************************************************************/
 
 #include "gauge.ih"
+#ifdef DDalphaAMG
+# include "DDalphaAMG_interface.h"
+#endif
 
 extern int gauge_precision_read_flag;
 paramsGaugeInfo GaugeInfo = { 0., 0, {0,0}, NULL, NULL};
@@ -181,6 +184,11 @@ int read_gauge_field(char * filename, su3 ** const gf) {
   destruct_reader(reader);
 
   g_update_gauge_copy = 1;
+
+#ifdef DDalphaAMG
+  if(gf==g_gauge_field)
+    MG_reset();
+#endif
 
   return(0);
 }

--- a/update_tm.c
+++ b/update_tm.c
@@ -337,6 +337,9 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
         _su3_assign(*v,*w);
       }
     }
+#ifdef DDalphaAMG
+    MG_reset();
+#endif
   }
   hf.update_gauge_copy = 1;
   g_update_gauge_copy = 1;


### PR DESCRIPTION
In response to the issues reported by @kostrzewa:

> - when using the DDlpahaAMG interface in invert, the MG setup is updated when the source changes or the flavour is switched, unless I set MGUpdateSetupIter = 0.
> 
> - Worse still, when processing multiple gauge configurations in one job, I've noticed that the DDalphaAMG interface will not update its copy of  the gauge configuration between gauge configurations. This is true whatever value I set MGUpdateSetupIter to. After the new gauge configuration has been read in, it will
> a) do MGUpdateSetupIter setup iterations (without updating the gauge field first), if MGUpdateSetupIter > 0
> b) attempt to do one inversion, notice that the result is wrong, and restart.
>
> Only after this restart will the gauge field be updated and the setup1 redone fully.

1. Fixed reset of multigrid when several measurements are done with invert or offline_measurments.
2. Changed position MG_reset when configuration is rejected. 
3. Fixed update of setup.

@kostrzewa can you please check if now everything works?