### PR TITLE
Update the header of config.in.h (closes GH-364)

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,4 +1,5 @@
-/* config.h.in.  Generated from configure.in by autoheader.  */
+/* Hand-written config.h.in. */
+
 #ifndef _CONFIG_H
 #define _CONFIG_H
 


### PR DESCRIPTION
The previous header of `config.in.h` suggested that it has been
auto-generated with `autoheader`. tmLQCD does not use the full set of
GNU Autotools, so that file is hand-written.

In order to prevent future confusion, the first line now explicitly
states that it is hand-written.