### PR TITLE
read_input: allow bicgstab as a solver for clover operator

### DIFF
--- a/read_input.l
+++ b/read_input.l
@@ -1189,6 +1189,11 @@ static inline void rmQuotes(char *str){
 
 
 <CSWSOLVER>{
+  bicgstab {
+    optr->solver = BICGSTAB;
+    if(myverbose) printf("  Solver set to BiCGstab line %d operator %d\n", line_of_file, current_operator);
+    BEGIN(name_caller);
+  }
   increigcg {
     optr->solver = INCREIGCG;
     if(myverbose) printf("  Solver set to INCR-EIG-CG line %d operator %d\n", line_of_file, current_operator);


### PR DESCRIPTION
This is mainly for using QUDA BiCGstab with the CLOVER operator (mu=0.0). ```invert_clover_eo`` is properly safeguarded and will just terminate if someone attempts to use the tmLQCD BiCGstab with the CLOVER operator.