### PR TITLE
First stab at QPhiX in HMC. 

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -32,7 +32,7 @@ $(top_srcdir)/configure: $(top_srcdir)/configure.in
 $(addsuffix .d, $(filter-out ${PROGRAMS_WITH_GIT_HASH},${ALLOBJ})): %.d: ${srcdir}/%.c Makefile
 	@ $(CCDEP) ${DEPFLAGS} ${DEFS} ${INCLUDES} $< > $@
 $(addsuffix .d, $(filter-out ${PROGRAMS_WITH_GIT_HASH},${CXXMODULES})): %.d: ${srcdir}/%.cpp Makefile
-	@ $(CCDEP) ${DEPFLAGS} ${DEFS} ${INCLUDES} $< > $@
+	@ $(CXXDEP) ${CXXDEPFLAGS} ${DEFS} ${INCLUDES} $< > $@
 	
 # dirty hack to prevent make from entering an infinite loop because a phony target is given as a real
 # dependency (make will build invert.d and hmc_tm.d indefinitely)

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,6 +20,7 @@ CFLAGS = @CFLAGS@
 CXXFLAGS = @CXXFLAGS@
 LDFLAGS = @LDFLAGS@
 DEPFLAGS = @DEPFLAGS@
+CXXDEPFLAGS = @CXXDEPFLAGS@
 CPPFLAGS = @CPPFLAGS@
 CCLD = @CCLD@
 LEX = @LEX@
@@ -57,8 +58,8 @@ MODULES = read_input gamma measure_gauge_action start \
         update_momenta integrator  phmc \
 	little_D block operator \
 	temporalgauge spinor_fft X_psi P_M_eta \
-	jacobi fatal_error invert_clover_eo gettime @SPI_FILES@ \
-	@QUDA_INTERFACE@ @DDalphaAMG_INTERFACE@
+	jacobi fatal_error invert_clover_eo gettime \
+        @SPI_FILES@ @QUDA_INTERFACE@ @DDalphaAMG_INTERFACE@
 
 CXXMODULES = @QPHIX_INTERFACE@
 

--- a/config.h.in
+++ b/config.h.in
@@ -209,5 +209,8 @@
 /* Using QPHIX */
 #undef TM_USE_QPHIX
 
+/* Structure of Array length to use with QPhiX */
+#undef QPHIX_SOALEN
+
 #endif
 

--- a/configure.in
+++ b/configure.in
@@ -985,20 +985,28 @@ AC_ARG_WITH(qphixdir,
               QPHIX_AVAILABLE=1
               AC_DEFINE(TM_USE_QPHIX,1,Using QPhiX)
               qphix_dir=$withval
-              LDFLAGS="$LDFLAGS -L${qphix_dir}/lib -lqphix_solver"
+              LDFLAGS="$LDFLAGS -L${qphix_dir}/lib -lqphix_solver -lqphix_codegen"
               INCLUDES="$INCLUDES -I${qphix_dir}/include/" 
               QPHIX_INTERFACE="qphix_interface"
               QPHIX_PROGRAMS="qphix_test_Dslash"
 
-						  # QMP: TODO AC_CHECK_LIB
+              # QMP: TODO AC_CHECK_LIB
               AC_MSG_CHECKING([where to search for QMP libs])
-						  AC_ARG_WITH(qmpdir,
-						    AS_HELP_STRING([--with-qmpdir[=dir]], [if using QPhiX, then set QMP lib dir]),
-						    qmp_dir=$withval
-						    LDFLAGS="$LDFLAGS -L${qmp_dir}/lib -lqmp"
-						    INCLUDES="$INCLUDES -I${qmp_dir}/include/"
-						  )
-						  AC_MSG_RESULT($qmp_dir)
+              AC_ARG_WITH(qmpdir,
+                          AS_HELP_STRING([--with-qmpdir[=dir]], [if using QPhiX, then set QMP lib dir]),
+                          qmp_dir=$withval
+                          LDFLAGS="$LDFLAGS -L${qmp_dir}/lib -lqmp"
+                          INCLUDES="$INCLUDES -I${qmp_dir}/include/"
+                          )
+              AC_MSG_RESULT($qmp_dir)
+
+              AC_MSG_CHECKING([Setting QPhiX SOALEN])
+              AC_ARG_ENABLE(qphix-soalen,
+                            AS_HELP_STRING([--enable-qphix-soalen], [if using QPhiX, set SOALEN [default=4]]),
+                            enable_qphix_soalen=$enableval, enable_qphix_soalen=4)
+              AC_MSG_RESULT($enable_qphix_soalen)
+              AC_DEFINE_UNQUOTED(QPHIX_SOALEN, ${enable_qphix_soalen}, Structure of Array length to use with QPhiX)
+
               AC_PROG_CXX
               #QPhiX needs to be linked with C++ linker
               CCLD=${CXX}

--- a/configure.in
+++ b/configure.in
@@ -32,6 +32,7 @@ fi
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
 AC_CHECK_PROG(CCDEP, gcc, "gcc", "$CC")
+AC_CHECK_PROG(CXXDEP, g++, "g++", "$CXX")
 #(endian="", AC_DEFINE(LITTLE_ENDIAN,1,The endian of the architechture))
 
 # AC_PROG_FC([ifort gfortran])
@@ -372,6 +373,7 @@ AC_SUBST(CCDEP)
 AC_SUBST(CXXDEP)
 AC_SUBST(CCLD)
 AC_SUBST(DEPFLAGS)
+AC_SUBST(CXXDEPFLAGS)
 AC_SUBST(DEBUG_FLAG)
 AC_SUBST(PROFILE_FLAG)
 AC_SUBST(XCHANGELIB)
@@ -639,6 +641,10 @@ dnl the GNU compiler
     if test $enable_mpi = yes; then
       CCDEP="gcc"
     fi
+    CXXDEP="$CXX"
+    if test $enable_mpi = yes; then
+      CXXDEP="g++"
+    fi
     DEBUG_FLAG="-g"
 dnl other compilers
   else
@@ -661,6 +667,7 @@ dnl check for icc
       DEBUG_FLAG="-g"
       PROFILE_FLAG="-p -g"
       CCDEP="$CC"
+      CXXDEP="$CXX"
 
     else
       # other compilers might support SSE inline assembly too
@@ -677,6 +684,7 @@ dnl check for icc
       CFLAGS="$CFLAGS -O"
       DEBUG_FLAG="-g"
       CCDEP="$CC"
+      CXXDEP="$CXX"
     fi
   fi
 
@@ -811,6 +819,7 @@ else
   SOPTARGS=
 fi
 
+CXXDEPFLAGS="$DEPFLAGS --std=c++11"
 
 AC_MSG_CHECKING(whether we want to switch on optimisation)
 AC_ARG_ENABLE(optimize,
@@ -1010,7 +1019,6 @@ AC_ARG_WITH(qphixdir,
               AC_PROG_CXX
               #QPhiX needs to be linked with C++ linker
               CCLD=${CXX}
-              CXXDEP=${CXX}
              ],
              [echo no
               QPHIX_AVAILABLE=0

--- a/default_input_values.h
+++ b/default_input_values.h
@@ -190,7 +190,7 @@
 #define _default_omp_num_threads 0
 
 /* default mixed precision solver values */
-#define _default_mixcg_innereps 1.0e-6
+#define _default_mixcg_innereps 5.0e-5
 #define _default_mixcg_maxinnersolverit 5000
 
 #define _default_use_preconditioning 0

--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -1,7680 +1,7893 @@
+@comment{x-kbibtex-personnameformatting=<%l><, %f>}
+
 @article{Clark:2009wm,
-      author         = "Clark, M.A. and Babich, R. and Barros, K. and Brower,
-                        R.C. and Rebbi, C.",
-      title          = "{Solving Lattice QCD systems of equations using mixed
-                        precision solvers on GPUs}",
-      journal        = "Comput.Phys.Commun.",
-      volume         = "181",
-      pages          = "1517-1528",
-      doi            = "10.1016/j.cpc.2010.05.002",
-      year           = "2010",
-      eprint         = "0911.3191",
-      archivePrefix  = "arXiv",
-      primaryClass   = "hep-lat",
-      SLACcitation   = "%%CITATION = ARXIV:0911.3191;%%",
+	archiveprefix = "arXiv",
+	author = "Clark, M.A. and Babich, R. and Barros, K. and Brower, R.C. and Rebbi, C.",
+	doi = "10.1016/j.cpc.2010.05.002",
+	eprint = "0911.3191",
+	journal = "Comput.Phys.Commun.",
+	pages = "1517--1528",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0911.3191;\%\%",
+	title = "{Solving Lattice QCD systems of equations using mixed precision solvers on GPUs}",
+	volume = "181",
+	year = "2010"
 }
 
 @article{Babich:2011np,
-      author         = "Babich, R. and Clark, M.A. and Joo, B. and Shi, G. and
-                        Brower, R.C. and others",
-      title          = "{Scaling Lattice QCD beyond 100 GPUs}",
-      year           = "2011",
-      eprint         = "1109.2935",
-      archivePrefix  = "arXiv",
-      primaryClass   = "hep-lat",
-      SLACcitation   = "%%CITATION = ARXIV:1109.2935;%%",
+	archiveprefix = "arXiv",
+	author = "Babich, R. and Clark, M.A. and Joo, B. and Shi, G. and Brower, R.C. and others",
+	eprint = "1109.2935",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:1109.2935;\%\%",
+	title = "{Scaling Lattice QCD beyond 100 GPUs}",
+	year = "2011"
 }
 
 @article{Strelchenko:2013vaa,
-      author         = "Strelchenko, Alexei and Alexandrou, Constantia and
-                        Koutsou, Giannis and Aviles-Casco, Alejandro Vaquero",
-      title          = "{Implementation of the twisted mass fermion operator in
-                        the QUDA library}",
-      journal        = "PoS",
-      volume         = "LATTICE2013",
-      pages          = "415",
-      year           = "2014",
-      eprint         = "1311.4462",
-      archivePrefix  = "arXiv",
-      primaryClass   = "hep-lat",
-      reportNumber   = "FERMILAB-CONF-13-528-CD",
-      SLACcitation   = "%%CITATION = ARXIV:1311.4462;%%",
+	archiveprefix = "arXiv",
+	author = "Strelchenko, Alexei and Alexandrou, Constantia and Koutsou, Giannis and Aviles-Casco, Alejandro Vaquero",
+	eprint = "1311.4462",
+	journal = "PoS",
+	pages = "415",
+	primaryclass = "hep-lat",
+	reportnumber = "FERMILAB-CONF-13-528-CD",
+	slaccitation = "%\%CITATION = ARXIV:1311.4462;\%\%",
+	title = "{Implementation of the twisted mass fermion operator in the QUDA library}",
+	volume = "LATTICE2013",
+	year = "2014"
 }
 
 @article{Luscher:2012av,
-      author         = "Luscher, Martin and Schaefer, Stefan",
-      title          = "{Lattice QCD with open boundary conditions and
-                        twisted-mass reweighting}",
-      journal        = "Comput.Phys.Commun.",
-      volume         = "184",
-      pages          = "519-528",
-      doi            = "10.1016/j.cpc.2012.10.003",
-      year           = "2013",
-      eprint         = "1206.2809",
-      archivePrefix  = "arXiv",
-      primaryClass   = "hep-lat",
-      reportNumber   = "CERN-PH-TH-2012-161",
-      SLACcitation   = "%%CITATION = ARXIV:1206.2809;%%",
+	archiveprefix = "arXiv",
+	author = "Luscher, Martin and Schaefer, Stefan",
+	doi = "10.1016/j.cpc.2012.10.003",
+	eprint = "1206.2809",
+	journal = "Comput.Phys.Commun.",
+	pages = "519--528",
+	primaryclass = "hep-lat",
+	reportnumber = "CERN-PH-TH-2012-161",
+	slaccitation = "%\%CITATION = ARXIV:1206.2809;\%\%",
+	title = "{Lattice QCD with open boundary conditions and twisted-mass reweighting}",
+	volume = "184",
+	year = "2013"
 }
+
 @article{Luscher:2010ae,
-      author         = "Luscher, Martin",
-      title          = "{Computational Strategies in Lattice QCD}",
-      pages          = "331-399",
-      year           = "2010",
-      eprint         = "1002.4232",
-      archivePrefix  = "arXiv",
-      primaryClass   = "hep-lat",
-      reportNumber   = "CERN-PH-TH-2010-047",
-      SLACcitation   = "%%CITATION = ARXIV:1002.4232;%%",
+	archiveprefix = "arXiv",
+	author = "Luscher, Martin",
+	eprint = "1002.4232",
+	pages = "331--399",
+	primaryclass = "hep-lat",
+	reportnumber = "CERN-PH-TH-2010-047",
+	slaccitation = "%\%CITATION = ARXIV:1002.4232;\%\%",
+	title = "{Computational Strategies in Lattice QCD}",
+	year = "2010"
 }
+
 @article{Clark:2006fx,
-      author         = "Clark, M.A. and Kennedy, A.D.",
-      title          = "{Accelerating dynamical fermion computations using the
-                        rational hybrid Monte Carlo (RHMC) algorithm with multiple
-                        pseudofermion fields}",
-      journal        = "Phys.Rev.Lett.",
-      volume         = "98",
-      pages          = "051601",
-      doi            = "10.1103/PhysRevLett.98.051601",
-      year           = "2007",
-      eprint         = "hep-lat/0608015",
-      archivePrefix  = "arXiv",
-      primaryClass   = "hep-lat",
-      SLACcitation   = "%%CITATION = HEP-LAT/0608015;%%",
-}
-@Article{'tHooft:1971fh,
-     author    = "'t Hooft, G.",
-     title     = "Renormalization of massless Yang-Mills fields",
-     journal   = "Nucl. Phys.",
-     volume    = "B33",
-     year      = "1971",
-     pages     = "173-199",
-     SLACcitation  = "%%CITATION = NUPHA,B33,173;%%"
-}
-@Article{'tHooft:1971rn,
-     author    = "'t Hooft, G.",
-     title     = "Renormalizable lagrangians for massive Yang-Mills fields",
-     journal   = "Nucl. Phys.",
-     volume    = "B35",
-     year      = "1971",
-     pages     = "167-188",
-     SLACcitation  = "%%CITATION = NUPHA,B35,167;%%"
-}
-@Unpublished{'tHooft:1972aa,
-  author = 	 "'t Hooft, G.",
-  title = 	 "",
-  note = 	 "Unpublished remarks at the 1972 Marseille Conference 
-                  on Yang-Mills Fields"
-}
-@Article{'tHooft:1972fi,
-     author    = "'t Hooft, G. and Veltman, M. J. G.",
-     title     = "Regularization and renormalization of gauge fields",
-     journal   = "Nucl. Phys.",
-     volume    = "B44",
-     year      = "1972",
-     pages     = "189-213",
-     SLACcitation  = "%%CITATION = NUPHA,B44,189;%%"
-}
-@Article{Abdel-Rehim:2004gx,
-     author    = "Abdel-Rehim, A. M. and Lewis, R.",
-     title     = "Twisted mass {QCD} for the pion electromagnetic form factor",
-     journal   = "Phys. Rev.",
-     volume    = "D71",
-     year      = "2005",
-     pages     = "014503",
-     eprint    = "hep-lat/0410047",
-     SLACcitation  = "%%CITATION = HEP-LAT 0410047;%%"
-}
-@Article{Abdel-Rehim:2005gz,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  ",
-     title     = "Spectrum of quenched twisted mass lattice QCD at maximal
-                  twist",
-     journal   = "Phys. Rev.",
-     volume    = "D71",
-     year      = "2005",
-     pages     = "094505",
-     eprint    = "hep-lat/0503007",
-     SLACcitation  = "%%CITATION = HEP-LAT/0503007;%%"
-}
-@Article{AbdelRehim:2004sp,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy",
-     title     = "Pion form factor with twisted mass QCD",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "299-301",
-     eprint    = "hep-lat/0408033",
-     SLACcitation  = "%%CITATION = HEP-LAT/0408033;%%"
-}
-@Article{AbdelRehim:2005gq,
-     author    = "Abdel-Rehim, A. M. and Lewis, R. and Woloshyn, R. M.",
-     title     = "Twisted mass lattice QCD and hadron phenomenology",
-     journal   = "Int. J. Mod. Phys.",
-     volume    = "A20",
-     year      = "2005",
-     pages     = "6159-6168",
-     SLACcitation  = "%%CITATION = IMPAE,A20,6159;%%"
-}
-@Article{AbdelRehim:2005gz,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  ",
-     title     = "{Spectrum of quenched twisted mass lattice QCD at maximal
-                  twist}",
-     journal   = "Phys. Rev.",
-     volume    = "D71",
-     year      = "2005",
-     pages     = "094505",
-     eprint    = "hep-lat/0503007",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.71.094505",
-     SLACcitation  = "%%CITATION = HEP-LAT/0503007;%%"
-}
-@Article{AbdelRehim:2005qv,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  ",
-     title     = "The hadron spectrum from twisted mass QCD with a strange
-                  quark",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "032",
-     eprint    = "hep-lat/0509056",
-     SLACcitation  = "%%CITATION = HEP-LAT/0509056;%%"
-}
-@Article{AbdelRehim:2005yx,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  ",
-     title     = "Maximal twist and the spectrum of quenched twisted mass
-                  lattice QCD",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "051",
-     eprint    = "hep-lat/0509098",
-     SLACcitation  = "%%CITATION = HEP-LAT/0509098;%%"
-}
-@Article{AbdelRehim:2006qu,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Petry, Robert G.
-                  and Woloshyn, R. M.",
-     title     = "The spectrum of tmLQCD with quark and link smearing",
-     journal   = "PoS",
-     volume    = "LAT2006",
-     year      = "2006",
-     pages     = "164",
-     eprint    = "hep-lat/0610004",
-     SLACcitation  = "%%CITATION = HEP-LAT/0610004;%%"
-}
-@Article{AbdelRehim:2006ra,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  and Wu, Jackson M. S.",
-     title     = "Lattice QCD with a twisted mass term and a strange quark",
-     journal   = "Eur. Phys. J.",
-     volume    = "A31",
-     year      = "2007",
-     pages     = "773-776",
-     eprint    = "hep-lat/0610090",
-     SLACcitation  = "%%CITATION = HEP-LAT/0610090;%%"
-}
-@Article{AbdelRehim:2006ve,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  and Wu, Jackson M. S.",
-     title     = "Strange quarks in quenched twisted mass lattice QCD",
-     journal   = "Phys. Rev.",
-     volume    = "D74",
-     year      = "2006",
-     pages     = "014507",
-     eprint    = "hep-lat/0601036",
-     SLACcitation  = "%%CITATION = HEP-LAT/0601036;%%"
-}
-@Article{Adler:1974gd,
-     author    = "Adler, Stephen L.",
-     title     = "{Some Simple Vacuum Polarization Phenomenology: e+ e- $\to$
-                  Hadrons: The mu - Mesic Atom x-Ray Discrepancy and (g-2) of
-                  the Muon}",
-     journal   = "Phys. Rev.",
-     volume    = "D10",
-     year      = "1974",
-     pages     = "3714",
-     SLACcitation  = "%%CITATION = PHRVA,D10,3714;%%"
-}
-@Article{Albanese:1987ds,
-     author    = "Albanese, M. and others",
- collaboration = "APE",
-     title     = "Glueball masses and string tension in lattice {QCD}",
-     journal   = "Phys. Lett.",
-     volume    = "B192",
-     year      = "1987",
-     pages     = "163",
-     SLACcitation  = "%%CITATION = PHLTA,B192,163;%%"
-}
-@Article{Alexandrou:2008tn,
-     author    = "Alexandrou, C. and others",
- collaboration = "ETM",
-     title     = "{Light baryon masses with dynamical twisted mass
-                  fermions}",
-     year      = "2008",
-     eprint    = "0803.3190",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0803.3190;%%"
-}
-@Article{AliKhan:2000iv,
-     author    = "Ali Khan, A. and others",
- collaboration = "CP-PACS",
-     title     = "Chiral properties of domain-wall quarks in quenched {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D63",
-     year      = "2001",
-     pages     = "114504",
-     eprint    = "hep-lat/0007014",
-     SLACcitation  = "%%CITATION = HEP-LAT 0007014;%%"
-}
-@Article{AliKhan:2003br,
-     author    = "Ali Khan, A. and others",
- collaboration = "QCDSF",
-     title     = "Accelerating the hybrid Monte Carlo algorithm",
-     journal   = "Phys. Lett.",
-     volume    = "B564",
-     year      = "2003",
-     pages     = "235-240",
-     eprint    = "hep-lat/0303026",
-     SLACcitation  = "%%CITATION = HEP-LAT 0303026;%%"
-}
-@Article{AliKhan:2003mu,
-     author    = "Ali Khan, A. and others",
-     title     = "Accelerating Hasenbusch's acceleration of hybrid Monte
-                  Carlo",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "129",
-     year      = "2004",
-     pages     = "853-855",
-     eprint    = "hep-lat/0309078",
-     SLACcitation  = "%%CITATION = HEP-LAT 0309078;%%"
-}
-@Article{Allton:1993wc,
-     author    = "Allton, C. R. and others",
- collaboration = "UK{QCD}",
-     title     = "Gauge invariant smearing and matrix correlators using
-                  {Wilson} fermions at Beta = 6.2",
-     journal   = "Phys. Rev.",
-     volume    = "D47",
-     year      = "1993",
-     pages     = "5128-5137",
-     eprint    = "hep-lat/9303009",
-     SLACcitation  = "%%CITATION = HEP-LAT 9303009;%%"
-}
-@Article{Allton:2004qq,
-     author    = "Allton, C. R. and others",
- collaboration = "UKQCD",
-     title     = "Improved Wilson QCD simulations with light quark masses",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "014501",
-     eprint    = "hep-lat/0403007",
-     SLACcitation  = "%%CITATION = HEP-LAT/0403007;%%"
-}
-@Article{Aoki:1984qi,
-     author    = "Aoki, S.",
-     title     = "New phase structure for lattice {QCD} with {Wilson} fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D30",
-     year      = "1984",
-     pages     = "2653",
-     SLACcitation  = "%%CITATION = PHRVA,D30,2653;%%"
-}
-@Article{Aoki:1985jj,
-     author    = "Aoki, S. and Higashijima, K.",
-     title     = "The recovery of the chiral symmetry in lattice {Gross-Neveu}
-                  model",
-     journal   = "Prog. Theor. Phys.",
-     volume    = "76",
-     year      = "1986",
-     pages     = "521",
-     SLACcitation  = "%%CITATION = PTPKA,76,521;%%"
-}
-@Article{Aoki:1986ua,
-     author    = "Aoki, Sinya",
-     title     = "NUMERICAL EVIDENCE FOR A PARITY VIOLATING PHASE IN LATTICE
-                  QCD WITH WILSON FERMION",
-     journal   = "Phys. Lett.",
-     volume    = "B190",
-     year      = "1987",
-     pages     = "140",
-     SLACcitation  = "%%CITATION = PHLTA,B190,140;%%"
-}
-@Article{Aoki:1986xr,
-     author    = "Aoki, S.",
-     title     = "A solution to the {U(1)} problem on a lattice",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "57",
-     year      = "1986",
-     pages     = "3136",
-     SLACcitation  = "%%CITATION = PRLTA,57,3136;%%"
-}
-@Article{Aoki:1993vs,
-     author    = "Aoki, S. and Boettcher, S. and Gocksch, A.",
-     title     = "Spontaneous breaking of flavor symmetry and parity in the
-                  Nambu-Jona-Lasinio model with {Wilson} fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B331",
-     year      = "1994",
-     pages     = "157-164",
-     eprint    = "hep-lat/9312084",
-     SLACcitation  = "%%CITATION = HEP-LAT 9312084;%%"
-}
-@Article{Aoki:1995ft,
-     author    = "Aoki, S.",
-     title     = "On the phase structure of {QCD} with {Wilson} fermions",
-     journal   = "Prog. Theor. Phys. Suppl.",
-     volume    = "122",
-     year      = "1996",
-     pages     = "179-186",
-     eprint    = "hep-lat/9509008",
-     SLACcitation  = "%%CITATION = HEP-LAT 9509008;%%"
-}
-@Article{Aoki:1995yf,
-     author    = "Aoki, S. and Ukawa, A. and Umemura, T.",
-     title     = "Finite temperature phase structure of lattice {QCD} with
-                  {Wilson} quark action",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "76",
-     year      = "1996",
-     pages     = "873-876",
-     eprint    = "hep-lat/9508008",
-     SLACcitation  = "%%CITATION = HEP-LAT 9508008;%%"
-}
-@Article{Aoki:1997fm,
-     author    = "Aoki, S.",
-     title     = "Phase structure of lattice {QCD} with {Wilson} fermion at
-                  finite  temperature",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "60A",
-     year      = "1998",
-     pages     = "206-219",
-     eprint    = "hep-lat/9707020",
-     SLACcitation  = "%%CITATION = HEP-LAT 9707020;%%"
-}
-@Article{Aoki:2001xq,
-     author    = "Aoki, S. and others",
- collaboration = "JL{QCD}",
-     title     = "Non-trivial phase structure of {N(f)} = 3 {QCD} with {O(a)}-
-                  improved {Wilson}  fermion at zero temperature",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "263-265",
-     eprint    = "hep-lat/0110088",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110088;%%"
-}
-@Article{Aoki:2002vt,
-     author    = "Aoki, Y. and others",
-     title     = "Domain wall fermions with improved gauge actions",
-     journal   = "Phys. Rev.",
-     volume    = "D69",
-     year      = "2004",
-     pages     = "074504",
-     eprint    = "hep-lat/0211023",
-     SLACcitation  = "%%CITATION = HEP-LAT 0211023;%%"
-}
-@Article{Aoki:2004iq,
-     author    = "Aoki, S. and others",
- collaboration = "JL{QCD}",
-     title     = "Bulk first-order phase transition in three-flavor lattice
-                  {QCD} with  {O(a)}-improved {Wilson} fermion action at zero
-                  temperature",
-     year      = "2004",
-     eprint    = "hep-lat/0409016",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409016;%%"
-}
-@Article{Aoki:2004ta,
-     author    = "Aoki, Sinya and B{\"a}r, Oliver",
-     title     = "Twisted-mass {QCD}, {O}(a) improvement and {Wilson} chiral
-                  perturbation  theory",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "116011",
-     eprint    = "hep-lat/0409006",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409006;%%"
-}
-@Article{Aoki:2005ii,
-     author    = "Aoki, S. and B{\"a}r, O.",
-     title     = "Determining the low energy parameters of {Wilson} chiral
-                  perturbation theory",
-     year      = "2005",
-     eprint    = "hep-lat/0509002",
-     SLACcitation  = "%%CITATION = HEP-LAT 0509002;%%"
-}
-@Article{Arnold:2003sx,
-     author    = "Arnold, Guido and others",
-     title     = "Numerical methods for the QCD overlap operator. II: Optimal
-                  Krylov subspace methods",
-     year      = "2003",
-     eprint    = "hep-lat/0311025",
-     SLACcitation  = "%%CITATION = HEP-LAT 0311025;%%"
-}
-@Article{Atiyah:1971rm,
-     author    = "Atiyah, M. F. and Singer, I. M.",
-     title     = "The Index of elliptic operators. 5",
-     journal   = "Annals Math.",
-     volume    = "93",
-     year      = "1971",
-     pages     = "139-149",
-     SLACcitation  = "%%CITATION = ANMAA,93,139;%%"
-}
-@Article{Aubin:2006cc,
-     author    = "Aubin, C. and Blum, T.",
-     title     = "{Hadronic contributions to the muon g-2 from the lattice}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "162",
-     year      = "2006",
-     pages     = "251-255",
-     SLACcitation  = "%%CITATION = NUPHZ,162,251;%%"
-}
-@Article{Aubin:2006xv,
-     author    = "Aubin, C. and Blum, T.",
-     title     = "{Calculating the hadronic vacuum polarization and leading
-                  hadronic  contribution to the muon anomalous magnetic
-                  moment with improved  staggered quarks}",
-     journal   = "Phys. Rev.",
-     volume    = "D75",
-     year      = "2007",
-     pages     = "114502",
-     eprint    = "hep-lat/0608011",
-     SLACcitation  = "%%CITATION = HEP-LAT/0608011;%%"
-}
-@Article{BAGEL,
- author="P.A. Boyle",
- year=2005,
- eprint=" http://www.ph.ed.ac.uk/\~{ }paboyle/bagel/Bagel.html"
- }
-@Article{Baikov:2004ku,
-     author    = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
-     title     = "{Vacuum polarization in pQCD: First complete O(alpha(s)**4)
-                  result}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "135",
-     year      = "2004",
-     pages     = "243-246",
-     SLACcitation  = "%%CITATION = NUPHZ,135,243;%%"
-}
-@Article{Baikov:2005rw,
-     author    = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
-     title     = "{Scalar correlator at O(alpha(s)**4), Higgs decay into b-
-                  quarks and  bounds on the light quark masses}",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "96",
-     year      = "2006",
-     pages     = "012003",
-     eprint    = "hep-ph/0511063",
-     SLACcitation  = "%%CITATION = HEP-PH/0511063;%%"
-}
-@Article{Baikov:2008jh,
-     author    = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
-     title     = "{Hadronic Z- and tau-Decays in Order alpha_s^4}",
-     year      = "2008",
-     eprint    = "0801.1821",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = ARXIV:0801.1821;%%"
-}
-@Article{Bali:2000vr,
-     author    = "Bali, G. S. and others",
- collaboration = "TXL",
-     title     = "Static potentials and glueball masses from {QCD} simulations
-                  with {Wilson}  sea quarks",
-     journal   = "Phys. Rev.",
-     volume    = "D62",
-     year      = "2000",
-     pages     = "054503",
-     eprint    = "hep-lat/0003012",
-     SLACcitation  = "%%CITATION = HEP-LAT 0003012;%%"
-}
-@Article{Bali:2004pb,
-     author    = "Bali, G. S. and others",
-     title     = "String breaking with dynamical {Wilson} fermions",
-     journal   = "Nucl. Phys. Proc. Supl.",
-     volume    = "140",
-     pages     = "609-611",
-     year      = "2004",
-     eprint    = "hep-lat/0409137",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409137;%%"
-}
-@Article{Bali:2005fu,
-     author    = "Bali, G. S. and Neff, H. and Duessel, T. and
-                  Lippert, T. and Schilling, K.",
- collaboration = "SESAM",
-     title     = "Observation of string breaking in {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D71",
-     year      = "2005",
-     pages     = "114513",
-     eprint    = "hep-lat/0505012",
-     SLACcitation  = "%%CITATION = HEP-LAT 0505012;%%"
-}
-@Article{Bar:2006zj,
-     author    = "B{\"a}r, O. and Jansen, K. and Schaefer, S. and Scorzato, L.
-                  and Shindler, A.",
-     title     = "Overlap fermions on a twisted mass sea",
-     year      = "2006",
-     eprint    = "hep-lat/0609039",
-     SLACcitation  = "%%CITATION = HEP-LAT 0609039;%%"
-}
-@Article{Baxter:1993bv,
-     author    = "Baxter, R. M. and others",
- collaboration = "UK{QCD}",
-     title     = "Quenched heavy light decay constants",
-     journal   = "Phys. Rev.",
-     volume    = "D49",
-     year      = "1994",
-     pages     = "1594-1605",
-     eprint    = "hep-lat/9308020",
-     SLACcitation  = "%%CITATION = HEP-LAT 9308020;%%"
-}
-@Article{Beane:2004tw,
-     author    = "Beane, Silas R.",
-     title     = "{Nucleon masses and magnetic moments in a finite volume}",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "034507",
-     eprint    = "hep-lat/0403015",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.70.034507",
-     SLACcitation  = "%%CITATION = HEP-LAT/0403015;%%"
-}
-@Article{Becher:1999he,
-     author    = "Becher, Thomas and Leutwyler, H.",
-     title     = "Baryon chiral perturbation theory in manifestly Lorentz
-                  invariant form",
-     journal   = "Eur. Phys. J.",
-     volume    = "C9",
-     year      = "1999",
-     pages     = "643-671",
-     eprint    = "hep-ph/9901384",
-     SLACcitation  = "%%CITATION = HEP-PH/9901384;%%"
-}
-@Article{Bietenholz:2004sa,
-     author    = "Bietenholz, W. and others",
- collaboration = "\xlf",
-     title     = "Comparison between overlap and twisted mass fermions
-                  towards the chiral  limit",
-     year      = "2004",
-     eprint    = "hep-lat/0409109",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409109;%%"
-}
-@Article{Bietenholz:2004wv,
-     author    = "Bietenholz, W. and others",
- collaboration = "\xlf",
-     title     = "Going chiral: Overlap versus twisted mass fermions",
-     journal   = "JHEP",
-     volume    = "12",
-     year      = "2004",
-     pages     = "044",
-     eprint    = "hep-lat/0411001",
-     SLACcitation  = "%%CITATION = HEP-LAT 0411001;%%"
-}
-@Article{Blossier:2007vv,
-     author    = "Blossier, B. and others",
- collaboration = "ETM",
-     title     = "{Light quark masses and pseudoscalar decay constants from
-                  Nf=2 Lattice QCD with twisted mass fermions}",
-     year      = "2007",
-     eprint    = "0709.4574",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = ARXIV:0709.4574;%%"
-}
-@Article{Blum:1994eh,
-     author    = "Blum, Tom and others",
-     title     = "QCD thermodynamics with Wilson quarks at large kappa",
-     journal   = "Phys. Rev.",
-     volume    = "D50",
-     year      = "1994",
-     pages     = "3377-3381",
-     eprint    = "hep-lat/9404006",
-     SLACcitation  = "%%CITATION = HEP-LAT 9404006;%%"
-}
-@Article{Blum:2000kn,
-     author    = "Blum, T. and others",
-     title     = "Quenched lattice {QCD} with domain wall fermions and the
-                  chiral limit",
-     journal   = "Phys. Rev.",
-     volume    = "D69",
-     year      = "2004",
-     pages     = "074502",
-     eprint    = "hep-lat/0007038",
-     SLACcitation  = "%%CITATION = HEP-LAT 0007038;%%"
-}
-@Article{Bodin:2005gg,
-     author    = "Bodin, F. and others",
- collaboration = "ApeNEXT",
-     title     = "The {apeNEXT} project",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "176-182",
-     SLACcitation  = "%%CITATION = NUPHZ,140,176;%%"
-}
-@Article{Bolder:2000un,
-     author    = "Bolder, B. and others",
-     title     = "A high precision study of the Q anti-Q potential from
-                  {Wilson} loops in  the regime of string breaking",
-     journal   = "Phys. Rev.",
-     volume    = "D63",
-     year      = "2001",
-     pages     = "074504",
-     eprint    = "hep-lat/0005018",
-     SLACcitation  = "%%CITATION = HEP-LAT 0005018;%%"
-}
-@Article{Boucaud:2007uk,
-     author    = "Boucaud, Ph. and others",
- collaboration = "ETM",
-     title     = "Dynamical twisted mass fermions with light quarks",
-     year      = "2007",
-     eprint    = "hep-lat/0701012",
-     SLACcitation  = "%%CITATION = HEP-LAT 0701012;%%"
-}
-@Article{Boucaud:2008xu,
-     author    = "Boucaud, Ph. and others",
- collaboration = "ETM",
-     title     = "{Dynamical Twisted Mass Fermions with Light Quarks:
-                  Simulation and Analysis Details}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "179",
-     year      = "2008",
-     pages     = "695-715",
-     eprint    = "0803.0224",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     doi       = "10.1016/j.cpc.2008.06.013",
-     SLACcitation  = "%%CITATION = 0803.0224;%%"
-}
-@Article{Boughezal:2006px,
-     author    = "Boughezal, R. and Czakon, M. and Schutzmeier, T.",
-     title     = "{Charm and bottom quark masses from perturbative QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D74",
-     year      = "2006",
-     pages     = "074006",
-     eprint    = "hep-ph/0605023",
-     SLACcitation  = "%%CITATION = HEP-PH/0605023;%%"
-}
-@Article{Boyle:2005fb,
-     author    = "Boyle, P. A. and others",
-     title     = "{QCDOC}: Project status and first results",
-     journal   = "J. Phys. Conf. Ser.",
-     volume    = "16",
-     year      = "2005",
-     pages     = "129-139",
-     SLACcitation  = "%%CITATION = 00462,16,129;%%"
+	archiveprefix = "arXiv",
+	author = "Clark, M.A. and Kennedy, A.D.",
+	doi = "10.1103/PhysRevLett.98.051601",
+	eprint = "hep-lat/0608015",
+	journal = "Phys.Rev.Lett.",
+	pages = "051601",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = HEP-LAT/0608015;\%\%",
+	title = "{Accelerating dynamical fermion computations using the rational hybrid Monte Carlo (RHMC) algorithm with multiple pseudofermion fields}",
+	volume = "98",
+	year = "2007"
 }
 
-@Article{Brower:1994er,
-     author    = "Brower, R. C. and Levi, A. R. and Orginos, K.",
-     title     = "Extrapolation methods for the Dirac inverter in hybrid
-                  Monte Carlo",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "42",
-     year      = "1995",
-     pages     = "855-857",
-     eprint    = "hep-lat/9412004",
-     SLACcitation  = "%%CITATION = HEP-LAT 9412004;%%"
+@article{'tHooft:1971fh,
+	author = "{'t Hooft}, G.",
+	journal = "Nucl. Phys.",
+	pages = "173--199",
+	slaccitation = "%\%CITATION = NUPHA,B33,173;\%\%",
+	title = "{Renormalization of massless Yang-Mills fields}",
+	volume = "B33",
+	year = "1971"
 }
 
-@Article{Brower:1995vx,
-     author    = "Brower, R. C. and Ivanenko, T. and Levi, A. R. and Orginos,
-                  K. N.",
-     title     = "Chronological inversion method for the Dirac matrix in
-                  hybrid Monte  Carlo",
-     journal   = "Nucl. Phys.",
-     volume    = "B484",
-     year      = "1997",
-     pages     = "353-374",
-     eprint    = "hep-lat/9509012",
-     SLACcitation  = "%%CITATION = HEP-LAT 9509012;%%"
-}
-@Article{Bunk:1995uv,
-     author    = "Bunk, B. and others",
-     title     = "A New simulation algorithm for lattice {QCD} with dynamical
-                  quarks",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "42",
-     year      = "1995",
-     pages     = "49-55",
-     eprint    = "hep-lat/9411016",
-     SLACcitation  = "%%CITATION = HEP-LAT 9411016;%%"
-}
-@Article{Bunk:1998rm,
-     author    = "Bunk, B. and Elser, S. and Frezzotti, R. and Jansen,
-                  K.",
-     title     = "Ordering monomial factors of polynomials in the product
-                  representation",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "118",
-     year      = "1999",
-     pages     = "95-109",
-     eprint    = "hep-lat/9805026",
-     SLACcitation  = "%%CITATION = HEP-LAT 9805026;%%"
-}
-@Article{Burrage:1998a,
-  author       = " K. Burrage and J. Erhel",
-  title        = "On the performance of various adaptive preconditioned GMRES strategies",
-  journal      = "Num. Lin. Alg. with Appl.",
-  year         = "1998",
-  volume       = "5",
-  pages        = "101-121"
-}
-@Article{Campbell:1987nv,
-     author    = "Campbell, N. A. and Huntley, A. and Michael, C.",
-     title     = "Heavy quark potentials and hybrid mesons from SU(3) lattice
-                  gauge theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B306",
-     year      = "1988",
-     pages     = "51",
-     SLACcitation  = "%%CITATION = NUPHA,B306,51;%%"
-}
-@Article{Capitani:2005jp,
-     author    = "Capitani, S. and others",
-     title     = "Parton distribution functions with twisted mass fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B639",
-     year      = "2006",
-     pages     = "520-526",
-     eprint    = "hep-lat/0511013",
-     SLACcitation  = "%%CITATION = HEP-LAT 0511013;%%"
-}
-@Article{Chen:2003im,
-     author    = "Chen, Y. and others",
-     title     = "Chiral logarithms in quenched {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "034502",
-     eprint    = "hep-lat/0304005",
-     SLACcitation  = "%%CITATION = HEP-LAT 0304005;%%"
-}
-@Book{Cheng:2000ct,
-     author    = "Cheng, T. P. and Li, L. F.",
-     title     = "Gauge theory of elementary particle physics: Problems and
-                  solutions",
-     publisher = "Oxford, UK: Clarendon",
-     year      = "2000",
-     pages     = "306",
-     edition   = "",
-}
-@Article{Chetyrkin:1990kr,
-     author    = "Chetyrkin, K. G. and K{\"u}hn, Johann H.",
-     title     = "{Mass corrections to the Z decay rate}",
-     journal   = "Phys. Lett.",
-     volume    = "B248",
-     year      = "1990",
-     pages     = "359-364",
-     SLACcitation  = "%%CITATION = PHLTA,B248,359;%%"
-}
-@Article{Chetyrkin:1996cf,
-     author    = "Chetyrkin, K. G. and K{\"u}hn, Johann H. and Steinhauser, M.",
-     title     = "{Three-loop polarization function and O(alpha(s)**2)
-                  corrections to the  production of heavy quarks}",
-     journal   = "Nucl. Phys.",
-     volume    = "B482",
-     year      = "1996",
-     pages     = "213-240",
-     eprint    = "hep-ph/9606230",
-     SLACcitation  = "%%CITATION = HEP-PH/9606230;%%"
-}
-@Article{Chetyrkin:1997mb,
-     author    = "Chetyrkin, K. G. and K{\"u}hn, Johann H. and Steinhauser, M.",
-     title     = "{Heavy quark current correlators to O(alpha(s)**2)}",
-     journal   = "Nucl. Phys.",
-     volume    = "B505",
-     year      = "1997",
-     pages     = "40-64",
-     eprint    = "hep-ph/9705254",
-     SLACcitation  = "%%CITATION = HEP-PH/9705254;%%"
-}
-@Article{Chetyrkin:1998ix,
-     author    = "Chetyrkin, K. G. and Harlander, R. and Steinhauser, M.",
-     title     = "{Singlet polarization functions at O(alpha(s)**2)}",
-     journal   = "Phys. Rev.",
-     volume    = "D58",
-     year      = "1998",
-     pages     = "014012",
-     eprint    = "hep-ph/9801432",
-     SLACcitation  = "%%CITATION = HEP-PH/9801432;%%"
-}
-@Article{Chetyrkin:2000zk,
-     author    = "Chetyrkin, K. G. and Harlander, R. V. and K{\"u}hn, Johann H.",
-     title     = "{Quartic mass corrections to R(had) at O(alpha(s)**3)}",
-     journal   = "Nucl. Phys.",
-     volume    = "B586",
-     year      = "2000",
-     pages     = "56-72",
-     eprint    = "hep-ph/0005139",
-     SLACcitation  = "%%CITATION = HEP-PH/0005139;%%"
-}
-@Article{Chetyrkin:2006xg,
-     author    = "Chetyrkin, K. G. and K{\"u}hn, J. H. and Sturm, C.",
-     title     = "{Four-loop moments of the heavy quark vacuum polarization
-                  function in  perturbative QCD}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C48",
-     year      = "2006",
-     pages     = "107-110",
-     eprint    = "hep-ph/0604234",
-     SLACcitation  = "%%CITATION = HEP-PH/0604234;%%"
-}
-@Article{Chiarappa:2004ry,
-     author    = "Chiarappa, T. and others",
-     title     = "{Comparing iterative methods for overlap and twisted mass
-                   fermions}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "853-855",
-     eprint    = "hep-lat/0409107",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/j.nuclphysbps.2004.11.281",
-     SLACcitation  = "%%CITATION = HEP-LAT/0409107;%%"
-}
-@Article{Chiarappa:2006ae,
-     author    = "Chiarappa, T. and others",
-     title     = "{Numerical simulation of {QCD} with u, d, s and c quarks in
-                  the twisted-mass {W}ilson formulation}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C50",
-     year      = "2007",
-     pages     = "373-383",
-     eprint    = "hep-lat/0606011",
-     archivePrefix = "arXiv",
-     doi       = "10.1140/epjc/s10052-006-0204-4",
-     SLACcitation  = "%%CITATION = HEP-LAT/0606011;%%"
-}
-@Article{Chiarappa:2006hz,
-     author    = "Chiarappa, T. and others",
-     title     = "{Iterative methods for overlap and twisted mass fermions}",
-     year      = "2008",
-     journal   = "Comput. Sci. Disc.",
-     volume    = "01",
-     pages     = "015001",
-     eprint    = "hep-lat/0609023",
-     archivePrefix = "arXiv",
-     SLACcitation  = "%%CITATION = HEP-LAT/0609023;%%"
-}
-@Article{Cichy:2008gk,
-     author    = "Cichy, K. and Gonzalez Lopez, J. and Jansen, K. and Kujawa,
-                  A. and Shindler, A.",
-     title     = "{Twisted Mass, Overlap and Creutz Fermions: Cut-off Effects
-                  at Tree-level of Perturbation Theory}",
-     journal   = "Nucl. Phys.",
-     volume    = "B800",
-     year      = "2008",
-     pages     = "94-108",
-     eprint    = "0802.3637",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     doi       = "10.1016/j.nuclphysb.2008.03.004",
-     SLACcitation  = "%%CITATION = 0802.3637;%%"
-}
-@Article{Clark:2004cq,
-     author    = "Clark, M. A. and Kennedy, A. D.",
-     title     = "Accelerating fermionic molecular dynamics",
-     year      = "2004",
-     eprint    = "hep-lat/0409134",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409134;%%"
+@article{'tHooft:1971rn,
+	author = "{'t Hooft}, G.",
+	journal = "Nucl. Phys.",
+	pages = "167--188",
+	slaccitation = "%\%CITATION = NUPHA,B35,167;\%\%",
+	title = "{Renormalizable lagrangians for massive Yang-Mills fields}",
+	volume = "B35",
+	year = "1971"
 }
 
-@Article{Clark:2005sq,
-     author    = "Clark, M. A. and de Forcrand, Ph. and Kennedy, A. D.",
-     title     = "Algorithm shootout: R versus RHMC",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2005",
-     pages     = "115",
-     eprint    = "hep-lat/0510004",
-     SLACcitation  = "%%CITATION = HEP-LAT 0510004;%%"
-}
-@Article{Clark:2006fx,
-     author    = "Clark, M. A. and Kennedy, A. D.",
-     title     = "Accelerating dynamical fermion computations using the
-                  rational hybrid {Monte} {Carlo} ({RHMC}) algorithm with multiple
-                  pseudofermion fields",
-     year      = "2006",
-     eprint    = "hep-lat/0608015",
-     SLACcitation  = "%%CITATION = HEP-LAT 0608015;%%"
-}
-@Article{Colangelo:2001df,
-     author    = "Colangelo, G. and Gasser, J. and Leutwyler, H.",
-     title     = "{pi pi scattering}",
-     journal   = "Nucl. Phys.",
-     volume    = "B603",
-     year      = "2001",
-     pages     = "125-179",
-     eprint    = "hep-ph/0103088",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/S0550-3213(01)00147-X",
-     SLACcitation  = "%%CITATION = HEP-PH/0103088;%%"
-}
-@Article{Colangelo:2003hf,
-     author    = "Colangelo, Gilberto and D{\"u}rr, Stephan",
-     title     = "The pion mass in finite volume",
-     journal   = "Eur. Phys. J.",
-     volume    = "C33",
-     year      = "2004",
-     pages     = "543-553",
-     eprint    = "hep-lat/0311023",
-     SLACcitation  = "%%CITATION = HEP-LAT/0311023;%%"
-}
-@Article{Colangelo:2005gd,
-     author    = "Colangelo, Gilberto and D{\"u}rr, Stephan and Haefeli,
-                  Christoph",
-     title     = "Finite volume effects for meson masses and decay
-                  constants",
-     journal   = "Nucl. Phys.",
-     volume    = "B721",
-     year      = "2005",
-     pages     = "136-174",
-     eprint    = "hep-lat/0503014",
-     SLACcitation  = "%%CITATION = HEP-LAT 0503014;%%"
-}
-@Article{Colangelo:2006mp,
-     author    = "Colangelo, Gilberto and Haefeli, Christoph",
-     title     = "{Finite volume effects for the pion mass at two loops}",
-     journal   = "Nucl. Phys.",
-     volume    = "B744",
-     year      = "2006",
-     pages     = "14-33",
-     eprint    = "hep-lat/0602017",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/j.nuclphysb.2006.03.010",
-     SLACcitation  = "%%CITATION = HEP-LAT/0602017;%%"
-}
-@Book{Collins:1994ab,
-     author    = "Collins, J.C.",
-     title     = "Renormalisation",
-     publisher = "Cambridge University Press",
-     series    = "Cambridge Monographs on Mathematical Physics",
-     year      = "1994",
-     edition   = "",
-}
-@Article{Creutz:1984fj,
-     author    = "Creutz, M. and Gocksch, A. and Ogilvie, M. and
-                  Okawa, M.",
-     title     = "Microcanonical renormalization group",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "53",
-     year      = "1984",
-     pages     = "875",
-     SLACcitation  = "%%CITATION = PRLTA,53,875;%%"
-}
-@Article{Creutz:1989wt,
-     author    = "Creutz, M. and Gocksch, A.",
-     title     = "Higher order hybrid monte carlo algorithms",
-     note     = "BNL-42601"
-}
-@Article{Creutz:1996bg,
-     author    = "Creutz, Michael",
-     title     = "Wilson fermions at finite temperature",
-     year      = "1996",
-     eprint    = "hep-lat/9608024",
-     SLACcitation  = "%%CITATION = HEP-LAT 9608024;%%"
-}
-@Article{Creutz:1998ee,
-     author    = "Creutz, M.",
-     title     = "Evaluating Grassmann integrals",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "81",
-     year      = "1998",
-     pages     = "3555-3558",
-     eprint    = "hep-lat/9806037",
-     SLACcitation  = "%%CITATION = HEP-LAT 9806037;%%"
-}
-@Article{Cundy:2005pi,
-     author    = "Cundy, N. and others",
-     title     = "Numerical Methods for the {QCD} Overlap Operator IV: Hybrid
-                  Monte Carlo",
-     year      = "2005",
-     eprint    = "hep-lat/0502007",
-     SLACcitation  = "%%CITATION = HEP-LAT 0502007;%%"
-}
-@Article{David:1984ys,
-     author    = "David, F. and Hamber, H. W.",
-     title     = "Chiral condensate with {Wilson} fermions",
-     journal   = "Nucl. Phys.",
-     volume    = "B248",
-     year      = "1984",
-     pages     = "381",
-     SLACcitation  = "%%CITATION = NUPHA,B248,381;%%"
-}
-@Article{Davies:2008sw,
-     author    = "Davies, C. T. H. and others",
- collaboration = "HPQCD",
-     title     = "{Update: Accurate Determinations of $\alpha_s$ from
-                  Realistic Lattice QCD}",
-     year      = "2008",
-     eprint    = "0807.1687",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0807.1687;%%"
-}
-@Article{DeGrand:1990dk,
-     author    = "DeGrand, T. A. and Rossi, P.",
-     title     = "Conditioning techniques for dynamical fermions",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "60",
-     year      = "1990",
-     pages     = "211-214",
-     SLACcitation  = "%%CITATION = CPHCB,60,211;%%"
-}
-@Article{DeGrand:1990ip,
-     author    = "DeGrand, T. A.",
-     title     = "Resonance masses from Monte Carlo simulations (with
-                  emphasis on the rho meson)",
-     journal   = "Phys. Rev.",
-     volume    = "D43",
-     year      = "1991",
-     pages     = "2296-2300",
-     SLACcitation  = "%%CITATION = PHRVA,D43,2296;%%"
-}
-@Article{DeGrand:2002vu,
-     author    = "DeGrand, Thomas and Hasenfratz, Anna and Kovacs, Tamas G.",
-     title     = "Improving the chiral properties of lattice fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D67",
-     year      = "2003",
-     pages     = "054501",
-     eprint    = "hep-lat/0211006",
-     SLACcitation  = "%%CITATION = HEP-LAT 0211006;%%"
-}
-@Article{DeTar:2007ni,
-     author    = "DeTar, Carleton and Levkova, L.",
-     title     = "Effects of the disconnected flavor singlet corrections on
-                  the hyperfine splitting in charmonium",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "116",
-     eprint    = "0710.1322",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = ARXIV:0710.1322;%%"
-}
-@Article{DelDebbio:2006cn,
-     author    = "Del Debbio, L. and Giusti, L. and Luscher, M. and
-                  Petronzio, R. and Tantalo, N.",
-     title     = "QCD with light Wilson quarks on fine lattices. I: First
-                  experiences and physics results",
-     journal   = "JHEP",
-     volume    = "02",
-     year      = "2007",
-     pages     = "056",
-     eprint    = "hep-lat/0610059",
-     SLACcitation  = "%%CITATION = HEP-LAT 0610059;%%"
-}
-@Article{DellaMorte:2000yp,
-     author    = "Della Morte, M. and Frezzotti, R. and Heitger, J. and Sint,
-                  S.",
-     title     = "Non-perturbative scaling tests of twisted mass {QCD}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "94",
-     year      = "2001",
-     pages     = "617-621",
-     eprint    = "hep-lat/0010091",
-     SLACcitation  = "%%CITATION = HEP-LAT 0010091;%%"
-}
-@Article{DellaMorte:2001tu,
-     author    = "Della Morte, M. and Frezzotti, R. and Heitger, J.",
-     title     = "Quenched twisted mass {QCD} at small quark masses and in
-                  large volume",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "260-262",
-     eprint    = "hep-lat/0110166",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110166;%%"
+@unpublished{'tHooft:1972aa,
+	author = "{'t Hooft}, G.",
+	note = "Unpublished remarks at the 1972 Marseille Conference on Yang-Mills Fields",
+	title = "{}"
 }
 
-@Article{DellaMorte:2001ys,
-     author    = "Della Morte, M. and Frezzotti, R. and Heitger,
-                  J. and Sint, S.",
- collaboration = "ALPHA",
-     title     = "Cutoff effects in twisted mass lattice {QCD}",
-     journal   = "JHEP",
-     volume    = "10",
-     year      = "2001",
-     pages     = "041",
-     eprint    = "hep-lat/0108019",
-     SLACcitation  = "%%CITATION = HEP-LAT 0108019;%%"
-}                                                                               
-@Article{DellaMorte:2003jj,
-     author    = "Della Morte, M. and others",
- collaboration = "ALPHA",
-     title     = "Simulating the Schroedinger functional with two pseudo-
-                  fermions",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "156",
-     year      = "2003",
-     pages     = "62-72",
-     eprint    = "hep-lat/0307008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0307008;%%"
-}                                                                               
-@Article{DellaMorte:2003mn,
-     author    = "Della Morte, M. and others",
- collaboration = "ALPHA",
-     title     = "Lattice HQET with exponentially improved statistical
-                  precision",
-     journal   = "Phys. Lett.",
-     volume    = "B581",
-     year      = "2004",
-     pages     = "93-98",
-     eprint    = "hep-lat/0307021",
-     SLACcitation  = "%%CITATION = HEP-LAT 0307021;%%"
-}             
-@Article{DellaMorte:2003mw,
-     author    = "Della Morte, M. and others",
- collaboration = "ALPHA",
-     title     = "Static quarks with improved statistical precision",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "129",
-     year      = "2004",
-     pages     = "346-348",
-     eprint    = "hep-lat/0309080",
-     SLACcitation  = "%%CITATION = HEP-LAT 0309080;%%"
-}                                                                  
-@Article{DellaMorte:2005yc,
-     author    = "Della Morte, M. and Shindler, A. and Sommer,
-                  R.",
-     title     = "On lattice actions for static quarks",
-     year      = "2005",
-     eprint    = "hep-lat/0506008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0506008;%%"
-}
-@Article{Dimopoulos:2006dm,
-     author    = "Dimopoulos, P. and others",
- collaboration = "ALPHA",
-     title     = "A precise determination of B(K) in quenched QCD",
-     journal   = "Nucl. Phys.",
-     volume    = "B749",
-     year      = "2006",
-     pages     = "69-108",
-     eprint    = "hep-ph/0601002",
-     SLACcitation  = "%%CITATION = HEP-PH 0601002;%%"
-}
-@Article{Dimopoulos:2007fn,
-     author    = "Dimopoulos, P. and others",
-     title     = "{Renormalisation of quark bilinears with Nf=2 Wilson
-                  fermions and tree-level improved gauge action}",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "241",
-     eprint    = "0710.0975",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0710.0975;%%"
-}
-@Article{Dimopoulos:2007qy,
-     author    = "Dimopoulos, Petros and Frezzotti, Roberto and Herdoiza,
-                  Gregorio and Urbach, Carsten and Wenger, Urs",
- collaboration = "ETM",
-     title     = "{Scaling and low energy constants in lattice QCD with N_f=2
-                  maximally twisted Wilson quarks}",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "102",
-     eprint    = "0710.2498",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0710.2498;%%"
-}
-@Article{Dimopoulos:2008sy,
-     author    = "Dimopoulos, Petros and others",
- collaboration = "ETM",
-     title     = "{Scaling and chiral extrapolation of pion mass and decay
-                  constant with maximally twisted mass QCD}",
-     year      = "2008",
-     eprint    = "0810.2873",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0810.2873;%%"
-}
-@Article{Dong:2001fm,
-     author    = "Dong, S. J. and others",
-     title     = "Chiral properties of pseudoscalar mesons on a quenched
-                  20**4 lattice  with overlap fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D65",
-     year      = "2002",
-     pages     = "054507",
-     eprint    = "hep-lat/0108020",
-     SLACcitation  = "%%CITATION = HEP-LAT 0108020;%%"
-}
-@Article{Duane:1987de,
-     author    = "Duane, S. and Kennedy, A. D. and Pendleton, B. J. and
-                  Roweth, D.",
-     title     = "{H}ybrid monte carlo",
-     journal   = "Phys. Lett.",
-     volume    = "B195",
-     year      = "1987",
-     pages     = "216-222",
-     SLACcitation  = "%%CITATION = PHLTA,B195,216;%%"
-}
-@Article{Edwards:1996vs,
-     author    = "Edwards, R. G. and Horvath, I. and Kennedy, A. D.",
-     title     = "Instabilities and non-reversibility of molecular dynamics
-                  trajectories",
-     journal   = "Nucl. Phys.",
-     volume    = "B484",
-     year      = "1997",
-     pages     = "375-402",
-     eprint    = "hep-lat/9606004",
-     SLACcitation  = "%%CITATION = HEP-LAT 9606004;%%"
-}
-@Article{Edwards:2004sx,
-     author    = "Edwards, Robert G. and Joo, Balint",
- collaboration = "SciDAC",
-     title     = "The {Chroma} software system for lattice {QCD}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "832",
-     eprint    = "hep-lat/0409003",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409003;%%"
-}
-@Article{Eichten:1989zv,
-     author    = "Eichten, E. and Hill, B.",
-     title     = "An effective field theory for the calculation of matrix
-                  elements involving heavy quarks",
-     journal   = "Phys. Lett.",
-     volume    = "B234",
-     year      = "1990",
-     pages     = "511",
-     SLACcitation  = "%%CITATION = PHLTA,B234,511;%%"
-}
-@Article{Farchioni:2002vn,
-     author    = "Farchioni, F. and Gebert, C. and Montvay, I.
-                  and Scorzato, L.",
-     title     = "Numerical simulation tests with light dynamical quarks",
-     journal   = "Eur. Phys. J.",
-     volume    = "C26",
-     year      = "2002",
-     pages     = "237-251",
-     eprint    = "hep-lat/0206008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0206008;%%"
-}
-@Article{Farchioni:2004fs,
-     author    = "Farchioni, F. and others",
-     title     = "The phase structure of lattice {QCD} with {Wilson} quarks and
-                  renormalization group improved gluons",
-     journal   = "Eur. Phys. J.",
-     volume    = "C42",
-     year      = "2005",
-     pages     = "73-87",
-     eprint    = "hep-lat/0410031",
-     SLACcitation  = "%%CITATION = HEP-LAT 0410031;%%"
-}
-@Article{Farchioni:2004ma,
-     author    = "Farchioni, F. and others",
-     title     = "Exploring the phase structure of lattice {{QCD}} with twisted
-                  mass quarks",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "240-245",
-     eprint    = "hep-lat/0409098",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409098;%%"
-}
-@Article{Farchioni:2004us,
-     author    = "Farchioni, F. and others",
-     title     = "Twisted mass quarks and the phase structure of lattice
-                  {QCD}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C39",
-     year      = "2005",
-     pages     = "421-433",
-     eprint    = "hep-lat/0406039",
-     SLACcitation  = "%%CITATION = HEP-LAT 0406039;%%"
-}
-@Article{Farchioni:2005ec,
-     author    = "Farchioni, Federico and others",
-     title     = "Dynamical twisted mass fermions",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "072",
-     eprint    = "hep-lat/0509131",
-     SLACcitation  = "%%CITATION = HEP-LAT 0509131;%%"
-}
-@Article{Farchioni:2005hf,
-     author    = "Farchioni, F. and others",
-     title     = "Twisted mass fermions: Neutral pion masses from
-                  disconnected contributions",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "033",
-     eprint    = "hep-lat/0509036",
-     SLACcitation  = "%%CITATION = HEP-LAT 0509036;%%"
-}
-@Article{Farchioni:2005tu,
-     author    = "Farchioni, F. and others",
-     title     = "Lattice spacing dependence of the first order phase
-                  transition for  dynamical twisted mass fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B624",
-     year      = "2005",
-     pages     = "324-333",
-     eprint    = "hep-lat/0506025",
-     SLACcitation  = "%%CITATION = HEP-LAT 0506025;%%"
-}
-@Article{Feldmann:1999uf,
-     author    = "Feldmann, Thorsten",
-     title     = "{Quark structure of pseudoscalar mesons}",
-     journal   = "Int. J. Mod. Phys.",
-     volume    = "A15",
-     year      = "2000",
-     pages     = "159-207",
-     eprint    = "hep-ph/9907491",
-     SLACcitation  = "%%CITATION = HEP-PH/9907491;%%"
-}
-@Article{Feynman:1948aa,
-     author    = "Feynman, R. P.",
-     title     = "Space-time approach to non-relativistic quantum mechanics",
-     journal   = "Rev. Mod. Phys.",
-     volume    = "20",
-     year      = "1948",
-     pages     = "367-387",
-     SLACcitation  = "%%CITATION = RMPHA,20,367;%%"
-}
-@Article{Fischer:1996th,
-     author    = "Fischer, S. and others",
-     title     = "A Parallel SSOR Preconditioner for Lattice {QCD}",
-     journal   = "Comp. Phys. Commun.",
-     volume    = "98",
-     year      = "1996",
-     pages     = "20-34",
-     eprint    = "hep-lat/9602019",
-     SLACcitation  = "%%CITATION = HEP-LAT 9602019;%%"
-}
-@Article{Fokkema:1998aa,
-     author    = "Fokkema, D.~R. and Sleijpen, G.~L.~G. and Van~der~Vorst, H.~A.",
-     title     = "{J}acobi-{D}avidson style {QR} and {QZ} algorithms for
-                  the reduction of matrix pencils",
-     journal   = "J. Sci. Comput.",
-     volume    = "20",
-     year      = "1998",
-     pages     = "94-125",
-}
-@Article{Foster:1998vw,
-     author    = "Foster, M. and Michael, C.",
-     collaboration = "UKQCD",
-     title     = "Quark mass dependence of hadron masses from lattice {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D59",
-     year      = "1999",
-     pages     = "074503",
-     eprint    = "hep-lat/9810021",
-     SLACcitation  = "%%CITATION = HEP-LAT 9810021;%%"
-}
-@Article{Freund,
-     author    = "Freund, R.W.",
-     journal   = "in Numerical Linear Algebra, L.\ Reichel, A.\ Ruttan and R.S.\ Varga (eds.)",
-     year      = "1993",
-     pages     = "p. 101",
-}
-@Article{Frezzotti:1997ym,
-     author    = "Frezzotti, R. and Jansen, K.",
-     title     = "A polynomial hybrid Monte Carlo algorithm",
-     journal   = "Phys. Lett.",
-     volume    = "B402",
-     year      = "1997",
-     pages     = "328-334",
-     eprint    = "hep-lat/9702016",
-     SLACcitation  = "%%CITATION = HEP-LAT 9702016;%%"
-}
-@Article{Frezzotti:1998eu,
-     author    = "Frezzotti, R. and Jansen, K.",
-     title     = "The {PHMC} algorithm for simulations of dynamical fermions.
-                  {I}: Description and properties",
-     journal   = "Nucl. Phys.",
-     volume    = "B555",
-     year      = "1999",
-     pages     = "395-431",
-     eprint    = "hep-lat/9808011",
-     SLACcitation  = "%%CITATION = HEP-LAT 9808011;%%"
-}
-@ArticleF{Frezzotti:1998yp,
-     author    = "Frezzotti, R. and Jansen, K.",
-     title     = "The {PHMC} algorithm for simulations of dynamical fermions.
-                  {II}:  Performance analysis",
-     journal   = "Nucl. Phys.",
-     volume    = "B555",
-     year      = "1999",
-     pages     = "432-453",
-     eprint    = "hep-lat/9808038",
-     SLACcitation  = "%%CITATION = HEP-LAT 9808038;%%"
-}
-@Article{Frezzotti:1999vv,
-     author    = "Frezzotti, R. and Grassi, P. A. and Sint,
-                  S. and Weisz, P.",
-     title     = "A local formulation of lattice {QCD} without unphysical
-                  fermion zero modes",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "83",
-     year      = "2000",
-     pages     = "941-946",
-     eprint    = "hep-lat/9909003",
-     SLACcitation  = "%%CITATION = HEP-LAT 9909003;%%"
-}
-@Article{Frezzotti:2000nk,
-     author    = "Frezzotti, R. and Grassi, P. A. and Sint,
-                  S. and Weisz, P.",
- collaboration = "ALPHA",
-     title     = "Lattice {QCD} with a chirally twisted mass term",
-     journal   = "JHEP",
-     volume    = "08",
-     year      = "2001",
-     pages     = "058",
-     eprint    = "hep-lat/0101001",
-     SLACcitation  = "%%CITATION = HEP-LAT 0101001;%%"
-}
-@Article{Frezzotti:2001du,
-     author    = "Frezzotti, R. and Sint, S.",
-     title     = "Some remarks on {O(a)} improved twisted mass {QCD}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "814-816",
-     eprint    = "hep-lat/0110140",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110140;%%"
-}
-@Article{Frezzotti:2001ea,
-     author    = "Frezzotti, R. and Sint, S. and Weisz, P.",
- collaboration = "ALPHA",
-     title     = "{O(a)} improved twisted mass lattice {QCD}",
-     journal   = "JHEP",
-     volume    = "07",
-     year      = "2001",
-     pages     = "048",
-     eprint    = "hep-lat/0104014",
-     SLACcitation  = "%%CITATION = HEP-LAT 0104014;%%"
-}
-@Article{Frezzotti:2003ni,
-     author    = "Frezzotti, R. and Rossi, G. C.",
-     title     = "Chirally improving {Wilson} fermions. {I}: {O(a)} improvement",
-     journal   = "JHEP",
-     volume    = "08",
-     year      = "2004",
-     pages     = "007",
-     eprint    = "hep-lat/0306014",
-     SLACcitation  = "%%CITATION = HEP-LAT 0306014;%%"
-}
-@Article{Frezzotti:2003xj,
-     author    = "Frezzotti, R. and Rossi, G. C.",
-     title     = "Twisted-mass lattice {QCD} with mass non-degenerate quarks",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "128",
-     year      = "2004",
-     pages     = "193-202",
-     eprint    = "hep-lat/0311008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0311008;%%"
-}
-@Article{Frezzotti:2004wz,
-     author    = "Frezzotti, R. and Rossi, G. C.",
-     title     = "Chirally improving {Wilson} fermions. {II}: Four-quark
-                  operators",
-     journal   = "JHEP",
-     volume    = "10",
-     year      = "2004",
-     pages     = "070",
-     eprint    = "hep-lat/0407002",
-     SLACcitation  = "%%CITATION = HEP-LAT 0407002;%%"
-}
-@Article{Frezzotti:2005gi,
-     author    = "Frezzotti, R. and Martinelli, G. and Papinutto, M. and
-                  Rossi, G. C.",
-     title     = "Reducing cutoff effects in maximally twisted lattice {QCD}
-                  close to the  chiral limit",
-     journal   = "JHEP",
-     volume    = "04",
-     year      = "2006",
-     pages     = "038",
-     eprint    = "hep-lat/0503034",
-     SLACcitation  = "%%CITATION = HEP-LAT 0503034;%%"
-}
-@Article{Frezzotti:2007qv,
-     author    = "Frezzotti, R. and Rossi, G.",
-     title     = "{O(a^2) cutoff effects in Wilson fermion simulations}",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "277",
-     eprint    = "0710.2492",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0710.2492;%%"
-}
-@Article{Frezzotti:2008dr,
-     author    = "Frezzotti, R. and Lubicz, V. and Simula, S.",
- collaboration = "ETM",
-     title     = "{Electromagnetic form factor of the pion from twisted-mass
-                  lattice {QCD} at {Nf}=2}",
-     year      = "2008",
-     eprint    = "0812.4042",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0812.4042;%%"
-}
-@Article{Fritzsch:1973pi,
-     author    = "Fritzsch, H. and Gell-Mann, M. and Leutwyler, H.",
-     title     = "Advantages of the color octet gluon picture",
-     journal   = "Phys. Lett.",
-     volume    = "B47",
-     year      = "1973",
-     pages     = "365-368",
-     SLACcitation  = "%%CITATION = PHLTA,B47,365;%%"
-}
-@Article{Frommer:1994vn,
-     author    = "Frommer, A. and Hannemann, V. and Nockel, B. and Lippert,
-                  T. and Schilling, K.",
-     title     = "Accelerating {Wilson} fermion matrix inversions by means of
-                  the stabilized biconjugate gradient algorithm",
-     journal   = "Int. J. Mod. Phys.",
-     volume    = "C5",
-     year      = "1994",
-     pages     = "1073-1088",
-     eprint    = "hep-lat/9404013",
-     SLACcitation  = "%%CITATION = HEP-LAT 9404013;%%"
-}
-@Article{Frommer:1995ik,
-     author    = "Frommer, Andreas and Nockel, Bertold and Gusken, Stephan
-                  and Lippert, Thomas and Schilling, Klaus",
-     title     = "Many masses on one stroke: Economic computation of quark
-                  propagators",
-     journal   = "Int. J. Mod. Phys.",
-     volume    = "C6",
-     year      = "1995",
-     pages     = "627-638",
-     eprint    = "hep-lat/9504020",
-     SLACcitation  = "%%CITATION = HEP-LAT 9504020;%%"
-}
-@Article{Furman:1994ky,
-     author    = "Furman, V. and Shamir, Y.",
-     title     = "Axial symmetries in lattice QCD with Kaplan fermions",
-     journal   = "Nucl. Phys.",
-     volume    = "B439",
-     year      = "1995",
-     pages     = "54-78",
-     eprint    = "hep-lat/9405004",
-     SLACcitation  = "%%CITATION = HEP-LAT 9405004;%%"
-}
-@Article{Garden:1999fg,
-     author    = "Garden, J. and Heitger, J. and Sommer, R. and
-                  Wittig H.",
- collaboration = "ALPHA",
-     title     = "Precision computation of the strange quark's mass in
-                  quenched {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B571",
-     year      = "2000",
-     pages     = "237-256",
-     eprint    = "hep-lat/9906013",
-     SLACcitation  = "%%CITATION = HEP-LAT 9906013;%%"
-}
-@Article{Garron:2003cb,
-     author    = "Garron, N. and Giusti, L. and Hoelbling,
-                  C. and Lellouch, L. and Rebbi, C.",
-     title     = "B(K) from quenched {QCD} with exact chiral symmetry",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "92",
-     year      = "2004",
-     pages     = "042001",
-     eprint    = "hep-ph/0306295",
-     SLACcitation  = "%%CITATION = HEP-PH 0306295;%%"
-}
-@Article{Gasser:1982ap,
-     author    = "Gasser, J. and Leutwyler, H.",
-     title     = "Quark masses",
-     journal   = "Phys. Rept.",
-     volume    = "87",
-     year      = "1982",
-     pages     = "77-169",
-     SLACcitation  = "%%CITATION = PRPLC,87,77;%%"
+@article{'tHooft:1972fi,
+	author = "{'t Hooft}, G. and Veltman, M. J. G.",
+	journal = "Nucl. Phys.",
+	pages = "189--213",
+	slaccitation = "%\%CITATION = NUPHA,B44,189;\%\%",
+	title = "{Regularization and renormalization of gauge fields}",
+	volume = "B44",
+	year = "1972"
 }
 
-@Article{Gasser:1983yg,
-     author    = "Gasser, J. and Leutwyler, H.",
-     title     = "Chiral perturbation theory to one loop",
-     journal   = "Ann. Phys.",
-     volume    = "158",
-     year      = "1984",
-     pages     = "142",
-     SLACcitation  = "%%CITATION = APNYA,158,142;%%"
+@article{Abdel-Rehim:2004gx,
+	author = "Abdel-Rehim, A. M. and Lewis, R.",
+	eprint = "hep-lat/0410047",
+	journal = "Phys. Rev.",
+	pages = "014503",
+	slaccitation = "%\%CITATION = HEP-LAT 0410047;\%\%",
+	title = "{Twisted mass {QCD} for the pion electromagnetic form factor}",
+	volume = "D71",
+	year = "2005"
 }
-@Article{Gasser:1985gg,
-     author    = "Gasser, J. and Leutwyler, H.",
-     title     = "Chiral perturbation theory: expansions in the mass of the
-                  strange quark",
-     journal   = "Nucl. Phys.",
-     volume    = "B250",
-     year      = "1985",
-     pages     = "465",
-     SLACcitation  = "%%CITATION = NUPHA,B250,465;%%"
+
+@article{Abdel-Rehim:2005gz,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.",
+	eprint = "hep-lat/0503007",
+	journal = "Phys. Rev.",
+	pages = "094505",
+	slaccitation = "%\%CITATION = HEP-LAT/0503007;\%\%",
+	title = "{Spectrum of quenched twisted mass lattice QCD at maximal twist}",
+	volume = "D71",
+	year = "2005"
 }
-@Article{Gasser:1986vb,
-     author    = "Gasser, J. and Leutwyler, H.",
-     title     = "LIGHT QUARKS AT LOW TEMPERATURES",
-     journal   = "Phys. Lett.",
-     volume    = "B184",
-     year      = "1987",
-     pages     = "83",
-     SLACcitation  = "%%CITATION = PHLTA,B184,83;%%"
+
+@article{AbdelRehim:2004sp,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy",
+	eprint = "hep-lat/0408033",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "299--301",
+	slaccitation = "%\%CITATION = HEP-LAT/0408033;\%\%",
+	title = "{Pion form factor with twisted mass QCD}",
+	volume = "140",
+	year = "2005"
 }
-@Article{Gattringer:2003qx,
-     author    = "Gattringer, C. and others",
- collaboration = "BGR",
-     title     = "Quenched spectroscopy with fixed-point and chirally
-                  improved fermions",
-     journal   = "Nucl. Phys.",
-     volume    = "B677",
-     year      = "2004",
-     pages     = "3-51",
-     eprint    = "hep-lat/0307013",
-     SLACcitation  = "%%CITATION = HEP-LAT 0307013;%%"
+
+@article{AbdelRehim:2005gq,
+	author = "Abdel-Rehim, A. M. and Lewis, R. and Woloshyn, R. M.",
+	journal = "Int. J. Mod. Phys.",
+	pages = "6159--6168",
+	slaccitation = "%\%CITATION = IMPAE,A20,6159;\%\%",
+	title = "{Twisted mass lattice QCD and hadron phenomenology}",
+	volume = "A20",
+	year = "2005"
 }
-@Article{Gell-Mann:1964nj,
-     author    = "Gell-Mann, M.",
-     title     = "A Schematic model of baryons and mesons",
-     journal   = "Phys. Lett.",
-     volume    = "8",
-     year      = "1964",
-     pages     = "214-215",
-     SLACcitation  = "%%CITATION = PHLTA,8,214;%%"
+
+@article{AbdelRehim:2005gz,
+	archiveprefix = "arXiv",
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.",
+	doi = "10.1103/PhysRevD.71.094505",
+	eprint = "hep-lat/0503007",
+	journal = "Phys. Rev.",
+	pages = "094505",
+	slaccitation = "%\%CITATION = HEP-LAT/0503007;\%\%",
+	title = "{Spectrum of quenched twisted mass lattice QCD at maximal twist}",
+	volume = "D71",
+	year = "2005"
 }
-@Article{Gell-Mann:1968rz,
-     author    = "Gell-Mann, M. and Oakes, R. J. and Renner, B.",
-     title     = "Behavior of current divergences under SU(3) x SU(3)",
-     journal   = "Phys. Rev.",
-     volume    = "175",
-     year      = "1968",
-     pages     = "2195-2199",
-     SLACcitation  = "%%CITATION = PHRVA,175,2195;%%"
+
+@article{AbdelRehim:2005qv,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.",
+	eprint = "hep-lat/0509056",
+	journal = "PoS",
+	pages = "032",
+	slaccitation = "%\%CITATION = HEP-LAT/0509056;\%\%",
+	title = "{The hadron spectrum from twisted mass QCD with a strange quark}",
+	volume = "LAT2005",
+	year = "2006"
 }
-@PhdThesis{Geus:2002,
-  author = 	 {R. Geus},
-  title = 	 {The Jacobi-Davidson algorithm for solving large
-                  sparse symmetric eigenvalue problems with
-                  application to the design of accelerator cavities}, 
-  school = 	 {Swiss Federal Institute Of Technology Z{\"u}rich},
-  year = 	 {2002},
-  OPTkey = 	 {DISS. ETH NO. 14734},
-  OPTtype = 	 {},
-  OPTaddress = 	 {},
-  OPTmonth = 	 {},
-  OPTnote = 	 {},
-  OPTannote = 	 {}
+
+@article{AbdelRehim:2005yx,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.",
+	eprint = "hep-lat/0509098",
+	journal = "PoS",
+	pages = "051",
+	slaccitation = "%\%CITATION = HEP-LAT/0509098;\%\%",
+	title = "{Maximal twist and the spectrum of quenched twisted mass lattice QCD}",
+	volume = "LAT2005",
+	year = "2006"
 }
-@Article{Gimenez:1998ue,
-     author    = "Gimenez, V. and Giusti, L. and Rapuano, F. and Talevi, M.",
-     title     = "Non-perturbative renormalization of quark bilinears",
-     journal   = "Nucl. Phys.",
-     volume    = "B531",
-     year      = "1998",
-     pages     = "429-445",
-     eprint    = "hep-lat/9806006",
-     SLACcitation  = "%%CITATION = HEP-LAT 9806006;%%"
+
+@article{AbdelRehim:2006qu,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Petry, Robert G. and Woloshyn, R. M.",
+	eprint = "hep-lat/0610004",
+	journal = "PoS",
+	pages = "164",
+	slaccitation = "%\%CITATION = HEP-LAT/0610004;\%\%",
+	title = "{The spectrum of tmLQCD with quark and link smearing}",
+	volume = "LAT2006",
+	year = "2006"
 }
-@Article{Gimenez:2005nt,
-     author    = "Gimenez, V. and Lubicz, V. and Mescia, F. and Porretti, V.
-                  and Reyes, J.",
-     title     = "{Operator product expansion and quark condensate from
-                  lattice QCD in  coordinate space}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C41",
-     year      = "2005",
-     pages     = "535-544",
-     eprint    = "hep-lat/0503001",
-     SLACcitation  = "%%CITATION = HEP-LAT/0503001;%%"
+
+@article{AbdelRehim:2006ra,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M. and Wu, Jackson M. S.",
+	eprint = "hep-lat/0610090",
+	journal = "Eur. Phys. J.",
+	pages = "773--776",
+	slaccitation = "%\%CITATION = HEP-LAT/0610090;\%\%",
+	title = "{Lattice QCD with a twisted mass term and a strange quark}",
+	volume = "A31",
+	year = "2007"
 }
-@Article{Ginsparg:1981bj,
-     author    = "Ginsparg, P. H. and {Wilson}, K. G.",
-     title     = "A remnant of chiral symmetry on the lattice",
-     journal   = "Phys. Rev.",
-     volume    = "D25",
-     year      = "1982",
-     pages     = "2649",
-     SLACcitation  = "%%CITATION = PHRVA,D25,2649;%%"
+
+@article{AbdelRehim:2006ve,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M. and Wu, Jackson M. S.",
+	eprint = "hep-lat/0601036",
+	journal = "Phys. Rev.",
+	pages = "014507",
+	slaccitation = "%\%CITATION = HEP-LAT/0601036;\%\%",
+	title = "{Strange quarks in quenched twisted mass lattice QCD}",
+	volume = "D74",
+	year = "2006"
 }
-@Article{Giusti:1998wy,
-     author    = "Giusti, L. and Rapuano, F. and Talevi, M. and Vladikas, A.
-                  ",
-     title     = "The QCD chiral condensate from the lattice",
-     journal   = "Nucl. Phys.",
-     volume    = "B538",
-     year      = "1999",
-     pages     = "249-277",
-     eprint    = "hep-lat/9807014",
-     SLACcitation  = "%%CITATION = HEP-LAT 9807014;%%"
+
+@article{Adler:1974gd,
+	author = "Adler, Stephen L.",
+	journal = "Phys. Rev.",
+	pages = "3714",
+	slaccitation = "%\%CITATION = PHRVA,D10,3714;\%\%",
+	title = "{Some Simple Vacuum Polarization Phenomenology: e+ e- $\to$ Hadrons: The mu - Mesic Atom x-Ray Discrepancy and (g-2) of the Muon}",
+	volume = "D10",
+	year = "1974"
 }
-@Article{Giusti:2001pk,
-     author    = "Giusti, L. and Hoelbling, C. and Rebbi, C.",
-     title     = "Light quark masses with overlap fermions in quenched {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D64",
-     year      = "2001",
-     pages     = "114508",
-     eprint    = "hep-lat/0108007",
-     note      = "Erratum-ibid.D65:079903,2002",
-     SLACcitation  = "%%CITATION = HEP-LAT 0108007;%%"
+
+@article{Albanese:1987ds,
+	author = "Albanese, M. and others",
+	collaboration = "APE",
+	journal = "Phys. Lett.",
+	pages = "163",
+	slaccitation = "%\%CITATION = PHLTA,B192,163;\%\%",
+	title = "{Glueball masses and string tension in lattice {QCD}}",
+	volume = "B192",
+	year = "1987"
 }
-@Article{Giusti:2002sm,
-     author    = "Giusti, L. and Hoelbling, C. and L{\"u}scher, M. and Wittig, H.
-                  ",
-     title     = "Numerical techniques for lattice QCD in the epsilon-
-                  regime",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "153",
-     year      = "2003",
-     pages     = "31-51",
-     eprint    = "hep-lat/0212012",
-     SLACcitation  = "%%CITATION = HEP-LAT 0212012;%%"
+
+@article{Alexandrou:2008tn,
+	archiveprefix = "arXiv",
+	author = "Alexandrou, C. and others",
+	collaboration = "ETM",
+	eprint = "0803.3190",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0803.3190;\%\%",
+	title = "{Light baryon masses with dynamical twisted mass fermions}",
+	year = "2008"
 }
-@Article{Giusti:2007hk,
-     author    = "Giusti, Leonardo",
-     title     = "Light dynamical fermions on the lattice: Toward the chiral
-                  regime of QCD",
-     journal   = "PoS.",
-     volume    = "LAT2006",
-     year      = "2007",
-     pages     = "",
-     eprint    = "hep-lat/0702014",
-     SLACcitation  = "%%CITATION = HEP-LAT/0702014;%%"
+
+@article{AliKhan:2000iv,
+	author = "{Ali Khan}, A. and others",
+	collaboration = "CP-PACS",
+	eprint = "hep-lat/0007014",
+	journal = "Phys. Rev.",
+	pages = "114504",
+	slaccitation = "%\%CITATION = HEP-LAT 0007014;\%\%",
+	title = "{Chiral properties of domain-wall quarks in quenched {QCD}}",
+	volume = "D63",
+	year = "2001"
 }
-@Article{Glassner:1996gz,
-     author    = "Gl{\"a}ssner, U. and others",
-     title     = "How to compute {G}reen's functions for entire mass
-                  trajectories within {K}rylov solvers",
-     year      = "1996",
-     eprint    = "hep-lat/9605008",
-     SLACcitation  = "%%CITATION = HEP-LAT 9605008;%%"
+
+@article{AliKhan:2003br,
+	author = "{Ali Khan}, A. and others",
+	collaboration = "QCDSF",
+	eprint = "hep-lat/0303026",
+	journal = "Phys. Lett.",
+	pages = "235--240",
+	slaccitation = "%\%CITATION = HEP-LAT 0303026;\%\%",
+	title = "{Accelerating the hybrid Monte Carlo algorithm}",
+	volume = "B564",
+	year = "2003"
 }
-@Article{Gockeler:1998fn,
-     author    = "G{\"o}ckeler, M. and others",
-     title     = "Scaling of non-perturbatively {O(a)} improved {Wilson}
-                  fermions: Hadron  spectrum, quark masses and decay
-                  constants",
-     journal   = "Phys. Rev.",
-     volume    = "D57",
-     year      = "1998",
-     pages     = "5562-5580",
-     eprint    = "hep-lat/9707021",
-     SLACcitation  = "%%CITATION = HEP-LAT 9707021;%%"
+
+@article{AliKhan:2003mu,
+	author = "{Ali Khan}, A. and others",
+	eprint = "hep-lat/0309078",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "853--855",
+	slaccitation = "%\%CITATION = HEP-LAT 0309078;\%\%",
+	title = "{Accelerating Hasenbusch's acceleration of hybrid Monte Carlo}",
+	volume = "129",
+	year = "2004"
 }
-@Article{Gorishnii:1990vf,
-     author    = "Gorishnii, S. G. and Kataev, A. L. and Larin, S. A.",
-     title     = "{The O (alpha-s**3) corrections to sigma-tot (e+ e- $\to$
-                  hadrons) and Gamma (tau- $\to$ tau-neutrino + hadrons) in
-                  QCD}",
-     journal   = "Phys. Lett.",
-     volume    = "B259",
-     year      = "1991",
-     pages     = "144-150",
-     SLACcitation  = "%%CITATION = PHLTA,B259,144;%%"
+
+@article{Allton:1993wc,
+	author = "Allton, C. R. and others",
+	collaboration = "UK{QCD}",
+	eprint = "hep-lat/9303009",
+	journal = "Phys. Rev.",
+	pages = "5128--5137",
+	slaccitation = "%\%CITATION = HEP-LAT 9303009;\%\%",
+	title = "{Gauge invariant smearing and matrix correlators using {Wilson} fermions at Beta = 6.2}",
+	volume = "D47",
+	year = "1993"
 }
-@Article{Greenberg:1964pe,
-     author    = "Greenberg, O. W.",
-     title     = "Spin and unitary spin independence in a paraquark model of
-                  baryons and mesons",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "13",
-     year      = "1964",
-     pages     = "598-602",
-     SLACcitation  = "%%CITATION = PRLTA,13,598;%%"
+
+@article{Allton:2004qq,
+	author = "Allton, C. R. and others",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0403007",
+	journal = "Phys. Rev.",
+	pages = "014501",
+	slaccitation = "%\%CITATION = HEP-LAT/0403007;\%\%",
+	title = "{Improved Wilson QCD simulations with light quark masses}",
+	volume = "D70",
+	year = "2004"
 }
-@Article{Gregory:2007ce,
-     author    = "Gregory, Eric B. and Irving, Alan and Richards, Chris M.
-                  and McNeile, Craig and Hart, Alistair",
-     title     = "Pseudoscalar Flavor-Singlet Physics with Staggered
-                  Fermions",
-     year      = "2007",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     eprint    = "0710.1725",
-     SLACcitation  = "%%CITATION = ARXIV:0710.1725;%%"
+
+@article{Aoki:1984qi,
+	author = "Aoki, S.",
+	journal = "Phys. Rev.",
+	pages = "2653",
+	slaccitation = "%\%CITATION = PHRVA,D30,2653;\%\%",
+	title = "{New phase structure for lattice {QCD} with {Wilson} fermions}",
+	volume = "D30",
+	year = "1984"
 }
-@Article{Gross:1973id,
-     author    = "Gross, D. J. and Wilczek, F.",
-     title     = "Ultraviolet behavior of non-Abelian gauge theories",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "30",
-     year      = "1973",
-     pages     = "1343-1346",
-     SLACcitation  = "%%CITATION = PRLTA,30,1343;%%"
+
+@article{Aoki:1985jj,
+	author = "Aoki, S. and Higashijima, K.",
+	journal = "Prog. Theor. Phys.",
+	pages = "521",
+	slaccitation = "%\%CITATION = PTPKA,76,521;\%\%",
+	title = "{The recovery of the chiral symmetry in lattice {Gross-Neveu} model}",
+	volume = "76",
+	year = "1986"
 }
-@Article{Gross:1973ju,
-     author    = "Gross, D. J. and Wilczek, F.",
-     title     = "Asymptotically free gauge theories. 1",
-     journal   = "Phys. Rev.",
-     volume    = "D8",
-     year      = "1973",
-     pages     = "3633-3652",
-     SLACcitation  = "%%CITATION = PHRVA,D8,3633;%%"
+
+@article{Aoki:1986ua,
+	author = "Aoki, Sinya",
+	journal = "Phys. Lett.",
+	pages = "140",
+	slaccitation = "%\%CITATION = PHLTA,B190,140;\%\%",
+	title = "{NUMERICAL EVIDENCE FOR A PARITY VIOLATING PHASE IN LATTICE QCD WITH WILSON FERMION}",
+	volume = "B190",
+	year = "1987"
 }
-@Article{Gross:1974jv,
-     author    = "Gross, D. J. and Neveu, A.",
-     title     = "Dynamical symmetry breaking in asymptotically free field
-                  theories",
-     journal   = "Phys. Rev.",
-     volume    = "D10",
-     year      = "1974",
-     pages     = "3235",
-     SLACcitation  = "%%CITATION = PHRVA,D10,3235;%%"
+
+@article{Aoki:1986xr,
+	author = "Aoki, S.",
+	journal = "Phys. Rev. Lett.",
+	pages = "3136",
+	slaccitation = "%\%CITATION = PRLTA,57,3136;\%\%",
+	title = "{A solution to the {U(1)} problem on a lattice}",
+	volume = "57",
+	year = "1986"
 }
-@Article{Guagnelli:1998ud,
-     author    = "Guagnelli, M. and Sommer, R. and Wittig, H.",
- collaboration = "ALPHA",
-     title     = "Precision computation of a low-energy reference scale in
-                  quenched  lattice {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B535",
-     year      = "1998",
-     pages     = "389-402",
-     eprint    = "hep-lat/9806005",
-     SLACcitation  = "%%CITATION = HEP-LAT 9806005;%%"
+
+@article{Aoki:1993vs,
+	author = "Aoki, S. and Boettcher, S. and Gocksch, A.",
+	eprint = "hep-lat/9312084",
+	journal = "Phys. Lett.",
+	pages = "157--164",
+	slaccitation = "%\%CITATION = HEP-LAT 9312084;\%\%",
+	title = "{Spontaneous breaking of flavor symmetry and parity in the Nambu-Jona-Lasinio model with {Wilson} fermions}",
+	volume = "B331",
+	year = "1994"
 }
-@Article{Guagnelli:2004ga,
-     author    = "Guagnelli, M. and others",
- collaboration = "Zeuthen-Rome (ZeRo)",
-     title     = "Non-perturbative pion matrix element of a twist-2 operator
-                  from the  lattice",
-     journal   = "Eur. Phys. J.",
-     volume    = "C40",
-     year      = "2005",
-     pages     = "69-80",
-     eprint    = "hep-lat/0405027",
-     SLACcitation  = "%%CITATION = HEP-LAT 0405027;%%"
+
+@article{Aoki:1995ft,
+	author = "Aoki, S.",
+	eprint = "hep-lat/9509008",
+	journal = "Prog. Theor. Phys. Suppl.",
+	pages = "179--186",
+	slaccitation = "%\%CITATION = HEP-LAT 9509008;\%\%",
+	title = "{On the phase structure of {QCD} with {Wilson} fermions}",
+	volume = "122",
+	year = "1996"
 }
-@Article{Guagnelli:2004ww,
-     author    = "Guagnelli, M. and others",
- collaboration = "Zeuthen-Rome (ZeRo)",
-     title     = "Finite size effects of a pion matrix element",
-     journal   = "Phys. Lett.",
-     volume    = "B597",
-     year      = "2004",
-     pages     = "216-221",
-     eprint    = "hep-lat/0403009",
-     SLACcitation  = "%%CITATION = HEP-LAT 0403009;%%"
+
+@article{Aoki:1995yf,
+	author = "Aoki, S. and Ukawa, A. and Umemura, T.",
+	eprint = "hep-lat/9508008",
+	journal = "Phys. Rev. Lett.",
+	pages = "873--876",
+	slaccitation = "%\%CITATION = HEP-LAT 9508008;\%\%",
+	title = "{Finite temperature phase structure of lattice {QCD} with {Wilson} quark action}",
+	volume = "76",
+	year = "1996"
 }
-@Article{Guagnelli:2005zc,
-     author    = "Guagnelli, M. and Heitger, J. and Pena, C. and Sint, S. and
-                  Vladikas, A.",
- collaboration = "ALPHA",
-     title     = "Non-perturbative renormalization of left-left four-fermion
-                  operators in  quenched lattice QCD",
-     journal   = "JHEP",
-     volume    = "03",
-     year      = "2006",
-     pages     = "088",
-     eprint    = "hep-lat/0505002",
-     SLACcitation  = "%%CITATION = HEP-LAT 0505002;%%"
+
+@article{Aoki:1997fm,
+	author = "Aoki, S.",
+	eprint = "hep-lat/9707020",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "206--219",
+	slaccitation = "%\%CITATION = HEP-LAT 9707020;\%\%",
+	title = "{Phase structure of lattice {QCD} with {Wilson} fermion at finite temperature}",
+	volume = "60A",
+	year = "1998"
 }
-@Article{Gupta:1988js,
-     author    = "Gupta, R. and Kilcup, G. W. and Sharpe, S. R.
-                  ",
-     title     = "Tuning the hybrid monte carlo algorithm",
-     journal   = "Phys. Rev.",
-     volume    = "D38",
-     year      = "1988",
-     pages     = "1278",
-     SLACcitation  = "%%CITATION = PHRVA,D38,1278;%%"
+
+@article{Aoki:2001xq,
+	author = "Aoki, S. and others",
+	collaboration = "JL{QCD}",
+	eprint = "hep-lat/0110088",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "263--265",
+	slaccitation = "%\%CITATION = HEP-LAT 0110088;\%\%",
+	title = "{Non-trivial phase structure of {N(f)} = 3 {QCD} with {O(a)}- improved {Wilson} fermion at zero temperature}",
+	volume = "106",
+	year = "2002"
 }
-@Article{Gupta:1989kx,
-     author    = "Gupta, R. and others",
-     title     = "{QCD} with dynamical {Wilson} fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D40",
-     year      = "1989",
-     pages     = "2072",
-     SLACcitation  = "%%CITATION = PHRVA,D40,2072;%%"
+
+@article{Aoki:2002vt,
+	author = "Aoki, Y. and others",
+	eprint = "hep-lat/0211023",
+	journal = "Phys. Rev.",
+	pages = "074504",
+	slaccitation = "%\%CITATION = HEP-LAT 0211023;\%\%",
+	title = "{Domain wall fermions with improved gauge actions}",
+	volume = "D69",
+	year = "2004"
 }
-@Article{Gupta:1990ka,
-     author    = "Gupta, S. and Irback, A. and Karsch, F. and
-                  Petersson, B.",
-     title     = "The acceptance probability in the hybrid monte carlo
-                  method",
-     journal   = "Phys. Lett.",
-     volume    = "B242",
-     year      = "1990",
-     pages     = "437-443",
-     SLACcitation  = "%%CITATION = PHLTA,B242,437;%%"
+
+@article{Aoki:2004iq,
+	author = "Aoki, S. and others",
+	collaboration = "JL{QCD}",
+	eprint = "hep-lat/0409016",
+	slaccitation = "%\%CITATION = HEP-LAT 0409016;\%\%",
+	title = "{Bulk first-order phase transition in three-flavor lattice {QCD} with {O(a)}-improved {Wilson} fermion action at zero temperature}",
+	year = "2004"
 }
-@Article{Gupta:1991sn,
-     author    = "Gupta, R. and others",
-     title     = "{QCD} with dynamical {Wilson} fermions. 2",
-     journal   = "Phys. Rev.",
-     volume    = "D44",
-     year      = "1991",
-     pages     = "3272-3292",
-     SLACcitation  = "%%CITATION = PHRVA,D44,3272;%%"
+
+@article{Aoki:2004ta,
+	author = "Aoki, Sinya and B{\"a}r, Oliver",
+	eprint = "hep-lat/0409006",
+	journal = "Phys. Rev.",
+	pages = "116011",
+	slaccitation = "%\%CITATION = HEP-LAT 0409006;\%\%",
+	title = "{Twisted-mass {QCD}, {O}(a) improvement and {Wilson} chiral perturbation theory}",
+	volume = "D70",
+	year = "2004"
 }
-@Unpublished{Gupta:1997nd,
-     author    = "Gupta, R.",
-     title     = "Introduction to lattice {QCD}",
-     year      = "1997",
-     eprint    = "hep-lat/9807028",
-     note      = "Lectures given at Les Houches Summer School in Theoretical Physics, Session 68",
-     SLACcitation  = "%%CITATION = HEP-LAT 9807028;%%"
+
+@article{Aoki:2005ii,
+	author = "Aoki, S. and B{\"a}r, O.",
+	eprint = "hep-lat/0509002",
+	slaccitation = "%\%CITATION = HEP-LAT 0509002;\%\%",
+	title = "{Determining the low energy parameters of {Wilson} chiral perturbation theory}",
+	year = "2005"
 }
-@Article{Han:1965pf,
-     author    = "Han, M. Y. and Nambu, Yoichiro",
-     title     = "Three-triplet model with double SU(3) symmetry",
-     journal   = "Phys. Rev.",
-     volume    = "139",
-     year      = "1965",
-     pages     = "B1006-B1010",
-     SLACcitation  = "%%CITATION = PHRVA,139,B1006;%%"
+
+@article{Arnold:2003sx,
+	author = "Arnold, Guido and others",
+	eprint = "hep-lat/0311025",
+	slaccitation = "%\%CITATION = HEP-LAT 0311025;\%\%",
+	title = "{Numerical methods for the QCD overlap operator. II: Optimal Krylov subspace methods}",
+	year = "2003"
 }
-@Article{Hasenbusch:2001ne,
-     author    = "Hasenbusch, M.",
-     title     = "Speeding up the {H}ybrid-{M}onte-{C}arlo algorithm for dynamical
-                  fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B519",
-     year      = "2001",
-     pages     = "177-182",
-     eprint    = "hep-lat/0107019",
-     SLACcitation  = "%%CITATION = HEP-LAT 0107019;%%"
+
+@article{Atiyah:1971rm,
+	author = "Atiyah, M. F. and Singer, I. M.",
+	journal = "Annals Math.",
+	pages = "139--149",
+	slaccitation = "%\%CITATION = ANMAA,93,139;\%\%",
+	title = "{The Index of elliptic operators. 5}",
+	volume = "93",
+	year = "1971"
 }
+
+@article{Aubin:2006cc,
+	author = "Aubin, C. and Blum, T.",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "251--255",
+	slaccitation = "%\%CITATION = NUPHZ,162,251;\%\%",
+	title = "{Hadronic contributions to the muon g-2 from the lattice}",
+	volume = "162",
+	year = "2006"
+}
+
+@article{Aubin:2006xv,
+	author = "Aubin, C. and Blum, T.",
+	eprint = "hep-lat/0608011",
+	journal = "Phys. Rev.",
+	pages = "114502",
+	slaccitation = "%\%CITATION = HEP-LAT/0608011;\%\%",
+	title = "{Calculating the hadronic vacuum polarization and leading hadronic contribution to the muon anomalous magnetic moment with improved staggered quarks}",
+	volume = "D75",
+	year = "2007"
+}
+
+@article{BAGEL,
+	author = "Boyle, P.A.",
+	eprint = "http://www.ph.ed.ac.uk/\~{ }paboyle/bagel/Bagel.html",
+	year = 2005
+}
+
+@article{Baikov:2004ku,
+	author = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "243--246",
+	slaccitation = "%\%CITATION = NUPHZ,135,243;\%\%",
+	title = "{Vacuum polarization in pQCD: First complete O(alpha(s)**4) result}",
+	volume = "135",
+	year = "2004"
+}
+
+@article{Baikov:2005rw,
+	author = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
+	eprint = "hep-ph/0511063",
+	journal = "Phys. Rev. Lett.",
+	pages = "012003",
+	slaccitation = "%\%CITATION = HEP-PH/0511063;\%\%",
+	title = "{Scalar correlator at O(alpha(s)**4), Higgs decay into b- quarks and bounds on the light quark masses}",
+	volume = "96",
+	year = "2006"
+}
+
+@article{Baikov:2008jh,
+	archiveprefix = "arXiv",
+	author = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
+	eprint = "0801.1821",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0801.1821;\%\%",
+	title = "{Hadronic Z- and tau-Decays in Order alpha\_s^4}",
+	year = "2008"
+}
+
+@article{Bali:2000vr,
+	author = "Bali, G. S. and others",
+	collaboration = "TXL",
+	eprint = "hep-lat/0003012",
+	journal = "Phys. Rev.",
+	pages = "054503",
+	slaccitation = "%\%CITATION = HEP-LAT 0003012;\%\%",
+	title = "{Static potentials and glueball masses from {QCD} simulations with {Wilson} sea quarks}",
+	volume = "D62",
+	year = "2000"
+}
+
+@article{Bali:2004pb,
+	author = "Bali, G. S. and others",
+	eprint = "hep-lat/0409137",
+	journal = "Nucl. Phys. Proc. Supl.",
+	pages = "609--611",
+	slaccitation = "%\%CITATION = HEP-LAT 0409137;\%\%",
+	title = "{String breaking with dynamical {Wilson} fermions}",
+	volume = "140",
+	year = "2004"
+}
+
+@article{Bali:2005fu,
+	author = "Bali, G. S. and Neff, H. and Duessel, T. and Lippert, T. and Schilling, K.",
+	collaboration = "SESAM",
+	eprint = "hep-lat/0505012",
+	journal = "Phys. Rev.",
+	pages = "114513",
+	slaccitation = "%\%CITATION = HEP-LAT 0505012;\%\%",
+	title = "{Observation of string breaking in {QCD}}",
+	volume = "D71",
+	year = "2005"
+}
+
+@article{Bar:2006zj,
+	author = "B{\"a}r, O. and Jansen, K. and Schaefer, S. and Scorzato, L. and Shindler, A.",
+	eprint = "hep-lat/0609039",
+	slaccitation = "%\%CITATION = HEP-LAT 0609039;\%\%",
+	title = "{Overlap fermions on a twisted mass sea}",
+	year = "2006"
+}
+
+@article{Baxter:1993bv,
+	author = "Baxter, R. M. and others",
+	collaboration = "UK{QCD}",
+	eprint = "hep-lat/9308020",
+	journal = "Phys. Rev.",
+	pages = "1594--1605",
+	slaccitation = "%\%CITATION = HEP-LAT 9308020;\%\%",
+	title = "{Quenched heavy light decay constants}",
+	volume = "D49",
+	year = "1994"
+}
+
+@article{Beane:2004tw,
+	archiveprefix = "arXiv",
+	author = "Beane, Silas R.",
+	doi = "10.1103/PhysRevD.70.034507",
+	eprint = "hep-lat/0403015",
+	journal = "Phys. Rev.",
+	pages = "034507",
+	slaccitation = "%\%CITATION = HEP-LAT/0403015;\%\%",
+	title = "{Nucleon masses and magnetic moments in a finite volume}",
+	volume = "D70",
+	year = "2004"
+}
+
+@article{Becher:1999he,
+	author = "Becher, Thomas and Leutwyler, H.",
+	eprint = "hep-ph/9901384",
+	journal = "Eur. Phys. J.",
+	pages = "643--671",
+	slaccitation = "%\%CITATION = HEP-PH/9901384;\%\%",
+	title = "{Baryon chiral perturbation theory in manifestly Lorentz invariant form}",
+	volume = "C9",
+	year = "1999"
+}
+
+@article{Bietenholz:2004sa,
+	author = "Bietenholz, W. and others",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0409109",
+	slaccitation = "%\%CITATION = HEP-LAT 0409109;\%\%",
+	title = "{Comparison between overlap and twisted mass fermions towards the chiral limit}",
+	year = "2004"
+}
+
+@article{Bietenholz:2004wv,
+	author = "Bietenholz, W. and others",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0411001",
+	journal = "JHEP",
+	pages = "044",
+	slaccitation = "%\%CITATION = HEP-LAT 0411001;\%\%",
+	title = "{Going chiral: Overlap versus twisted mass fermions}",
+	volume = "12",
+	year = "2004"
+}
+
+@article{Blossier:2007vv,
+	archiveprefix = "arXiv",
+	author = "Blossier, B. and others",
+	collaboration = "ETM",
+	eprint = "0709.4574",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0709.4574;\%\%",
+	title = "{Light quark masses and pseudoscalar decay constants from Nf=2 Lattice QCD with twisted mass fermions}",
+	year = "2007"
+}
+
+@article{Blum:1994eh,
+	author = "Blum, Tom and others",
+	eprint = "hep-lat/9404006",
+	journal = "Phys. Rev.",
+	pages = "3377--3381",
+	slaccitation = "%\%CITATION = HEP-LAT 9404006;\%\%",
+	title = "{QCD thermodynamics with Wilson quarks at large kappa}",
+	volume = "D50",
+	year = "1994"
+}
+
+@article{Blum:2000kn,
+	author = "Blum, T. and others",
+	eprint = "hep-lat/0007038",
+	journal = "Phys. Rev.",
+	pages = "074502",
+	slaccitation = "%\%CITATION = HEP-LAT 0007038;\%\%",
+	title = "{Quenched lattice {QCD} with domain wall fermions and the chiral limit}",
+	volume = "D69",
+	year = "2004"
+}
+
+@article{Bodin:2005gg,
+	author = "Bodin, F. and others",
+	collaboration = "ApeNEXT",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "176--182",
+	slaccitation = "%\%CITATION = NUPHZ,140,176;\%\%",
+	title = "{The {apeNEXT} project}",
+	volume = "140",
+	year = "2005"
+}
+
+@article{Bolder:2000un,
+	author = "Bolder, B. and others",
+	eprint = "hep-lat/0005018",
+	journal = "Phys. Rev.",
+	pages = "074504",
+	slaccitation = "%\%CITATION = HEP-LAT 0005018;\%\%",
+	title = "{A high precision study of the Q anti-Q potential from {Wilson} loops in the regime of string breaking}",
+	volume = "D63",
+	year = "2001"
+}
+
+@article{Boucaud:2007uk,
+	author = "Boucaud, Ph. and others",
+	collaboration = "ETM",
+	eprint = "hep-lat/0701012",
+	slaccitation = "%\%CITATION = HEP-LAT 0701012;\%\%",
+	title = "{Dynamical twisted mass fermions with light quarks}",
+	year = "2007"
+}
+
+@article{Boucaud:2008xu,
+	archiveprefix = "arXiv",
+	author = "Boucaud, Ph. and others",
+	collaboration = "ETM",
+	doi = "10.1016/j.cpc.2008.06.013",
+	eprint = "0803.0224",
+	journal = "Comput. Phys. Commun.",
+	pages = "695--715",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0803.0224;\%\%",
+	title = "{Dynamical Twisted Mass Fermions with Light Quarks: Simulation and Analysis Details}",
+	volume = "179",
+	year = "2008"
+}
+
+@article{Boughezal:2006px,
+	author = "Boughezal, R. and Czakon, M. and Schutzmeier, T.",
+	eprint = "hep-ph/0605023",
+	journal = "Phys. Rev.",
+	pages = "074006",
+	slaccitation = "%\%CITATION = HEP-PH/0605023;\%\%",
+	title = "{Charm and bottom quark masses from perturbative QCD}",
+	volume = "D74",
+	year = "2006"
+}
+
+@article{Boyle:2005fb,
+	author = "Boyle, P. A. and others",
+	journal = "J. Phys. Conf. Ser.",
+	pages = "129--139",
+	slaccitation = "%\%CITATION = 00462,16,129;\%\%",
+	title = "{{QCDOC}: Project status and first results}",
+	volume = "16",
+	year = "2005"
+}
+
+@article{Brower:1994er,
+	author = "Brower, R. C. and Levi, A. R. and Orginos, K.",
+	eprint = "hep-lat/9412004",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "855--857",
+	slaccitation = "%\%CITATION = HEP-LAT 9412004;\%\%",
+	title = "{Extrapolation methods for the Dirac inverter in hybrid Monte Carlo}",
+	volume = "42",
+	year = "1995"
+}
+
+@article{Brower:1995vx,
+	author = "Brower, R. C. and Ivanenko, T. and Levi, A. R. and Orginos, K. N.",
+	eprint = "hep-lat/9509012",
+	journal = "Nucl. Phys.",
+	pages = "353--374",
+	slaccitation = "%\%CITATION = HEP-LAT 9509012;\%\%",
+	title = "{Chronological inversion method for the Dirac matrix in hybrid Monte Carlo}",
+	volume = "B484",
+	year = "1997"
+}
+
+@article{Bunk:1995uv,
+	author = "Bunk, B. and others",
+	eprint = "hep-lat/9411016",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "49--55",
+	slaccitation = "%\%CITATION = HEP-LAT 9411016;\%\%",
+	title = "{A New simulation algorithm for lattice {QCD} with dynamical quarks}",
+	volume = "42",
+	year = "1995"
+}
+
+@article{Bunk:1998rm,
+	author = "Bunk, B. and Elser, S. and Frezzotti, R. and Jansen, K.",
+	eprint = "hep-lat/9805026",
+	journal = "Comput. Phys. Commun.",
+	pages = "95--109",
+	slaccitation = "%\%CITATION = HEP-LAT 9805026;\%\%",
+	title = "{Ordering monomial factors of polynomials in the product representation}",
+	volume = "118",
+	year = "1999"
+}
+
+@article{Burrage:1998a,
+	author = "Burrage, K. and Erhel, J.",
+	journal = "Num. Lin. Alg. with Appl.",
+	pages = "101--121",
+	title = "{On the performance of various adaptive preconditioned GMRES strategies}",
+	volume = "5",
+	year = "1998"
+}
+
+@article{Campbell:1987nv,
+	author = "Campbell, N. A. and Huntley, A. and Michael, C.",
+	journal = "Nucl. Phys.",
+	pages = "51",
+	slaccitation = "%\%CITATION = NUPHA,B306,51;\%\%",
+	title = "{Heavy quark potentials and hybrid mesons from SU(3) lattice gauge theory}",
+	volume = "B306",
+	year = "1988"
+}
+
+@article{Capitani:2005jp,
+	author = "Capitani, S. and others",
+	eprint = "hep-lat/0511013",
+	journal = "Phys. Lett.",
+	pages = "520--526",
+	slaccitation = "%\%CITATION = HEP-LAT 0511013;\%\%",
+	title = "{Parton distribution functions with twisted mass fermions}",
+	volume = "B639",
+	year = "2006"
+}
+
+@article{Chen:2003im,
+	author = "Chen, Y. and others",
+	eprint = "hep-lat/0304005",
+	journal = "Phys. Rev.",
+	pages = "034502",
+	slaccitation = "%\%CITATION = HEP-LAT 0304005;\%\%",
+	title = "{Chiral logarithms in quenched {QCD}}",
+	volume = "D70",
+	year = "2004"
+}
+
+@book{Cheng:2000ct,
+	author = "Cheng, T. P. and Li, L. F.",
+	edition = "",
+	pages = "306",
+	publisher = "Oxford, UK: Clarendon",
+	title = "{Gauge theory of elementary particle physics: Problems and solutions}",
+	year = "2000"
+}
+
+@article{Chetyrkin:1990kr,
+	author = "Chetyrkin, K. G. and K{\"u}hn, Johann H.",
+	journal = "Phys. Lett.",
+	pages = "359--364",
+	slaccitation = "%\%CITATION = PHLTA,B248,359;\%\%",
+	title = "{Mass corrections to the Z decay rate}",
+	volume = "B248",
+	year = "1990"
+}
+
+@article{Chetyrkin:1996cf,
+	author = "Chetyrkin, K. G. and K{\"u}hn, Johann H. and Steinhauser, M.",
+	eprint = "hep-ph/9606230",
+	journal = "Nucl. Phys.",
+	pages = "213--240",
+	slaccitation = "%\%CITATION = HEP-PH/9606230;\%\%",
+	title = "{Three-loop polarization function and O(alpha(s)**2) corrections to the production of heavy quarks}",
+	volume = "B482",
+	year = "1996"
+}
+
+@article{Chetyrkin:1997mb,
+	author = "Chetyrkin, K. G. and K{\"u}hn, Johann H. and Steinhauser, M.",
+	eprint = "hep-ph/9705254",
+	journal = "Nucl. Phys.",
+	pages = "40--64",
+	slaccitation = "%\%CITATION = HEP-PH/9705254;\%\%",
+	title = "{Heavy quark current correlators to O(alpha(s)**2)}",
+	volume = "B505",
+	year = "1997"
+}
+
+@article{Chetyrkin:1998ix,
+	author = "Chetyrkin, K. G. and Harlander, R. and Steinhauser, M.",
+	eprint = "hep-ph/9801432",
+	journal = "Phys. Rev.",
+	pages = "014012",
+	slaccitation = "%\%CITATION = HEP-PH/9801432;\%\%",
+	title = "{Singlet polarization functions at O(alpha(s)**2)}",
+	volume = "D58",
+	year = "1998"
+}
+
+@article{Chetyrkin:2000zk,
+	author = "Chetyrkin, K. G. and Harlander, R. V. and K{\"u}hn, Johann H.",
+	eprint = "hep-ph/0005139",
+	journal = "Nucl. Phys.",
+	pages = "56--72",
+	slaccitation = "%\%CITATION = HEP-PH/0005139;\%\%",
+	title = "{Quartic mass corrections to R(had) at O(alpha(s)**3)}",
+	volume = "B586",
+	year = "2000"
+}
+
+@article{Chetyrkin:2006xg,
+	author = "Chetyrkin, K. G. and K{\"u}hn, J. H. and Sturm, C.",
+	eprint = "hep-ph/0604234",
+	journal = "Eur. Phys. J.",
+	pages = "107--110",
+	slaccitation = "%\%CITATION = HEP-PH/0604234;\%\%",
+	title = "{Four-loop moments of the heavy quark vacuum polarization function in perturbative QCD}",
+	volume = "C48",
+	year = "2006"
+}
+
+@article{Chiarappa:2004ry,
+	archiveprefix = "arXiv",
+	author = "Chiarappa, T. and others",
+	doi = "10.1016/j.nuclphysbps.2004.11.281",
+	eprint = "hep-lat/0409107",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "853--855",
+	slaccitation = "%\%CITATION = HEP-LAT/0409107;\%\%",
+	title = "{Comparing iterative methods for overlap and twisted mass fermions}",
+	volume = "140",
+	year = "2005"
+}
+
+@article{Chiarappa:2006ae,
+	archiveprefix = "arXiv",
+	author = "Chiarappa, T. and others",
+	doi = "10.1140/epjc/s10052-006-0204-4",
+	eprint = "hep-lat/0606011",
+	journal = "Eur. Phys. J.",
+	pages = "373--383",
+	slaccitation = "%\%CITATION = HEP-LAT/0606011;\%\%",
+	title = "{Numerical simulation of {QCD} with u, d, s and c quarks in the twisted-mass {W}ilson formulation}",
+	volume = "C50",
+	year = "2007"
+}
+
+@article{Chiarappa:2006hz,
+	archiveprefix = "arXiv",
+	author = "Chiarappa, T. and others",
+	eprint = "hep-lat/0609023",
+	journal = "Comput. Sci. Disc.",
+	pages = "015001",
+	slaccitation = "%\%CITATION = HEP-LAT/0609023;\%\%",
+	title = "{Iterative methods for overlap and twisted mass fermions}",
+	volume = "01",
+	year = "2008"
+}
+
+@article{Cichy:2008gk,
+	archiveprefix = "arXiv",
+	author = "Cichy, K. and {Gonzalez Lopez}, J. and Jansen, K. and Kujawa, A. and Shindler, A.",
+	doi = "10.1016/j.nuclphysb.2008.03.004",
+	eprint = "0802.3637",
+	journal = "Nucl. Phys.",
+	pages = "94--108",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0802.3637;\%\%",
+	title = "{Twisted Mass, Overlap and Creutz Fermions: Cut-off Effects at Tree-level of Perturbation Theory}",
+	volume = "B800",
+	year = "2008"
+}
+
+@article{Clark:2004cq,
+	author = "Clark, M. A. and Kennedy, A. D.",
+	eprint = "hep-lat/0409134",
+	slaccitation = "%\%CITATION = HEP-LAT 0409134;\%\%",
+	title = "{Accelerating fermionic molecular dynamics}",
+	year = "2004"
+}
+
+@article{Clark:2005sq,
+	author = "Clark, M. A. and de Forcrand, Ph. and Kennedy, A. D.",
+	eprint = "hep-lat/0510004",
+	journal = "PoS",
+	pages = "115",
+	slaccitation = "%\%CITATION = HEP-LAT 0510004;\%\%",
+	title = "{Algorithm shootout: R versus RHMC}",
+	volume = "LAT2005",
+	year = "2005"
+}
+
+@article{Clark:2006fx,
+	author = "Clark, M. A. and Kennedy, A. D.",
+	eprint = "hep-lat/0608015",
+	slaccitation = "%\%CITATION = HEP-LAT 0608015;\%\%",
+	title = "{Accelerating dynamical fermion computations using the rational hybrid {Monte} {Carlo} ({RHMC}) algorithm with multiple pseudofermion fields}",
+	year = "2006"
+}
+
+@article{Colangelo:2001df,
+	archiveprefix = "arXiv",
+	author = "Colangelo, G. and Gasser, J. and Leutwyler, H.",
+	doi = "10.1016/S0550-3213(01)00147-X",
+	eprint = "hep-ph/0103088",
+	journal = "Nucl. Phys.",
+	pages = "125--179",
+	slaccitation = "%\%CITATION = HEP-PH/0103088;\%\%",
+	title = "{pi pi scattering}",
+	volume = "B603",
+	year = "2001"
+}
+
+@article{Colangelo:2003hf,
+	author = "Colangelo, Gilberto and D{\"u}rr, Stephan",
+	eprint = "hep-lat/0311023",
+	journal = "Eur. Phys. J.",
+	pages = "543--553",
+	slaccitation = "%\%CITATION = HEP-LAT/0311023;\%\%",
+	title = "{The pion mass in finite volume}",
+	volume = "C33",
+	year = "2004"
+}
+
+@article{Colangelo:2005gd,
+	author = "Colangelo, Gilberto and D{\"u}rr, Stephan and Haefeli, Christoph",
+	eprint = "hep-lat/0503014",
+	journal = "Nucl. Phys.",
+	pages = "136--174",
+	slaccitation = "%\%CITATION = HEP-LAT 0503014;\%\%",
+	title = "{Finite volume effects for meson masses and decay constants}",
+	volume = "B721",
+	year = "2005"
+}
+
+@article{Colangelo:2006mp,
+	archiveprefix = "arXiv",
+	author = "Colangelo, Gilberto and Haefeli, Christoph",
+	doi = "10.1016/j.nuclphysb.2006.03.010",
+	eprint = "hep-lat/0602017",
+	journal = "Nucl. Phys.",
+	pages = "14--33",
+	slaccitation = "%\%CITATION = HEP-LAT/0602017;\%\%",
+	title = "{Finite volume effects for the pion mass at two loops}",
+	volume = "B744",
+	year = "2006"
+}
+
+@book{Collins:1994ab,
+	author = "Collins, J.C.",
+	edition = "",
+	publisher = "Cambridge University Press",
+	series = "{Cambridge Monographs on Mathematical Physics}",
+	title = "{Renormalisation}",
+	year = "1994"
+}
+
+@article{Creutz:1984fj,
+	author = "Creutz, M. and Gocksch, A. and Ogilvie, M. and Okawa, M.",
+	journal = "Phys. Rev. Lett.",
+	pages = "875",
+	slaccitation = "%\%CITATION = PRLTA,53,875;\%\%",
+	title = "{Microcanonical renormalization group}",
+	volume = "53",
+	year = "1984"
+}
+
+@article{Creutz:1989wt,
+	author = "Creutz, M. and Gocksch, A.",
+	note = "BNL-42601",
+	title = "{Higher order hybrid monte carlo algorithms}"
+}
+
+@article{Creutz:1996bg,
+	author = "Creutz, Michael",
+	eprint = "hep-lat/9608024",
+	slaccitation = "%\%CITATION = HEP-LAT 9608024;\%\%",
+	title = "{Wilson fermions at finite temperature}",
+	year = "1996"
+}
+
+@article{Creutz:1998ee,
+	author = "Creutz, M.",
+	eprint = "hep-lat/9806037",
+	journal = "Phys. Rev. Lett.",
+	pages = "3555--3558",
+	slaccitation = "%\%CITATION = HEP-LAT 9806037;\%\%",
+	title = "{Evaluating Grassmann integrals}",
+	volume = "81",
+	year = "1998"
+}
+
+@article{Cundy:2005pi,
+	author = "Cundy, N. and others",
+	eprint = "hep-lat/0502007",
+	slaccitation = "%\%CITATION = HEP-LAT 0502007;\%\%",
+	title = "{Numerical Methods for the {QCD} Overlap Operator IV: Hybrid Monte Carlo}",
+	year = "2005"
+}
+
+@article{David:1984ys,
+	author = "David, F. and Hamber, H. W.",
+	journal = "Nucl. Phys.",
+	pages = "381",
+	slaccitation = "%\%CITATION = NUPHA,B248,381;\%\%",
+	title = "{Chiral condensate with {Wilson} fermions}",
+	volume = "B248",
+	year = "1984"
+}
+
+@article{Davies:2008sw,
+	archiveprefix = "arXiv",
+	author = "Davies, C. T. H. and others",
+	collaboration = "HPQCD",
+	eprint = "0807.1687",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0807.1687;\%\%",
+	title = "{Update: Accurate Determinations of $\alpha_s$ from Realistic Lattice QCD}",
+	year = "2008"
+}
+
+@article{DeGrand:1990dk,
+	author = "DeGrand, T. A. and Rossi, P.",
+	journal = "Comput. Phys. Commun.",
+	pages = "211--214",
+	slaccitation = "%\%CITATION = CPHCB,60,211;\%\%",
+	title = "{Conditioning techniques for dynamical fermions}",
+	volume = "60",
+	year = "1990"
+}
+
+@article{DeGrand:1990ip,
+	author = "DeGrand, T. A.",
+	journal = "Phys. Rev.",
+	pages = "2296--2300",
+	slaccitation = "%\%CITATION = PHRVA,D43,2296;\%\%",
+	title = "{Resonance masses from Monte Carlo simulations (with emphasis on the rho meson)}",
+	volume = "D43",
+	year = "1991"
+}
+
+@article{DeGrand:2002vu,
+	author = "DeGrand, Thomas and Hasenfratz, Anna and Kovacs, Tamas G.",
+	eprint = "hep-lat/0211006",
+	journal = "Phys. Rev.",
+	pages = "054501",
+	slaccitation = "%\%CITATION = HEP-LAT 0211006;\%\%",
+	title = "{Improving the chiral properties of lattice fermions}",
+	volume = "D67",
+	year = "2003"
+}
+
+@article{DeTar:2007ni,
+	archiveprefix = "arXiv",
+	author = "DeTar, Carleton and Levkova, L.",
+	eprint = "0710.1322",
+	journal = "PoS",
+	pages = "116",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0710.1322;\%\%",
+	title = "{Effects of the disconnected flavor singlet corrections on the hyperfine splitting in charmonium}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{DelDebbio:2006cn,
+	author = "{Del Debbio}, L. and Giusti, L. and Luscher, M. and Petronzio, R. and Tantalo, N.",
+	eprint = "hep-lat/0610059",
+	journal = "JHEP",
+	pages = "056",
+	slaccitation = "%\%CITATION = HEP-LAT 0610059;\%\%",
+	title = "{QCD with light Wilson quarks on fine lattices. I: First experiences and physics results}",
+	volume = "02",
+	year = "2007"
+}
+
+@article{DellaMorte:2000yp,
+	author = "{Della Morte}, M. and Frezzotti, R. and Heitger, J. and Sint, S.",
+	eprint = "hep-lat/0010091",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "617--621",
+	slaccitation = "%\%CITATION = HEP-LAT 0010091;\%\%",
+	title = "{Non-perturbative scaling tests of twisted mass {QCD}}",
+	volume = "94",
+	year = "2001"
+}
+
+@article{DellaMorte:2001tu,
+	author = "{Della Morte}, M. and Frezzotti, R. and Heitger, J.",
+	eprint = "hep-lat/0110166",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "260--262",
+	slaccitation = "%\%CITATION = HEP-LAT 0110166;\%\%",
+	title = "{Quenched twisted mass {QCD} at small quark masses and in large volume}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{DellaMorte:2001ys,
+	author = "{Della Morte}, M. and Frezzotti, R. and Heitger, J. and Sint, S.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0108019",
+	journal = "JHEP",
+	pages = "041",
+	slaccitation = "%\%CITATION = HEP-LAT 0108019;\%\%",
+	title = "{Cutoff effects in twisted mass lattice {QCD}}",
+	volume = "10",
+	year = "2001"
+}
+
+@article{DellaMorte:2003jj,
+	author = "{Della Morte}, M. and others",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0307008",
+	journal = "Comput. Phys. Commun.",
+	pages = "62--72",
+	slaccitation = "%\%CITATION = HEP-LAT 0307008;\%\%",
+	title = "{Simulating the Schroedinger functional with two pseudo- fermions}",
+	volume = "156",
+	year = "2003"
+}
+
+@article{DellaMorte:2003mn,
+	author = "{Della Morte}, M. and others",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0307021",
+	journal = "Phys. Lett.",
+	pages = "93--98",
+	slaccitation = "%\%CITATION = HEP-LAT 0307021;\%\%",
+	title = "{Lattice HQET with exponentially improved statistical precision}",
+	volume = "B581",
+	year = "2004"
+}
+
+@article{DellaMorte:2003mw,
+	author = "{Della Morte}, M. and others",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0309080",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "346--348",
+	slaccitation = "%\%CITATION = HEP-LAT 0309080;\%\%",
+	title = "{Static quarks with improved statistical precision}",
+	volume = "129",
+	year = "2004"
+}
+
+@article{DellaMorte:2005yc,
+	author = "{Della Morte}, M. and Shindler, A. and Sommer, R.",
+	eprint = "hep-lat/0506008",
+	slaccitation = "%\%CITATION = HEP-LAT 0506008;\%\%",
+	title = "{On lattice actions for static quarks}",
+	year = "2005"
+}
+
+@article{Dimopoulos:2006dm,
+	author = "Dimopoulos, P. and others",
+	collaboration = "ALPHA",
+	eprint = "hep-ph/0601002",
+	journal = "Nucl. Phys.",
+	pages = "69--108",
+	slaccitation = "%\%CITATION = HEP-PH 0601002;\%\%",
+	title = "{A precise determination of B(K) in quenched QCD}",
+	volume = "B749",
+	year = "2006"
+}
+
+@article{Dimopoulos:2007fn,
+	archiveprefix = "arXiv",
+	author = "Dimopoulos, P. and others",
+	eprint = "0710.0975",
+	journal = "PoS",
+	pages = "241",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.0975;\%\%",
+	title = "{Renormalisation of quark bilinears with Nf=2 Wilson fermions and tree-level improved gauge action}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{Dimopoulos:2007qy,
+	archiveprefix = "arXiv",
+	author = "Dimopoulos, Petros and Frezzotti, Roberto and Herdoiza, Gregorio and Urbach, Carsten and Wenger, Urs",
+	collaboration = "ETM",
+	eprint = "0710.2498",
+	journal = "PoS",
+	pages = "102",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.2498;\%\%",
+	title = "{Scaling and low energy constants in lattice QCD with N\_f=2 maximally twisted Wilson quarks}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{Dimopoulos:2008sy,
+	archiveprefix = "arXiv",
+	author = "Dimopoulos, Petros and others",
+	collaboration = "ETM",
+	eprint = "0810.2873",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0810.2873;\%\%",
+	title = "{Scaling and chiral extrapolation of pion mass and decay constant with maximally twisted mass QCD}",
+	year = "2008"
+}
+
+@article{Dong:2001fm,
+	author = "Dong, S. J. and others",
+	eprint = "hep-lat/0108020",
+	journal = "Phys. Rev.",
+	pages = "054507",
+	slaccitation = "%\%CITATION = HEP-LAT 0108020;\%\%",
+	title = "{Chiral properties of pseudoscalar mesons on a quenched 20**4 lattice with overlap fermions}",
+	volume = "D65",
+	year = "2002"
+}
+
+@article{Duane:1987de,
+	author = "Duane, S. and Kennedy, A. D. and Pendleton, B. J. and Roweth, D.",
+	journal = "Phys. Lett.",
+	pages = "216--222",
+	slaccitation = "%\%CITATION = PHLTA,B195,216;\%\%",
+	title = "{{H}ybrid monte carlo}",
+	volume = "B195",
+	year = "1987"
+}
+
+@article{Edwards:1996vs,
+	author = "Edwards, R. G. and Horvath, I. and Kennedy, A. D.",
+	eprint = "hep-lat/9606004",
+	journal = "Nucl. Phys.",
+	pages = "375--402",
+	slaccitation = "%\%CITATION = HEP-LAT 9606004;\%\%",
+	title = "{Instabilities and non-reversibility of molecular dynamics trajectories}",
+	volume = "B484",
+	year = "1997"
+}
+
+@article{Edwards:2004sx,
+	author = "Edwards, Robert G. and Joo, Balint",
+	collaboration = "SciDAC",
+	eprint = "hep-lat/0409003",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "832",
+	slaccitation = "%\%CITATION = HEP-LAT 0409003;\%\%",
+	title = "{The {Chroma} software system for lattice {QCD}}",
+	volume = "140",
+	year = "2005"
+}
+
+@article{Eichten:1989zv,
+	author = "Eichten, E. and Hill, B.",
+	journal = "Phys. Lett.",
+	pages = "511",
+	slaccitation = "%\%CITATION = PHLTA,B234,511;\%\%",
+	title = "{An effective field theory for the calculation of matrix elements involving heavy quarks}",
+	volume = "B234",
+	year = "1990"
+}
+
+@article{Farchioni:2002vn,
+	author = "Farchioni, F. and Gebert, C. and Montvay, I. and Scorzato, L.",
+	eprint = "hep-lat/0206008",
+	journal = "Eur. Phys. J.",
+	pages = "237--251",
+	slaccitation = "%\%CITATION = HEP-LAT 0206008;\%\%",
+	title = "{Numerical simulation tests with light dynamical quarks}",
+	volume = "C26",
+	year = "2002"
+}
+
+@article{Farchioni:2004fs,
+	author = "Farchioni, F. and others",
+	eprint = "hep-lat/0410031",
+	journal = "Eur. Phys. J.",
+	pages = "73--87",
+	slaccitation = "%\%CITATION = HEP-LAT 0410031;\%\%",
+	title = "{The phase structure of lattice {QCD} with {Wilson} quarks and renormalization group improved gluons}",
+	volume = "C42",
+	year = "2005"
+}
+
+@article{Farchioni:2004ma,
+	author = "Farchioni, F. and others",
+	eprint = "hep-lat/0409098",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "240--245",
+	slaccitation = "%\%CITATION = HEP-LAT 0409098;\%\%",
+	title = "{Exploring the phase structure of lattice {{QCD}} with twisted mass quarks}",
+	volume = "140",
+	year = "2005"
+}
+
+@article{Farchioni:2004us,
+	author = "Farchioni, F. and others",
+	eprint = "hep-lat/0406039",
+	journal = "Eur. Phys. J.",
+	pages = "421--433",
+	slaccitation = "%\%CITATION = HEP-LAT 0406039;\%\%",
+	title = "{Twisted mass quarks and the phase structure of lattice {QCD}}",
+	volume = "C39",
+	year = "2005"
+}
+
+@article{Farchioni:2005ec,
+	author = "Farchioni, Federico and others",
+	eprint = "hep-lat/0509131",
+	journal = "PoS",
+	pages = "072",
+	slaccitation = "%\%CITATION = HEP-LAT 0509131;\%\%",
+	title = "{Dynamical twisted mass fermions}",
+	volume = "LAT2005",
+	year = "2006"
+}
+
+@article{Farchioni:2005hf,
+	author = "Farchioni, F. and others",
+	eprint = "hep-lat/0509036",
+	journal = "PoS",
+	pages = "033",
+	slaccitation = "%\%CITATION = HEP-LAT 0509036;\%\%",
+	title = "{Twisted mass fermions: Neutral pion masses from disconnected contributions}",
+	volume = "LAT2005",
+	year = "2006"
+}
+
+@article{Farchioni:2005tu,
+	author = "Farchioni, F. and others",
+	eprint = "hep-lat/0506025",
+	journal = "Phys. Lett.",
+	pages = "324--333",
+	slaccitation = "%\%CITATION = HEP-LAT 0506025;\%\%",
+	title = "{Lattice spacing dependence of the first order phase transition for dynamical twisted mass fermions}",
+	volume = "B624",
+	year = "2005"
+}
+
+@article{Feldmann:1999uf,
+	author = "Feldmann, Thorsten",
+	eprint = "hep-ph/9907491",
+	journal = "Int. J. Mod. Phys.",
+	pages = "159--207",
+	slaccitation = "%\%CITATION = HEP-PH/9907491;\%\%",
+	title = "{Quark structure of pseudoscalar mesons}",
+	volume = "A15",
+	year = "2000"
+}
+
+@article{Feynman:1948aa,
+	author = "Feynman, R. P.",
+	journal = "Rev. Mod. Phys.",
+	pages = "367--387",
+	slaccitation = "%\%CITATION = RMPHA,20,367;\%\%",
+	title = "{Space-time approach to non-relativistic quantum mechanics}",
+	volume = "20",
+	year = "1948"
+}
+
+@article{Fischer:1996th,
+	author = "Fischer, S. and others",
+	eprint = "hep-lat/9602019",
+	journal = "Comp. Phys. Commun.",
+	pages = "20--34",
+	slaccitation = "%\%CITATION = HEP-LAT 9602019;\%\%",
+	title = "{A Parallel SSOR Preconditioner for Lattice {QCD}}",
+	volume = "98",
+	year = "1996"
+}
+
+@article{Fokkema:1998aa,
+	author = "Fokkema, D.~R. and Sleijpen, G.~L.~G. and Van~der~Vorst, H.~A.",
+	journal = "J. Sci. Comput.",
+	pages = "94--125",
+	title = "{{J}acobi-{D}avidson style {QR} and {QZ} algorithms for the reduction of matrix pencils}",
+	volume = "20",
+	year = "1998"
+}
+
+@article{Foster:1998vw,
+	author = "Foster, M. and Michael, C.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/9810021",
+	journal = "Phys. Rev.",
+	pages = "074503",
+	slaccitation = "%\%CITATION = HEP-LAT 9810021;\%\%",
+	title = "{Quark mass dependence of hadron masses from lattice {QCD}}",
+	volume = "D59",
+	year = "1999"
+}
+
+@article{Freund,
+	author = "Freund, R.W.",
+	journal = "in Numerical Linear Algebra, L.\ Reichel, A.\ Ruttan and R.S.\ Varga (eds.)",
+	pages = "p. 101",
+	year = "1993"
+}
+
+@article{Frezzotti:1997ym,
+	author = "Frezzotti, R. and Jansen, K.",
+	eprint = "hep-lat/9702016",
+	journal = "Phys. Lett.",
+	pages = "328--334",
+	slaccitation = "%\%CITATION = HEP-LAT 9702016;\%\%",
+	title = "{A polynomial hybrid Monte Carlo algorithm}",
+	volume = "B402",
+	year = "1997"
+}
+
+@article{Frezzotti:1998eu,
+	author = "Frezzotti, R. and Jansen, K.",
+	eprint = "hep-lat/9808011",
+	journal = "Nucl. Phys.",
+	pages = "395--431",
+	slaccitation = "%\%CITATION = HEP-LAT 9808011;\%\%",
+	title = "{The {PHMC} algorithm for simulations of dynamical fermions. {I}: Description and properties}",
+	volume = "B555",
+	year = "1999"
+}
+
+@articlef{Frezzotti:1998yp,
+	author = "Frezzotti, R. and Jansen, K.",
+	eprint = "hep-lat/9808038",
+	journal = "Nucl. Phys.",
+	pages = "432--453",
+	slaccitation = "%\%CITATION = HEP-LAT 9808038;\%\%",
+	title = "{The {PHMC} algorithm for simulations of dynamical fermions. {II}: Performance analysis}",
+	volume = "B555",
+	year = "1999"
+}
+
+@article{Frezzotti:1999vv,
+	author = "Frezzotti, R. and Grassi, P. A. and Sint, S. and Weisz, P.",
+	eprint = "hep-lat/9909003",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "941--946",
+	slaccitation = "%\%CITATION = HEP-LAT 9909003;\%\%",
+	title = "{A local formulation of lattice {QCD} without unphysical fermion zero modes}",
+	volume = "83",
+	year = "2000"
+}
+
+@article{Frezzotti:2000nk,
+	author = "Frezzotti, R. and Grassi, P. A. and Sint, S. and Weisz, P.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0101001",
+	journal = "JHEP",
+	pages = "058",
+	slaccitation = "%\%CITATION = HEP-LAT 0101001;\%\%",
+	title = "{Lattice {QCD} with a chirally twisted mass term}",
+	volume = "08",
+	year = "2001"
+}
+
+@article{Frezzotti:2001du,
+	author = "Frezzotti, R. and Sint, S.",
+	eprint = "hep-lat/0110140",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "814--816",
+	slaccitation = "%\%CITATION = HEP-LAT 0110140;\%\%",
+	title = "{Some remarks on {O(a)} improved twisted mass {QCD}}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Frezzotti:2001ea,
+	author = "Frezzotti, R. and Sint, S. and Weisz, P.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0104014",
+	journal = "JHEP",
+	pages = "048",
+	slaccitation = "%\%CITATION = HEP-LAT 0104014;\%\%",
+	title = "{{O(a)} improved twisted mass lattice {QCD}}",
+	volume = "07",
+	year = "2001"
+}
+
+@article{Frezzotti:2003ni,
+	author = "Frezzotti, R. and Rossi, G. C.",
+	eprint = "hep-lat/0306014",
+	journal = "JHEP",
+	pages = "007",
+	slaccitation = "%\%CITATION = HEP-LAT 0306014;\%\%",
+	title = "{Chirally improving {Wilson} fermions. {I}: {O(a)} improvement}",
+	volume = "08",
+	year = "2004"
+}
+
+@article{Frezzotti:2003xj,
+	author = "Frezzotti, R. and Rossi, G. C.",
+	eprint = "hep-lat/0311008",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "193--202",
+	slaccitation = "%\%CITATION = HEP-LAT 0311008;\%\%",
+	title = "{Twisted-mass lattice {QCD} with mass non-degenerate quarks}",
+	volume = "128",
+	year = "2004"
+}
+
+@article{Frezzotti:2004wz,
+	author = "Frezzotti, R. and Rossi, G. C.",
+	eprint = "hep-lat/0407002",
+	journal = "JHEP",
+	pages = "070",
+	slaccitation = "%\%CITATION = HEP-LAT 0407002;\%\%",
+	title = "{Chirally improving {Wilson} fermions. {II}: Four-quark operators}",
+	volume = "10",
+	year = "2004"
+}
+
+@article{Frezzotti:2005gi,
+	author = "Frezzotti, R. and Martinelli, G. and Papinutto, M. and Rossi, G. C.",
+	eprint = "hep-lat/0503034",
+	journal = "JHEP",
+	pages = "038",
+	slaccitation = "%\%CITATION = HEP-LAT 0503034;\%\%",
+	title = "{Reducing cutoff effects in maximally twisted lattice {QCD} close to the chiral limit}",
+	volume = "04",
+	year = "2006"
+}
+
+@article{Frezzotti:2007qv,
+	archiveprefix = "arXiv",
+	author = "Frezzotti, R. and Rossi, G.",
+	eprint = "0710.2492",
+	journal = "PoS",
+	pages = "277",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.2492;\%\%",
+	title = "{O(a^2) cutoff effects in Wilson fermion simulations}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{Frezzotti:2008dr,
+	archiveprefix = "arXiv",
+	author = "Frezzotti, R. and Lubicz, V. and Simula, S.",
+	collaboration = "ETM",
+	eprint = "0812.4042",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0812.4042;\%\%",
+	title = "{Electromagnetic form factor of the pion from twisted-mass lattice {QCD} at {Nf}=2}",
+	year = "2008"
+}
+
+@article{Fritzsch:1973pi,
+	author = "Fritzsch, H. and Gell-Mann, M. and Leutwyler, H.",
+	journal = "Phys. Lett.",
+	pages = "365--368",
+	slaccitation = "%\%CITATION = PHLTA,B47,365;\%\%",
+	title = "{Advantages of the color octet gluon picture}",
+	volume = "B47",
+	year = "1973"
+}
+
+@article{Frommer:1994vn,
+	author = "Frommer, A. and Hannemann, V. and Nockel, B. and Lippert, T. and Schilling, K.",
+	eprint = "hep-lat/9404013",
+	journal = "Int. J. Mod. Phys.",
+	pages = "1073--1088",
+	slaccitation = "%\%CITATION = HEP-LAT 9404013;\%\%",
+	title = "{Accelerating {Wilson} fermion matrix inversions by means of the stabilized biconjugate gradient algorithm}",
+	volume = "C5",
+	year = "1994"
+}
+
+@article{Frommer:1995ik,
+	author = "Frommer, Andreas and Nockel, Bertold and Gusken, Stephan and Lippert, Thomas and Schilling, Klaus",
+	eprint = "hep-lat/9504020",
+	journal = "Int. J. Mod. Phys.",
+	pages = "627--638",
+	slaccitation = "%\%CITATION = HEP-LAT 9504020;\%\%",
+	title = "{Many masses on one stroke: Economic computation of quark propagators}",
+	volume = "C6",
+	year = "1995"
+}
+
+@article{Furman:1994ky,
+	author = "Furman, V. and Shamir, Y.",
+	eprint = "hep-lat/9405004",
+	journal = "Nucl. Phys.",
+	pages = "54--78",
+	slaccitation = "%\%CITATION = HEP-LAT 9405004;\%\%",
+	title = "{Axial symmetries in lattice QCD with Kaplan fermions}",
+	volume = "B439",
+	year = "1995"
+}
+
+@article{Garden:1999fg,
+	author = "Garden, J. and Heitger, J. and Sommer, R. and H., Wittig",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/9906013",
+	journal = "Nucl. Phys.",
+	pages = "237--256",
+	slaccitation = "%\%CITATION = HEP-LAT 9906013;\%\%",
+	title = "{Precision computation of the strange quark's mass in quenched {QCD}}",
+	volume = "B571",
+	year = "2000"
+}
+
+@article{Garron:2003cb,
+	author = "Garron, N. and Giusti, L. and Hoelbling, C. and Lellouch, L. and Rebbi, C.",
+	eprint = "hep-ph/0306295",
+	journal = "Phys. Rev. Lett.",
+	pages = "042001",
+	slaccitation = "%\%CITATION = HEP-PH 0306295;\%\%",
+	title = "{B(K) from quenched {QCD} with exact chiral symmetry}",
+	volume = "92",
+	year = "2004"
+}
+
+@article{Gasser:1982ap,
+	author = "Gasser, J. and Leutwyler, H.",
+	journal = "Phys. Rept.",
+	pages = "77--169",
+	slaccitation = "%\%CITATION = PRPLC,87,77;\%\%",
+	title = "{Quark masses}",
+	volume = "87",
+	year = "1982"
+}
+
+@article{Gasser:1983yg,
+	author = "Gasser, J. and Leutwyler, H.",
+	journal = "Ann. Phys.",
+	pages = "142",
+	slaccitation = "%\%CITATION = APNYA,158,142;\%\%",
+	title = "{Chiral perturbation theory to one loop}",
+	volume = "158",
+	year = "1984"
+}
+
+@article{Gasser:1985gg,
+	author = "Gasser, J. and Leutwyler, H.",
+	journal = "Nucl. Phys.",
+	pages = "465",
+	slaccitation = "%\%CITATION = NUPHA,B250,465;\%\%",
+	title = "{Chiral perturbation theory: expansions in the mass of the strange quark}",
+	volume = "B250",
+	year = "1985"
+}
+
+@article{Gasser:1986vb,
+	author = "Gasser, J. and Leutwyler, H.",
+	journal = "Phys. Lett.",
+	pages = "83",
+	slaccitation = "%\%CITATION = PHLTA,B184,83;\%\%",
+	title = "{LIGHT QUARKS AT LOW TEMPERATURES}",
+	volume = "B184",
+	year = "1987"
+}
+
+@article{Gattringer:2003qx,
+	author = "Gattringer, C. and others",
+	collaboration = "BGR",
+	eprint = "hep-lat/0307013",
+	journal = "Nucl. Phys.",
+	pages = "3--51",
+	slaccitation = "%\%CITATION = HEP-LAT 0307013;\%\%",
+	title = "{Quenched spectroscopy with fixed-point and chirally improved fermions}",
+	volume = "B677",
+	year = "2004"
+}
+
+@article{Gell-Mann:1964nj,
+	author = "Gell-Mann, M.",
+	journal = "Phys. Lett.",
+	pages = "214--215",
+	slaccitation = "%\%CITATION = PHLTA,8,214;\%\%",
+	title = "{A Schematic model of baryons and mesons}",
+	volume = "8",
+	year = "1964"
+}
+
+@article{Gell-Mann:1968rz,
+	author = "Gell-Mann, M. and Oakes, R. J. and Renner, B.",
+	journal = "Phys. Rev.",
+	pages = "2195--2199",
+	slaccitation = "%\%CITATION = PHRVA,175,2195;\%\%",
+	title = "{Behavior of current divergences under SU(3) x SU(3)}",
+	volume = "175",
+	year = "1968"
+}
+
+@phdthesis{Geus:2002,
+	author = "Geus, R.",
+	optaddress = "",
+	optannote = "",
+	optkey = "DISS. ETH NO. 14734",
+	optmonth = "",
+	optnote = "",
+	opttype = "",
+	school = "Swiss Federal Institute Of Technology Z{\"u}rich",
+	title = "{The Jacobi-Davidson algorithm for solving large sparse symmetric eigenvalue problems with application to the design of accelerator cavities}",
+	year = "2002"
+}
+
+@article{Gimenez:1998ue,
+	author = "Gimenez, V. and Giusti, L. and Rapuano, F. and Talevi, M.",
+	eprint = "hep-lat/9806006",
+	journal = "Nucl. Phys.",
+	pages = "429--445",
+	slaccitation = "%\%CITATION = HEP-LAT 9806006;\%\%",
+	title = "{Non-perturbative renormalization of quark bilinears}",
+	volume = "B531",
+	year = "1998"
+}
+
+@article{Gimenez:2005nt,
+	author = "Gimenez, V. and Lubicz, V. and Mescia, F. and Porretti, V. and Reyes, J.",
+	eprint = "hep-lat/0503001",
+	journal = "Eur. Phys. J.",
+	pages = "535--544",
+	slaccitation = "%\%CITATION = HEP-LAT/0503001;\%\%",
+	title = "{Operator product expansion and quark condensate from lattice QCD in coordinate space}",
+	volume = "C41",
+	year = "2005"
+}
+
+@article{Ginsparg:1981bj,
+	author = "Ginsparg, P. H. and {Wilson}, K. G.",
+	journal = "Phys. Rev.",
+	pages = "2649",
+	slaccitation = "%\%CITATION = PHRVA,D25,2649;\%\%",
+	title = "{A remnant of chiral symmetry on the lattice}",
+	volume = "D25",
+	year = "1982"
+}
+
+@article{Giusti:1998wy,
+	author = "Giusti, L. and Rapuano, F. and Talevi, M. and Vladikas, A.",
+	eprint = "hep-lat/9807014",
+	journal = "Nucl. Phys.",
+	pages = "249--277",
+	slaccitation = "%\%CITATION = HEP-LAT 9807014;\%\%",
+	title = "{The QCD chiral condensate from the lattice}",
+	volume = "B538",
+	year = "1999"
+}
+
+@article{Giusti:2001pk,
+	author = "Giusti, L. and Hoelbling, C. and Rebbi, C.",
+	eprint = "hep-lat/0108007",
+	journal = "Phys. Rev.",
+	note = "Erratum-ibid.D65:079903,2002",
+	pages = "114508",
+	slaccitation = "%\%CITATION = HEP-LAT 0108007;\%\%",
+	title = "{Light quark masses with overlap fermions in quenched {QCD}}",
+	volume = "D64",
+	year = "2001"
+}
+
+@article{Giusti:2002sm,
+	author = "Giusti, L. and Hoelbling, C. and L{\"u}scher, M. and Wittig, H.",
+	eprint = "hep-lat/0212012",
+	journal = "Comput. Phys. Commun.",
+	pages = "31--51",
+	slaccitation = "%\%CITATION = HEP-LAT 0212012;\%\%",
+	title = "{Numerical techniques for lattice QCD in the epsilon- regime}",
+	volume = "153",
+	year = "2003"
+}
+
+@article{Giusti:2007hk,
+	author = "Giusti, Leonardo",
+	eprint = "hep-lat/0702014",
+	journal = "PoS.",
+	pages = "",
+	slaccitation = "%\%CITATION = HEP-LAT/0702014;\%\%",
+	title = "{Light dynamical fermions on the lattice: Toward the chiral regime of QCD}",
+	volume = "LAT2006",
+	year = "2007"
+}
+
+@article{Glassner:1996gz,
+	author = "Gl{\"a}ssner, U. and others",
+	eprint = "hep-lat/9605008",
+	slaccitation = "%\%CITATION = HEP-LAT 9605008;\%\%",
+	title = "{How to compute {G}reen's functions for entire mass trajectories within {K}rylov solvers}",
+	year = "1996"
+}
+
+@article{Gockeler:1998fn,
+	author = "G{\"o}ckeler, M. and others",
+	eprint = "hep-lat/9707021",
+	journal = "Phys. Rev.",
+	pages = "5562--5580",
+	slaccitation = "%\%CITATION = HEP-LAT 9707021;\%\%",
+	title = "{Scaling of non-perturbatively {O(a)} improved {Wilson} fermions: Hadron spectrum, quark masses and decay constants}",
+	volume = "D57",
+	year = "1998"
+}
+
+@article{Gorishnii:1990vf,
+	author = "Gorishnii, S. G. and Kataev, A. L. and Larin, S. A.",
+	journal = "Phys. Lett.",
+	pages = "144--150",
+	slaccitation = "%\%CITATION = PHLTA,B259,144;\%\%",
+	title = "{The O (alpha-s**3) corrections to sigma-tot (e+ e- $\to$ hadrons) and Gamma (tau- $\to$ tau-neutrino + hadrons) in QCD}",
+	volume = "B259",
+	year = "1991"
+}
+
+@article{Greenberg:1964pe,
+	author = "Greenberg, O. W.",
+	journal = "Phys. Rev. Lett.",
+	pages = "598--602",
+	slaccitation = "%\%CITATION = PRLTA,13,598;\%\%",
+	title = "{Spin and unitary spin independence in a paraquark model of baryons and mesons}",
+	volume = "13",
+	year = "1964"
+}
+
+@article{Gregory:2007ce,
+	archiveprefix = "arXiv",
+	author = "Gregory, Eric B. and Irving, Alan and Richards, Chris M. and McNeile, Craig and Hart, Alistair",
+	eprint = "0710.1725",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0710.1725;\%\%",
+	title = "{Pseudoscalar Flavor-Singlet Physics with Staggered Fermions}",
+	year = "2007"
+}
+
+@article{Gross:1973id,
+	author = "Gross, D. J. and Wilczek, F.",
+	journal = "Phys. Rev. Lett.",
+	pages = "1343--1346",
+	slaccitation = "%\%CITATION = PRLTA,30,1343;\%\%",
+	title = "{Ultraviolet behavior of non-Abelian gauge theories}",
+	volume = "30",
+	year = "1973"
+}
+
+@article{Gross:1973ju,
+	author = "Gross, D. J. and Wilczek, F.",
+	journal = "Phys. Rev.",
+	pages = "3633--3652",
+	slaccitation = "%\%CITATION = PHRVA,D8,3633;\%\%",
+	title = "{Asymptotically free gauge theories. 1}",
+	volume = "D8",
+	year = "1973"
+}
+
+@article{Gross:1974jv,
+	author = "Gross, D. J. and Neveu, A.",
+	journal = "Phys. Rev.",
+	pages = "3235",
+	slaccitation = "%\%CITATION = PHRVA,D10,3235;\%\%",
+	title = "{Dynamical symmetry breaking in asymptotically free field theories}",
+	volume = "D10",
+	year = "1974"
+}
+
+@article{Guagnelli:1998ud,
+	author = "Guagnelli, M. and Sommer, R. and Wittig, H.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/9806005",
+	journal = "Nucl. Phys.",
+	pages = "389--402",
+	slaccitation = "%\%CITATION = HEP-LAT 9806005;\%\%",
+	title = "{Precision computation of a low-energy reference scale in quenched lattice {QCD}}",
+	volume = "B535",
+	year = "1998"
+}
+
+@article{Guagnelli:2004ga,
+	author = "Guagnelli, M. and others",
+	collaboration = "Zeuthen-Rome (ZeRo)",
+	eprint = "hep-lat/0405027",
+	journal = "Eur. Phys. J.",
+	pages = "69--80",
+	slaccitation = "%\%CITATION = HEP-LAT 0405027;\%\%",
+	title = "{Non-perturbative pion matrix element of a twist-2 operator from the lattice}",
+	volume = "C40",
+	year = "2005"
+}
+
+@article{Guagnelli:2004ww,
+	author = "Guagnelli, M. and others",
+	collaboration = "Zeuthen-Rome (ZeRo)",
+	eprint = "hep-lat/0403009",
+	journal = "Phys. Lett.",
+	pages = "216--221",
+	slaccitation = "%\%CITATION = HEP-LAT 0403009;\%\%",
+	title = "{Finite size effects of a pion matrix element}",
+	volume = "B597",
+	year = "2004"
+}
+
+@article{Guagnelli:2005zc,
+	author = "Guagnelli, M. and Heitger, J. and Pena, C. and Sint, S. and Vladikas, A.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0505002",
+	journal = "JHEP",
+	pages = "088",
+	slaccitation = "%\%CITATION = HEP-LAT 0505002;\%\%",
+	title = "{Non-perturbative renormalization of left-left four-fermion operators in quenched lattice QCD}",
+	volume = "03",
+	year = "2006"
+}
+
+@article{Gupta:1988js,
+	author = "Gupta, R. and Kilcup, G. W. and Sharpe, S. R.",
+	journal = "Phys. Rev.",
+	pages = "1278",
+	slaccitation = "%\%CITATION = PHRVA,D38,1278;\%\%",
+	title = "{Tuning the hybrid monte carlo algorithm}",
+	volume = "D38",
+	year = "1988"
+}
+
+@article{Gupta:1989kx,
+	author = "Gupta, R. and others",
+	journal = "Phys. Rev.",
+	pages = "2072",
+	slaccitation = "%\%CITATION = PHRVA,D40,2072;\%\%",
+	title = "{{QCD} with dynamical {Wilson} fermions}",
+	volume = "D40",
+	year = "1989"
+}
+
+@article{Gupta:1990ka,
+	author = "Gupta, S. and Irback, A. and Karsch, F. and Petersson, B.",
+	journal = "Phys. Lett.",
+	pages = "437--443",
+	slaccitation = "%\%CITATION = PHLTA,B242,437;\%\%",
+	title = "{The acceptance probability in the hybrid monte carlo method}",
+	volume = "B242",
+	year = "1990"
+}
+
+@article{Gupta:1991sn,
+	author = "Gupta, R. and others",
+	journal = "Phys. Rev.",
+	pages = "3272--3292",
+	slaccitation = "%\%CITATION = PHRVA,D44,3272;\%\%",
+	title = "{{QCD} with dynamical {Wilson} fermions. 2}",
+	volume = "D44",
+	year = "1991"
+}
+
+@unpublished{Gupta:1997nd,
+	author = "Gupta, R.",
+	eprint = "hep-lat/9807028",
+	note = "Lectures given at Les Houches Summer School in Theoretical Physics, Session 68",
+	slaccitation = "%\%CITATION = HEP-LAT 9807028;\%\%",
+	title = "{Introduction to lattice {QCD}}",
+	year = "1997"
+}
+
+@article{Han:1965pf,
+	author = "Han, M. Y. and Nambu, Yoichiro",
+	journal = "Phys. Rev.",
+	pages = "B1006--B1010",
+	slaccitation = "%\%CITATION = PHRVA,139,B1006;\%\%",
+	title = "{Three-triplet model with double SU(3) symmetry}",
+	volume = "139",
+	year = "1965"
+}
+
+@article{Hasenbusch:2001ne,
+	author = "Hasenbusch, M.",
+	eprint = "hep-lat/0107019",
+	journal = "Phys. Lett.",
+	pages = "177--182",
+	slaccitation = "%\%CITATION = HEP-LAT 0107019;\%\%",
+	title = "{Speeding up the {H}ybrid-{M}onte-{C}arlo algorithm for dynamical fermions}",
+	volume = "B519",
+	year = "2001"
+}
+
 @article{Hasenbusch:2002ai,
-      author         = "Hasenbusch, M. and Jansen, K.",
-      title          = "{Speeding up lattice QCD simulations with clover improved
-                        Wilson fermions}",
-      journal        = "Nucl.Phys.",
-      volume         = "B659",
-      pages          = "299-320",
-      doi            = "10.1016/S0550-3213(03)00227-X",
-      year           = "2003",
-      eprint         = "hep-lat/0211042",
-      archivePrefix  = "arXiv",
-      primaryClass   = "hep-lat",
-      reportNumber   = "DESY-02-200",
-      SLACcitation   = "%%CITATION = HEP-LAT/0211042;%%",
-}
-@Article{Hasenbusch:2003vg,
-     author    = "Hasenbusch, M.",
-     title     = "Full {QCD} algorithms towards the chiral limit",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "129",
-     year      = "2004",
-     pages     = "27-33",
-     eprint    = "hep-lat/0310029",
-     SLACcitation  = "%%CITATION = HEP-LAT 0310029;%%"
-}
-@Article{Hasenfratz:1998jp,
-     author    = "Hasenfratz, P.",
-     title     = "Lattice {QCD} without tuning, mixing and current
-                  renormalization",
-     journal   = "Nucl. Phys.",
-     volume    = "B525",
-     year      = "1998",
-     pages     = "401-409",
-     eprint    = "hep-lat/9802007",
-     SLACcitation  = "%%CITATION = HEP-LAT 9802007;%%"
-}
-@Article{Hasenfratz:1998ri,
-     author    = "Hasenfratz, P. and Laliena, V. and Niedermayer,
-                  F.",
-     title     = "The index theorem in {QCD} with a finite cut-off",
-     journal   = "Phys. Lett.",
-     volume    = "B427",
-     year      = "1998",
-     pages     = "125-131",
-     eprint    = "hep-lat/9801021",
-     SLACcitation  = "%%CITATION = HEP-LAT 9801021;%%"
-}
-@Article{Hasenfratz:2001hp,
-     author    = "Hasenfratz, A. and Knechtli, F.",
-     title     = "Flavor symmetry and the static potential with hypercubic
-                  blocking",
-     journal   = "Phys. Rev.",
-     volume    = "D64",
-     year      = "2001",
-     pages     = "034504",
-     eprint    = "hep-lat/0103029",
-     SLACcitation  = "%%CITATION = HEP-LAT 0103029;%%"
-}
-@Article{Hasenfratz:2001tw,
-     author    = "Hasenfratz, A. and Hoffmann, R. and Knechtli, F.",
-     title     = "The static potential with hypercubic blocking",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "418-420",
-     eprint    = "hep-lat/0110168",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110168;%%"
-}
-@Article{Hashimoto:2008xg,
-     author    = "Hashimoto, Koichi and Izubuchi, Taku",
-     title     = "{eta' meson from two flavor dynamical domain wall
-                  fermions}",
-     year      = "2008",
-     eprint    = "0803.0186",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = ARXIV:0803.0186;%%"
-}
-@Article{Heitger:2000ay,
-     author    = "Heitger, J. and Sommer, R. and Wittig, H.",
- collaboration = "ALPHA",
-     title     = "Effective chiral Lagrangians and lattice {{QCD}}",
-     journal   = "Nucl. Phys.",
-     volume    = "B588",
-     year      = "2000",
-     pages     = "377-399",
-     eprint    = "hep-lat/0006026",
-     note      = "and references therein",
-     SLACcitation  = "%%CITATION = HEP-LAT 0006026;%%"
-}
-@Article{Hernandez:1998et,
-     author    = "Hernandez, P. and Jansen, K. and L{\"u}scher, M.",
-     title     = "Locality properties of Neuberger's lattice Dirac operator",
-     journal   = "Nucl. Phys.",
-     volume    = "B552",
-     year      = "1999",
-     pages     = "363-378",
-     eprint    = "hep-lat/9808010",
-     SLACcitation  = "%%CITATION = HEP-LAT 9808010;%%"
-}
-@Article{Hernandez:2000sb,
-     author    = "Hernandez, P. and Jansen, K. and Lellouch, L.",
-     title     = "A numerical treatment of Neuberger's lattice Dirac
-                  operator",
-     year      = "2000",
-     eprint    = "hep-lat/0001008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0001008;%%"
-}
-@Article{Hernandez:2001hq,
-     author    = "Hernandez, P. and Jansen, K. and Lellouch, L. and
-                  Wittig, H.",
-     title     = "Scalar condensate and light quark masses from overlap
-                  fermions",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "766-771",
-     eprint    = "hep-lat/0110199",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110199;%%"
-}
-@Article{Hernandez:2001yn,
-     author    = "Hernandez, P. and Jansen, K. and Lellouch, L. and
-                  Wittig, H.",
-     title     = "Non-perturbative renormalization of the quark condensate in
-                  {Ginsparg}-{Wilson} regularizations",
-     journal   = "JHEP",
-     volume    = "07",
-     year      = "2001",
-     pages     = "018",
-     eprint    = "hep-lat/0106011",
-     SLACcitation  = "%%CITATION = HEP-LAT 0106011;%%"
-}
-@Article{Horsley:2004mx,
-     author    = "Horsley, R. and Perlt, H. and Rakow, P. E. L. and
-                  Schierholz, G. and Schiller, A.",
- collaboration = "QCDSF",
-     title     = "One-loop renormalisation of quark bilinears for overlap
-                  fermions with  improved gauge actions",
-     journal   = "Nucl. Phys.",
-     volume    = "B693",
-     year      = "2004",
-     pages     = "3-35",
-     eprint    = "hep-lat/0404007",
-     SLACcitation  = "%%CITATION = HEP-LAT 0404007;%%"
-}
-@Article{Ilgenfritz:2003gw,
-     author    = "Ilgenfritz, E.-M. and Kerler, W. and
-                  M{\"u}ller-Preu{\ss}ker, M. and Sternbeck, A. and St{\"u}ben, H.",
-     title     = "A numerical reinvestigation of the {Aoki} phase with {N(f)} = 2
-                  {Wilson}  fermions at zero temperature",
-     journal   = "Phys. Rev.",
-     volume    = "D69",
-     year      = "2004",
-     pages     = "074511",
-     eprint    = "hep-lat/0309057",
-     SLACcitation  = "%%CITATION = HEP-LAT 0309057;%%"
-}
-@Article{Ilgenfritz:2006tz,
-     author    = "Ilgenfritz, E. -M. and others",
-     title     = "Twisted mass QCD thermodynamics: First results on apeNEXT",
-     year      = "2006",
-     eprint    = "hep-lat/0610112",
-     SLACcitation  = "%%CITATION = HEP-LAT 0610112;%%"
-}
-@Article{Iwasaki:1983ck,
-     author    = "Iwasaki, Y.",
-     title     = "Renormalization group analysis of lattice theories and
-                  improved lattice action. 2. four-dimensional nonabelian
-                  SU(N) gauge model",
-     note     = "UTHEP-118"
-}
-@Article{Iwasaki:1985we,
-     author    = "Iwasaki, Y.",
-     title     = "Renormalization group analysis of lattice theories and
-                  improved lattice action: two-dimensional nonlinear O(N)
-                  sigma model",
-     journal   = "Nucl. Phys.",
-     volume    = "B258",
-     year      = "1985",
-     pages     = "141-156",
-     SLACcitation  = "%%CITATION = NUPHA,B258,141;%%"
-}
-@Article{Iwasaki:1992hn,
-     author    = "Iwasaki, Y. and Kanaya, K. and Sakai, S. and Yoshie, T.",
-     title     = "Quark confinement in multi - flavor quantum
-                  chromodynamics",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "30",
-     year      = "1993",
-     pages     = "327-330",
-     eprint    = "hep-lat/9211035",
-     SLACcitation  = "%%CITATION = HEP-LAT 9211035;%%"
-}
-@Article{Izubuchi:1998hy,
-     author    = "Izubuchi, T. and Noaki, J. and Ukawa, A.",
-     title     = "Two-dimensional lattice Gross-Neveu model with {Wilson}
-                  fermion action at  finite temperature and chemical
-                  potential",
-     journal   = "Phys. Rev.",
-     volume    = "D58",
-     year      = "1998",
-     pages     = "114507",
-     eprint    = "hep-lat/9805019",
-     SLACcitation  = "%%CITATION = HEP-LAT 9805019;%%"
-}
-@Article{Jacobs:1983ph,
-     author    = "Jacobs, L.",
-     title     = "Undoubling chirally symmetric lattice fermions",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "51",
-     year      = "1983",
-     pages     = "172",
-     SLACcitation  = "%%CITATION = PRLTA,51,172;%%"
-}
-@Article{Jagels:1994a,
-     author    = "Jagels, C. F. and Reichel, L.",
-     title     = " fast minimal residual algorithm for shifted unitary matrices",
-     journal   = "Numer. Linear Algebra Appl.",
-     volume    = "1(6)",
-     pages     = "555-570",
-     year      = "1994"
-}
-@Article{Jagels:1994aa,
-     author    = "Jagels, C. F. and Reichel, L.",
-     title     = "A Fast Minimal Residual Algorithm for Shifted Unitary 
-                  Matrices",
-     journal   = "Numerical Linear Algebra with Aplications",
-     volume    = "1(6)",
-     year      = "1994",
-     pages     = "555-570",
-}
-@Article{Jansen:1994ym,
-     author    = "Jansen, K.",
-     title     = "Domain wall fermions and chiral gauge theories",
-     journal   = "Phys. Rept.",
-     volume    = "273",
-     year      = "1996",
-     pages     = "1-54",
-     eprint    = "hep-lat/9410018",
-     SLACcitation  = "%%CITATION = HEP-LAT 9410018;%%"
-}
-@Article{Jansen:1995ck,
-     author    = "Jansen, Karl and others",
-     title     = "Non-perturbative renormalization of lattice QCD at all
-                  scales",
-     journal   = "Phys. Lett.",
-     volume    = "B372",
-     year      = "1996",
-     pages     = "275-282",
-     eprint    = "hep-lat/9512009",
-     SLACcitation  = "%%CITATION = HEP-LAT 9512009;%%"
-}
-@Article{Jansen:1996cq,
-     author    = "Jansen, K. and Liu, C.",
-     title     = "Study of Liapunov exponents and the reversibility of
-                  molecular dynamics  algorithms",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "53",
-     year      = "1997",
-     pages     = "974-976",
-     eprint    = "hep-lat/9607057",
-     SLACcitation  = "%%CITATION = HEP-LAT 9607057;%%"
-}
-@Article{Jansen:1996xp,
-     author    = "Jansen, K.",
-     title     = "Recent developments in fermion simulation algorithms",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "53",
-     year      = "1997",
-     pages     = "127-133",
-     eprint    = "hep-lat/9607051",
-     SLACcitation  = "%%CITATION = HEP-LAT 9607051;%%"
-}
-@Article{Jansen:1997yt,
-     author    = "Jansen, K. and Liu, C.",
-     title     = "Implementation of Symanzik's improvement program for
-                  simulations of  dynamical {Wilson} fermions in lattice {QCD}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "99",
-     year      = "1997",
-     pages     = "221-234",
-     eprint    = "hep-lat/9603008",
-     SLACcitation  = "%%CITATION = HEP-LAT 9603008;%%"
-}
-@Article{Jansen:1998mx,
-     author    = "Jansen, K. and Sommer, R.",
- collaboration = "ALPHA",
-     title     = "O(alpha) improvement of lattice {QCD} with two flavors of
-                  {Wilson} quarks",
-     journal   = "Nucl. Phys.",
-     volume    = "B530",
-     year      = "1998",
-     pages     = "185-203",
-     eprint    = "hep-lat/9803017",
-     SLACcitation  = "%%CITATION = HEP-LAT 9803017;%%"
-}
-@Article{Jansen:2003ir,
-     author    = "Jansen, K. and Shindler, A. and Urbach, C. and
-                  Wetzorke, I.",
- collaboration = "\xlf",
-     title     = "Scaling test for {Wilson} twisted mass {QCD}",
-     journal   = "Phys. Lett.",
-     volume    = "B586",
-     year      = "2004",
-     pages     = "432-438",
-     eprint    = "hep-lat/0312013",
-     SLACcitation  = "%%CITATION = HEP-LAT 0312013;%%"
-}
-@Article{Jansen:2003jq,
-     author    = "Jansen, K. and Nagai, K.-I.",
-     title     = "Reducing residual-mass effects for domain-wall fermions",
-     journal   = "JHEP",
-     volume    = "12",
-     year      = "2003",
-     pages     = "038",
-     eprint    = "hep-lat/0305009",
-     SLACcitation  = "%%CITATION = HEP-LAT 0305009;%%"
-}
-@Article{Jansen:2003nt,
-     author    = "Jansen, K.",
-     title     = "Actions for dynamical fermion simulations: Are we ready to
-                  go?",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "129",
-     year      = "2004",
-     pages     = "3-16",
-     eprint    = "hep-lat/0311039",
-     SLACcitation  = "%%CITATION = HEP-LAT 0311039;%%"
-}
-@Article{Jansen:2005cg,
-     author    = "Jansen, K. and others",
- collaboration = "\xlf",
-     title     = "Flavour breaking effects of {Wilson} twisted mass fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B624",
-     year      = "2005",
-     pages     = "334-341",
-     eprint    = "hep-lat/0507032",
-     SLACcitation  = "%%CITATION = HEP-LAT 0507032;%%"
-}
-@Unpublished{Jansen:2005chi,
-  author = 	 {Jansen, K. and others},
-collaborations = {\xlf},
-  title = 	 {},
-  note = 	 {in preparation},
-  OPTkey = 	 {},
-  OPTmonth = 	 {},
-  year = 	 {2005},
-  OPTannote = 	 {}
-}
-@Article{Jansen:2005gf,
-     author    = "Jansen, K. and Papinutto, M. and Shindler, A. and Urbach,
-                  C. and Wetzorke, I.",
- collaboration = "\xlf",
-     title     = "Light quarks with twisted mass fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B619",
-     year      = "2005",
-     pages     = "184-191",
-     eprint    = "hep-lat/0503031",
-     SLACcitation  = "%%CITATION = HEP-LAT 0503031;%%"
-}
-@Article{Jansen:2005kk,
-     author    = "Jansen, K. and Papinutto, M. and Shindler, A. and Urbach,
-                  C. and Wetzorke, I.",
- collaboration = "\xlf",
-     title     = "Quenched scaling of {Wilson} twisted mass fermions",
-     journal   = "JHEP",
-     volume    = "09",
-     year      = "2005",
-     pages     = "071",
-     eprint    = "hep-lat/0507010",
-     SLACcitation  = "%%CITATION = HEP-LAT 0507010;%%"
-}
-@Article{Jansen:2005yp,
-     author    = "Jansen, Karl and Shindler, Andrea and Urbach, Carsten and
-                  Wenger, Urs",
-     title     = "{HMC} algorithm with multiple time scale integration and mass
-                  preconditioning",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "118",
-     eprint    = "hep-lat/0510064",
-     SLACcitation  = "%%CITATION = HEP-LAT 0510064;%%"
-}
-@Article{Jansen:2006ks,
-     author    = "Jansen, Karl",
-     title     = "Status report on ILDG activities",
-     year      = "2006",
-     eprint    = "hep-lat/0609012",
-     SLACcitation  = "%%CITATION = HEP-LAT 0609012;%%"
-}
-@Article{Jansen:2006rf,
-     author    = "Jansen, Karl and Urbach, Carsten",
- collaboration = "ETM",
-     title     = "First results with two light flavours of quarks with
-                  maximally twisted mass",
-     year      = "2006",
-     eprint    = "hep-lat/0610015",
-     SLACcitation  = "%%CITATION = HEP-LAT 0610015;%%"
-}
-@Article{Jansen:2008wv,
-     author    = "Jansen, K. and Michael, C. and Urbach, C.",
- collaboration = "ETM",
-     title     = "The eta' meson from lattice {QCD}",
-     year      = "2008",
-     eprint    = "0804.3871",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0804.3871;%%"
-}
-@Article{Jansen:2008zz,
-     author    = "Jansen, K. and Michael, C. and Urbach, C.",
-     title     = "{The eta-prime meson from lattice QCD}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C58",
-     year      = "2008",
-     pages     = "261-269",
-     doi       = "10.1140/epjc/s10052-008-0764-6",
-     SLACcitation  = "%%CITATION = EPHJA,C58,261;%%"
-}
-@Unpublished{Jegerlehner:1996pm,
-     author    = "Jegerlehner, Beat",
-     title     = "Krylov space solvers for shifted linear systems",
-     year      = "1996",
-     eprint    = "hep-lat/9612014",
-     note      = "unpublished",
-     SLACcitation  = "%%CITATION = HEP-LAT 9612014;%%"
-}
-@Article{Jegerlehner:1997rn,
-     author    = "Jegerlehner, B.",
-     title     = "Multiple mass solvers",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "63",
-     year      = "1998",
-     pages     = "958-960",
-     eprint    = "hep-lat/9708029",
-     SLACcitation  = "%%CITATION = HEP-LAT 9708029;%%"
-}
-@Article{Jegerlehner:2003qp,
-     author    = "Jegerlehner, F.",
-     title     = "Theoretical precision in estimates of the hadronic
-                  contributions to  (g-2)mu and alpha(QED)(M(Z))",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "126",
-     year      = "2004",
-     pages     = "325-334",
-     eprint    = "hep-ph/0310234",
-     SLACcitation  = "%%CITATION = HEP-PH 0310234;%%"
+	archiveprefix = "arXiv",
+	author = "Hasenbusch, M. and Jansen, K.",
+	doi = "10.1016/S0550-3213(03)00227-X",
+	eprint = "hep-lat/0211042",
+	journal = "Nucl.Phys.",
+	pages = "299--320",
+	primaryclass = "hep-lat",
+	reportnumber = "DESY-02-200",
+	slaccitation = "%\%CITATION = HEP-LAT/0211042;\%\%",
+	title = "{Speeding up lattice QCD simulations with clover improved Wilson fermions}",
+	volume = "B659",
+	year = "2003"
 }
 
-@Article{Jenkins:1990jv,
-     author    = "Jenkins, Elizabeth Ellen and Manohar, Aneesh V.",
-     title     = "Baryon chiral perturbation theory using a heavy fermion
-                  Lagrangian",
-     journal   = "Phys. Lett.",
-     volume    = "B255",
-     year      = "1991",
-     pages     = "558-562",
-     SLACcitation  = "%%CITATION = PHLTA,B255,558;%%"
-}
-@Article{Kaiser:1998ds,
-     author    = "Kaiser, Roland and Leutwyler, H.",
-     title     = "{Pseudoscalar decay constants at large N(c)}",
-     year      = "1998",
-     eprint    = "hep-ph/9806336",
-     SLACcitation  = "%%CITATION = HEP-PH/9806336;%%"
-}
-@Article{Kalkreuter:1995mm,
-     author    = "Kalkreuter, Thomas and Simma, Hubert",
-     title     = "An Accelerated conjugate gradient algorithm to compute low
-                  lying eigenvalues: A Study for the Dirac operator in SU(2)
-                  lattice QCD",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "93",
-     year      = "1996",
-     pages     = "33-47",
-     eprint    = "hep-lat/9507023",
-     SLACcitation  = "%%CITATION = HEP-LAT 9507023;%%"
-}
-@Article{Kalkreuter:1996mm,
-     author    = "Kalkreuter, T. and Simma, H.",
-     title     = "An Accelerated conjugate gradient algorithm to compute low
-                  lying eigenvalues: A Study for the Dirac operator in SU(2)
-                  lattice {QCD}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "93",
-     year      = "1996",
-     pages     = "33-47",
-     eprint    = "hep-lat/9507023",
-     SLACcitation  = "%%CITATION = HEP-LAT 9507023;%%"
-}
-@Article{Kaplan:1992bt,
-     author    = "Kaplan, D. B.",
-     title     = "A Method for simulating chiral fermions on the lattice",
-     journal   = "Phys. Lett.",
-     volume    = "B288",
-     year      = "1992",
-     pages     = "342-347",
-     eprint    = "hep-lat/9206013",
-     SLACcitation  = "%%CITATION = HEP-LAT 9206013;%%"
-}
-@Article{Karsten:1980wd,
-     author    = "Karsten, L. H. and Smit, J.",
-     title     = "Lattice fermions: species doubling, chiral invariance, and
-                  the triangle anomaly",
-     journal   = "Nucl. Phys.",
-     volume    = "B183",
-     year      = "1981",
-     pages     = "103",
-     SLACcitation  = "%%CITATION = NUPHA,B183,103;%%"
-}
-@Article{Kennedy:1990bv,
-     author    = "Kennedy, A. D. and Pendleton, B.",
-     title     = "Acceptances and autocorrelations in hybrid Monte Carlo",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "20",
-     year      = "1991",
-     pages     = "118-121",
-     SLACcitation  = "%%CITATION = NUPHZ,20,118;%%"
-}
-@Article{Knechtli:1998gf,
-     author    = "Knechtli, F. and Sommer, R.",
- collaboration = "ALPHA",
-     title     = "String breaking in SU(2) gauge theory with scalar matter
-                  fields",
-     journal   = "Phys. Lett.",
-     volume    = "B440",
-     year      = "1998",
-     pages     = "345-352",
-     eprint    = "hep-lat/9807022",
-     SLACcitation  = "%%CITATION = HEP-LAT 9807022;%%"
-}
-@Article{Knechtli:2000df,
-     author    = "Knechtli, F. and Sommer, R.",
- collaboration = "ALPHA",
-     title     = "String breaking as a mixing phenomenon in the SU(2) Higgs
-                  model",
-     journal   = "Nucl. Phys.",
-     volume    = "B590",
-     year      = "2000",
-     pages     = "309-328",
-     eprint    = "hep-lat/0005021",
-     SLACcitation  = "%%CITATION = HEP-LAT 0005021;%%"
-}
-@Article{Lacock:1994qx,
-     author    = "Lacock, P. and McKerrell, A. and Michael, C. and Stopher,
-                            I. M. and Stephenson, P. W.",
-     collaboration = "UKQCD",
-     title     = "Efficient hadronic operators in lattice gauge theory",
-     journal   = "Phys. Rev.",
-     volume    = "D51",
-     year      = "1995",
-     pages     = "6403-6410",
-     eprint    = "hep-lat/9412079",
-     SLACcitation  = "%%CITATION = HEP-LAT 9412079;%%"
-}
-@Article{Lepage:1992xa,
-     author    = "Lepage, G. Peter and Mackenzie, Paul B.",
-     title     = "On the viability of lattice perturbation theory",
-     journal   = "Phys. Rev.",
-     volume    = "D48",
-     year      = "1993",
-     pages     = "2250-2264",
-     eprint    = "hep-lat/9209022",
-     SLACcitation  = "%%CITATION = HEP-LAT 9209022;%%"
-}
-@Article{Lepage:2001ym,
-     author    = "Lepage, G. P. and others",
-     title     = "{Constrained curve fitting}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "12-20",
-     eprint    = "hep-lat/0110175",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/S0920-5632(01)01638-3",
-     SLACcitation  = "%%CITATION = HEP-LAT/0110175;%%"
-}
-@Article{Lesk:2002gd,
-     author    = "Lesk, V. I. and others",
- collaboration = "CP-PACS",
-     title     = "Flavor singlet meson mass in the continuum limit in two-
-                  flavor lattice QCD",
-     journal   = "Phys. Rev.",
-     volume    = "D67",
-     year      = "2003",
-     pages     = "074503",
-     eprint    = "hep-lat/0211040",
-     SLACcitation  = "%%CITATION = HEP-LAT/0211040;%%"
-}
-@Article{Leutwyler:1997yr,
-     author    = "Leutwyler, H.",
-     title     = "{On the 1/N-expansion in chiral perturbation theory}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "64",
-     year      = "1998",
-     pages     = "223-231",
-     eprint    = "hep-ph/9709408",
-     SLACcitation  = "%%CITATION = HEP-PH/9709408;%%"
-}
-@Article{Leutwyler:2006qq,
-     author    = "Leutwyler, H.",
-     title     = "pi pi scattering",
-     year      = "2006",
-     eprint    = "hep-ph/0612112",
-     SLACcitation  = "%%CITATION = HEP-PH 0612112;%%"
-}
-@Article{Liu:1997fs,
-     author    = "Liu, C. and Jaster, A. and Jansen, K.",
-     title     = "Liapunov exponents and the reversibility of molecular
-                  dynamics  algorithms",
-     journal   = "Nucl. Phys.",
-     volume    = "B524",
-     year      = "1998",
-     pages     = "603-617",
-     eprint    = "hep-lat/9708017",
-     SLACcitation  = "%%CITATION = HEP-LAT 9708017;%%"
-}
-@Article{Luscher:1985dn,
-     author    = "Luscher, M.",
-     title     = "{Volume Dependence of the Energy Spectrum in Massive
-                  Quantum Field Theories. 1. Stable Particle States}",
-     journal   = "Commun. Math. Phys.",
-     volume    = "104",
-     year      = "1986",
-     pages     = "177",
-     doi       = "10.1007/BF01211589",
-     SLACcitation  = "%%CITATION = CMPHA,104,177;%%"
-}
-@Article{Luscher:1990ck,
-     author    = "L{\"u}scher, M. and Wolff, U.",
-     title     = "How to calculate the elastic scattering matrix in two-
-                  dimensional quantum field theories by numerical
-                  simulation",
-     journal   = "Nucl. Phys.",
-     volume    = "B339",
-     year      = "1990",
-     pages     = "222-252",
-     SLACcitation  = "%%CITATION = NUPHA,B339,222;%%"
-}
-@Article{Luscher:1993dy,
-     author    = "Luscher, Martin",
-     title     = "{A Portable high quality random number generator for
-                  lattice field theory simulations}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "79",
-     year      = "1994",
-     pages     = "100-110",
-     eprint    = "hep-lat/9309020",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/0010-4655(94)90232-1",
-     SLACcitation  = "%%CITATION = HEP-LAT/9309020;%%"
-}
-@Article{Luscher:1993xx,
-     author    = "L{\"u}scher, M.",
-     title     = "A New approach to the problem of dynamical quarks in
-                  numerical simulations of lattice {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B418",
-     year      = "1994",
-     pages     = "637-648",
-     eprint    = "hep-lat/9311007",
-     SLACcitation  = "%%CITATION = HEP-LAT 9311007;%%"
-}
-@Article{Luscher:1996sc,
-     author    = "L{\"u}scher, M. and Sint, S. and Sommer, R. and
-                  Weisz, P.",
-     title     = "Chiral symmetry and {O(a)} improvement in lattice {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B478",
-     year      = "1996",
-     pages     = "365-400",
-     eprint    = "hep-lat/9605038",
-     SLACcitation  = "%%CITATION = HEP-LAT 9605038;%%"
-}
-@Article{Luscher:1996ug,
-     author    = "L{\"u}scher, M. and Sint, S. and Sommer, R. and
-                  Weisz, P. and Wolff, U.",
-     title     = "Non-perturbative {O(a)} improvement of lattice {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B491",
-     year      = "1997",
-     pages     = "323-343",
-     eprint    = "hep-lat/9609035",
-     SLACcitation  = "%%CITATION = HEP-LAT 9609035;%%"
-}
-@Article{Luscher:1998pq,
-     author    = "L{\"u}scher, M.",
-     title     = "Exact chiral symmetry on the lattice and the {Ginsparg}-
-                  {Wilson} relation",
-     journal   = "Phys. Lett.",
-     volume    = "B428",
-     year      = "1998",
-     pages     = "342-345",
-     eprint    = "hep-lat/9802011",
-     SLACcitation  = "%%CITATION = HEP-LAT 9802011;%%"
-}
-@Article{Luscher:2001tx,
-     author    = "L{\"u}scher, Martin",
-     title     = "{Lattice QCD on PCs?}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "21-28",
-     eprint    = "hep-lat/0110007",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/S0920-5632(01)01639-5",
-     SLACcitation  = "%%CITATION = HEP-LAT/0110007;%%"
-}
-@Article{Luscher:2003qa,
-     author    = "L{\"u}scher, M.",
-     title     = "Solution of the {D}irac equation in lattice {QCD} using a
-                  domain  decomposition method",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "156",
-     year      = "2004",
-     pages     = "209-220",
-     eprint    = "hep-lat/0310048",
-     SLACcitation  = "%%CITATION = HEP-LAT 0310048;%%"
-}
-@Article{Luscher:2004rx,
-     author    = "L{\"u}scher, M.",
-     title     = "Schwarz-preconditioned {HMC} algorithm for two-flavour
-                  lattice {QCD}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "165",
-     year      = "2005",
-     pages     = "199",
-     eprint    = "hep-lat/0409106",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409106;%%"
+@article{Hasenbusch:2003vg,
+	author = "Hasenbusch, M.",
+	eprint = "hep-lat/0310029",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "27--33",
+	slaccitation = "%\%CITATION = HEP-LAT 0310029;\%\%",
+	title = "{Full {QCD} algorithms towards the chiral limit}",
+	volume = "129",
+	year = "2004"
 }
 
-@Article{Luscher:2005mv,
-     author    = "L{\"u}scher, Martin",
-     title     = "Lattice {QCD} with light {W}ilson quarks",
-     journal   = "\href{http://pos.sissa.it/archive/conferences/020/008/LAT2005_002.pdf}{PoS(LAT2005)002}", 
-     year      = "2005",
-     eprint    = "hep-lat/0509152",
-     howpublished="Talk presented at International Symposium on Lattice Field Theory (Lattice 2005)",
-     SLACcitation  = "%%CITATION = HEP-LAT 0509152;%%"
-}
-@Article{Luscher:ranluxweb,
-     author    = "L{\"u}scher, M.",
-     title     = "Ranlux random number generator",
-     eprint    = "http://luscher.web.cern.ch/luscher/ranlux/"
-}
-@Article{Luscher:sse,
-     author    = "L{\"u}scher, M.",
-     title     = "Lattice QCD parallel benchmark programs",
-     eprint    = "http://luscher.web.cern.ch/luscher/QCDpbm/"
-}
-@Article{Madras:1988ei,
-     author    = "Madras, N. and Sokal, A. D.",
-     title     = "The Pivot algorithm: a highly efficient Monte Carlo method
-                  for selfavoiding walk",
-     journal   = "J. Statist. Phys.",
-     volume    = "50",
-     year      = "1988",
-     pages     = "109-186",
-     SLACcitation  = "%%CITATION = JSTPB,50,109;%%"
-}
-@Article{Martinelli:1982mw,
-     author    = "Martinelli, G. and Zhang, Yi-Cheng",
-     title     = "THE CONNECTION BETWEEN LOCAL OPERATORS ON THE LATTICE AND
-                  IN THE CONTINUUM AND ITS RELATION TO MESON DECAY
-                  CONSTANTS",
-     journal   = "Phys. Lett.",
-     volume    = "B123",
-     year      = "1983",
-     pages     = "433",
-     SLACcitation  = "%%CITATION = PHLTA,B123,433;%%"
-}
-@Article{Martinelli:1994ty,
-     author    = "Martinelli, G. and Pittori, C. and Sachrajda, Christopher
-                  T. and Testa, M. and Vladikas, A.",
-     title     = "{A General method for nonperturbative renormalization of
-                  lattice operators}",
-     journal   = "Nucl. Phys.",
-     volume    = "B445",
-     year      = "1995",
-     pages     = "81-108",
-     eprint    = "hep-lat/9411010",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/0550-3213(95)00126-D",
-     SLACcitation  = "%%CITATION = HEP-LAT/9411010;%%"
-}
-@Article{McNeile:2000hf,
-     author    = "McNeile, C. and Michael, C.",
-     collaboration = "UKQCD",
-     title     = "The eta and eta' mesons in {QCD}",
-     journal   = "Phys. Lett.",
-     volume    = "B491",
-     year      = "2000",
-     pages     = "123-129",
-     eprint    = "hep-lat/0006020",
-     SLACcitation  = "%%CITATION = HEP-LAT 0006020;%%"
-}
-@Article{McNeile:2000xx,
-     author    = "McNeile, Craig and Michael, Chris",
-     collaboration = "UKQCD",
-     title     = "Mixing of scalar glueballs and flavour-singlet scalar
-                  mesons",
-     journal   = "Phys. Rev.",
-     volume    = "D63",
-     year      = "2001",
-     pages     = "114503",
-     eprint    = "hep-lat/0010019",
-     SLACcitation  = "%%CITATION = HEP-LAT0010019;%%"
-}
-@Article{McNeile:2001cr,
-     author    = "McNeile, C. and Michael, C. and Sharkey, K. J.",
- collaboration = "UKQCD",
-     title     = "The flavor singlet mesons in {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D65",
-     year      = "2002",
-     pages     = "014508",
-     eprint    = "hep-lat/0107003",
-     SLACcitation  = "%%CITATION = HEP-LAT 0107003;%%"
-}
-@Article{McNeile:2002fh,
-     author    = "McNeile, C. and Michael, C.",
- collaboration = "UKQCD",
-     title     = "Hadronic decay of a vector meson from the lattice",
-     journal   = "Phys. Lett.",
-     volume    = "B556",
-     year      = "2003",
-     pages     = "177-184",
-     eprint    = "hep-lat/0212020",
-     SLACcitation  = "%%CITATION = HEP-LAT 0212020;%%"
-}
-@Article{McNeile:2006bz,
-     author    = "McNeile, C. and Michael, C.",
-     collaboration = "UKQCD",
-     title     = "Decay width of light quark hybrid meson from the lattice",
-     journal   = "Phys. Rev.",
-     volume    = "D73",
-     year      = "2006",
-     pages     = "074506",
-     eprint    = "hep-lat/0603007",
-     SLACcitation  = "%%CITATION = HEP-LAT 0603007;%%"
-}
-@Article{Meyer:2006ty,
-     author    = "Meyer, Harvey B. and others",
-     title     = "{Exploring the HMC trajectory-length dependence of
-                  autocorrelation times in lattice QCD}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "176",
-     year      = "2007",
-     pages     = "91-97",
-     eprint    = "hep-lat/0606004",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/j.cpc.2006.08.002",
-     SLACcitation  = "%%CITATION = HEP-LAT/0606004;%%"
-}
-@Article{Michael:1982gb,
-     author    = "Michael, C. and Teasdale, I.",
-     title     = "EXTRACTING GLUEBALL MASSES FROM LATTICE QCD",
-     journal   = "Nucl. Phys.",
-     volume    = "B215",
-     year      = "1983",
-     pages     = "433",
-     SLACcitation  = "%%CITATION = NUPHA,B215,433;%%"
-}
-@Article{Michael:1989mf,
-     author    = "Michael, C.",
-     title     = "Particle decay in lattice gauge theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B327",
-     year      = "1989",
-     pages     = "515",
-     SLACcitation  = "%%CITATION = NUPHA,B327,515;%%"
-}
-@Article{Michael:1991nc,
-     author    = "Michael, C.",
-     title     = "Hadronic forces from the lattice",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "26",
-     year      = "1992",
-     pages     = "417-419",
-     SLACcitation  = "%%CITATION = NUPHZ,26,417;%%"
-}
-@Article{Michael:1993yj,
-     author    = "Michael, Christopher",
-     title     = "{Fitting correlated data}",
-     journal   = "Phys. Rev.",
-     volume    = "D49",
-     year      = "1994",
-     pages     = "2616-2619",
-     eprint    = "hep-lat/9310026",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.49.2616",
-     SLACcitation  = "%%CITATION = HEP-LAT/9310026;%%"
-}
-@Article{Michael:1994sz,
-     author    = "Michael, Christopher and McKerrell, A.",
-     title     = "{Fitting correlated hadron mass spectrum data}",
-     journal   = "Phys. Rev.",
-     volume    = "D51",
-     year      = "1995",
-     pages     = "3745-3750",
-     eprint    = "hep-lat/9412087",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.51.3745",
-     SLACcitation  = "%%CITATION = HEP-LAT/9412087;%%"
-}
-@Article{Michael:2007vn,
-     author    = "Michael, C. and Urbach, C.",
- collaboration = "ETM",
-     title     = "Neutral mesons and disconnected diagrams in Twisted Mass
-                  QCD",
-     journal   = "",
-     volume    = "",
-     pages     = "",
-     year      = "2007",
-     eprint    = "0709.4564",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = ARXIV:0709.4564;%%"
-}
-@Book{Montvay:1994cy,
-     author    = "Montvay, I. and M{\"u}nster, G.",
-     title     = "Quantum fields on a lattice",
-     publisher = "Cambridge University Press",
-     year      = "1994",
-     series    = "Cambridge Monographs on Mathematical Physics",
-}
-@Article{Montvay:1995ea,
-     author    = "Montvay, I.",
-     title     = "An Algorithm for Gluinos on the Lattice",
-     journal   = "Nucl. Phys.",
-     volume    = "B466",
-     year      = "1996",
-     pages     = "259-284",
-     eprint    = "hep-lat/9510042",
-     SLACcitation  = "%%CITATION = HEP-LAT 9510042;%%"
-}
-@Article{Montvay:2005tj,
-     author    = "Montvay, I. and Scholz, E.",
-     title     = "Updating algorithms with multi-step stochastic correction",
-     journal   = "Phys. Lett.",
-     volume    = "B623",
-     year      = "2005",
-     pages     = "73-79",
-     eprint    = "hep-lat/0506006",
-     SLACcitation  = "%%CITATION = HEP-LAT 0506006;%%"
-}
-@Article{Morgan:2002a,
-  author       = "Morgan, R. B.",
-  title        = "GMRES with Deated Restarting",
-  journal      = "SIAM J. Sci. Comput.",
-  volume       = "24",
-  year         = "2002",
-  pages        = "20"
-}
-@Article{Morningstar:2003gk,
-     author    = "Morningstar, Colin and Peardon, Mike J.",
-     title     = "{Analytic smearing of SU(3) link variables in lattice
-                  QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D69",
-     year      = "2004",
-     pages     = "054501",
-     eprint    = "hep-lat/0311018",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.69.054501",
-     SLACcitation  = "%%CITATION = HEP-LAT/0311018;%%"
-}
-@Article{Munster:2004am,
-     author    = "M{\"u}nster, G.",
-     title     = "On the phase structure of twisted mass lattice {QCD}",
-     journal   = "JHEP",
-     volume    = "09",
-     year      = "2004",
-     pages     = "035",
-     eprint    = "hep-lat/0407006",
-     SLACcitation  = "%%CITATION = HEP-LAT 0407006;%%"
-}
-@Article{Munster:2004wt,
-     author    = "M{\"u}nster, Gernot and Schmidt, Christian and Scholz, Enno E.
-                  ",
-     title     = "Chiral perturbation theory for twisted mass {QCD}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "320-322",
-     eprint    = "hep-lat/0409066",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409066;%%"
-}
-@Article{Nagai:2005mi,
-     author    = "Nagai, Kei-ichi and Jansen, Karl",
-     title     = "Two-dimensional lattice Gross-Neveu model with Wilson
-                  twisted mass  fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B633",
-     year      = "2006",
-     pages     = "325-330",
-     eprint    = "hep-lat/0510076",
-     SLACcitation  = "%%CITATION = HEP-LAT 0510076;%%"
-}   
-@Unpublished{Nagai:priv,
-  author = 	 {Nagai, K},
-  title = 	 {Two-dimensional Gross-Neveu model with {Wilson}
-                  twisted mass fermions},
-  note = 	 {private communication},
-  OPTkey = 	 {},
-  OPTmonth = 	 {},
-  OPTyear = 	 {},
-  OPTannote = 	 {}
-}
-@Article{Necco:2001xg,
-     author    = "Necco, S. and Sommer, R.",
-     title     = "The {N(f)} = 0 heavy quark potential from short to
-                  intermediate  distances",
-     journal   = "Nucl. Phys.",
-     volume    = "B622",
-     year      = "2002",
-     pages     = "328-346",
-     eprint    = "hep-lat/0108008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0108008;%%"
-}
-@Article{Necco:2003vh,
-     author    = "Necco, Silvia",
-     journal   = "Nucl. Phys.",
-     volume    = "B683",
-     year      = "2004",
-     pages     = "137-167",
-     eprint    = "hep-lat/0309017",
-     SLACcitation  = "%%CITATION = HEP-LAT 0309017;%%"
-}
-@Article{Neff:2001zr,
-     author    = "Neff, H. and Eicker, N. and Lippert, T. and Negele, J. W.
-                  and Schilling, K.",
-     title     = "On the low fermionic eigenmode dominance in {QCD} on the
-                  lattice",
-     journal   = "Phys. Rev.",
-     volume    = "D64",
-     year      = "2001",
-     pages     = "114509",
-     eprint    = "hep-lat/0106016",
-     SLACcitation  = "%%CITATION = HEP-LAT/0106016;%%"
-}
-@Article{Neuberger:1997fp,
-     author    = "Neuberger, H.",
-     title     = "Exactly massless quarks on the lattice",
-     journal   = "Phys. Lett.",
-     volume    = "B417",
-     year      = "1998",
-     pages     = "141-144",
-     eprint    = "hep-lat/9707022",
-     SLACcitation  = "%%CITATION = HEP-LAT 9707022;%%"
-}
-@Article{Neuberger:1998wv,
-     author    = "Neuberger, H.",
-     title     = "More about exactly massless quarks on the lattice",
-     journal   = "Phys. Lett.",
-     volume    = "B427",
-     year      = "1998",
-     pages     = "353-355",
-     eprint    = "hep-lat/9801031",
-     SLACcitation  = "%%CITATION = HEP-LAT 9801031;%%"
-}
-@Article{Niedermayer:1998bi,
-     author    = "Niedermayer, F.",
-     title     = "Exact chiral symmetry, topological charge and related
-                  topics",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "73",
-     year      = "1999",
-     pages     = "105-119",
-     eprint    = "hep-lat/9810026",
-     SLACcitation  = "%%CITATION = HEP-LAT 9810026;%%"
-}
-@Article{Nielsen:1980rz,
-     author    = "Nielsen, H. B. and Ninomiya, M.",
-     title     = "Absence of neutrinos on a lattice. 1. proof by homotopy
-                  theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B185",
-     year      = "1981",
-     pages     = "20",
-     SLACcitation  = "%%CITATION = NUPHA,B185,20;%%"
-}
-@Article{Nielsen:1981hk,
-     author    = "Nielsen, H. B. and Ninomiya, M.",
-     title     = "No go theorem for regularizing chiral fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B105",
-     year      = "1981",
-     pages     = "219",
-     SLACcitation  = "%%CITATION = PHLTA,B105,219;%%"
-}
-@Article{Nielsen:1981xu,
-     author    = "Nielsen, H. B. and Ninomiya, M.",
-     title     = "Absence of neutrinos on a lattice. 2. intuitive topological
-                  proof",
-     journal   = "Nucl. Phys.",
-     volume    = "B193",
-     year      = "1981",
-     pages     = "173",
-     SLACcitation  = "%%CITATION = NUPHA,B193,173;%%"
-}
-@Article{Noaki:1998zc,
-     author    = "Noaki, J. and Izubuchi, T. and Ukawa, A.",
-     title     = "Two-dimensional Gross-Neveu model with {Wilson} fermion
-                  action at finite temperature and density",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "73",
-     year      = "1999",
-     pages     = "483-485",
-     eprint    = "hep-lat/9809071",
-     SLACcitation  = "%%CITATION = HEP-LAT 9809071;%%"
-}
-@Article{Orginos:2001xa,
-     author    = "Orginos, K.",
- collaboration = "RBC",
-     title     = "Chiral properties of domain wall fermions with improved
-                  gauge actions",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "721-723",
-     eprint    = "hep-lat/0110074",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110074;%%"
-}
-@Article{Orth:2005kq,
-     author    = "Orth, B. and Lippert, T. and Schilling, K.",
-     title     = "Finite-size effects in lattice {QCD} with dynamical {Wilson}
-                  fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D72",
-     year      = "2005",
-     pages     = "014503",
-     eprint    = "hep-lat/0503016",
-     SLACcitation  = "%%CITATION = HEP-LAT 0503016;%%"
-}
-@Article{Osterwalder:1973dx,
-     author    = "Osterwalder, K. and Schrader, R.",
-     title     = "Axioms for euclidean Green's functions",
-     journal   = "Commun. Math. Phys.",
-     volume    = "31",
-     year      = "1973",
-     pages     = "83-112",
-     SLACcitation  = "%%CITATION = CMPHA,31,83;%%"
-}
-@Article{Osterwalder:1975tc,
-     author    = "Osterwalder, K. and Schrader, R.",
-     title     = "Axioms for euclidean Green's functions. 2",
-     journal   = "Commun. Math. Phys.",
-     volume    = "42",
-     year      = "1975",
-     pages     = "281",
-     SLACcitation  = "%%CITATION = CMPHA,42,281;%%"
-}
-@Article{Osterwalder:1977pc,
-     author    = "Osterwalder, K. and Seiler, E.",
-     title     = "Gauge field theories on the lattice",
-     journal   = "Ann. Phys.",
-     volume    = "110",
-     year      = "1978",
-     pages     = "440",
-     SLACcitation  = "%%CITATION = APNYA,110,440;%%"
-}
-@Article{PDBook,
-     author = "Eidelman, S. and others",
-     title = "{Review of Particle Physics}",
-     journal = "{Physics Letters B}",
-     year = "2004",
-     volume = "592",
-     pages = {1+},
-     url = {http://pdg.lbl.gov}
-}
-@Article{Peardon:2002wb,
-     author    = "Peardon, M. J. and Sexton, J.",
- collaboration = "TrinLat",
-     title     = "Multiple molecular dynamics time-scales in hybrid Monte
-                  Carlo fermion simulations",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "119",
-     year      = "2003",
-     pages     = "985-987",
-     eprint    = "hep-lat/0209037",
-     SLACcitation  = "%%CITATION = HEP-LAT 0209037;%%"
-}
-@Book{Peskin:1995ev,
-  author = 	 {Peskin, M. E. and Schroeder, D. V.},
-  title = 	 {An Introduction to quantum field theory},
-  publisher = 	 {Westview Press},
-  year = 	 {1995},
-  OPTkey = 	 {},
-  OPTvolume = 	 {},
-  OPTnumber = 	 {},
-  OPTseries = 	 {Advanced Book Program},
-  OPTaddress = 	 {Boulder, Colorado},
-  OPTedition = 	 {},
-  OPTmonth = 	 {},
-  OPTnote = 	 {},
-  OPTannote = 	 {}
-}
-@Article{Politzer:1973fx,
-     author    = "Politzer, H. D.",
-     title     = "Reliable perturbative results for strong interactions?",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "30",
-     year      = "1973",
-     pages     = "1346-1349",
-     SLACcitation  = "%%CITATION = PRLTA,30,1346;%%"
-}
-@Article{Politzer:1974fr,
-     author    = "Politzer, H. D.",
-     title     = "Asymptotic freedom: an approach to strong interactions",
-     journal   = "Phys. Rept.",
-     volume    = "14",
-     year      = "1974",
-     pages     = "129-180",
-     SLACcitation  = "%%CITATION = PRPLC,14,129;%%"
-}
-@Manual{R:2005,
-    title = {R: A language and environment for statistical computing},
-    author = {{R Development Core Team}},
-    organization = {R Foundation for Statistical Computing},
-    address = {Vienna, Austria},
-    year = {2005},
-    note = {{ISBN} 3-900051-07-0},
-    url = {http://www.R-project.org},
+@article{Hasenfratz:1998jp,
+	author = "Hasenfratz, P.",
+	eprint = "hep-lat/9802007",
+	journal = "Nucl. Phys.",
+	pages = "401--409",
+	slaccitation = "%\%CITATION = HEP-LAT 9802007;\%\%",
+	title = "{Lattice {QCD} without tuning, mixing and current renormalization}",
+	volume = "B525",
+	year = "1998"
 }
 
-@Book{Rothe:1992wy,
-     author    = "Rothe, H.J.",
-     title     = "Lattice gauge theories",
-     publisher = "World Scientific, Singapore",
-     year      = "1992",
-     pages     = "528",
-     edition   = "",
-}
-@Article{Rupak:2002sm,
-     author    = "Rupak, G. and Shoresh, N.",
-     title     = "Chiral perturbation theory for the {Wilson} lattice action",
-     journal   = "Phys. Rev.",
-     volume    = "D66",
-     year      = "2002",
-     pages     = "054503",
-     eprint    = "hep-lat/0201019",
-     SLACcitation  = "%%CITATION = HEP-LAT 0201019;%%"
+@article{Hasenfratz:1998ri,
+	author = "Hasenfratz, P. and Laliena, V. and Niedermayer, F.",
+	eprint = "hep-lat/9801021",
+	journal = "Phys. Lett.",
+	pages = "125--131",
+	slaccitation = "%\%CITATION = HEP-LAT 9801021;\%\%",
+	title = "{The index theorem in {QCD} with a finite cut-off}",
+	volume = "B427",
+	year = "1998"
 }
 
-@Article{Saad:1993a,
-  author  = "Saad, Y.",
-  title   = "A flexible inner-outer preconditioned GMRES altorithm",
-  journal = "SIAM J. Sci. Comput.",
-  volume  = "14 (2)",
-  year    = "1993",
-  page    = "461-469"  
-}
-@Article{Sachrajda:2004mi,
-     author    = "Sachrajda, C. T. and Villadoro, G.",
-     title     = "{Twisted boundary conditions in lattice simulations}",
-     journal   = "Phys. Lett.",
-     volume    = "B609",
-     year      = "2005",
-     pages     = "73-85",
-     eprint    = "hep-lat/0411033",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/j.physletb.2005.01.033",
-     SLACcitation  = "%%CITATION = HEP-LAT/0411033;%%"
-}
-@Article{Scorzato:2004da,
-     author    = "Scorzato, L.",
-     title     = "Pion mass splitting and phase structure in twisted mass
-                  {QCD}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C37",
-     year      = "2004",
-     pages     = "445-455",
-     eprint    = "hep-lat/0407023",
-     SLACcitation  = "%%CITATION = HEP-LAT 0407023;%%"
+@article{Hasenfratz:2001hp,
+	author = "Hasenfratz, A. and Knechtli, F.",
+	eprint = "hep-lat/0103029",
+	journal = "Phys. Rev.",
+	pages = "034504",
+	slaccitation = "%\%CITATION = HEP-LAT 0103029;\%\%",
+	title = "{Flavor symmetry and the static potential with hypercubic blocking}",
+	volume = "D64",
+	year = "2001"
 }
 
-@Article{Scorzato:2005rb,
-     author    = "Scorzato, L. and others",
-     title     = "N(f) = 2 lattice {QCD} and chiral perturbation theory",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "153",
-     year      = "2006",
-     pages     = "283-290",
-     eprint    = "hep-lat/0511036",
-     SLACcitation  = "%%CITATION = HEP-LAT 0511036;%%"
+@article{Hasenfratz:2001tw,
+	author = "Hasenfratz, A. and Hoffmann, R. and Knechtli, F.",
+	eprint = "hep-lat/0110168",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "418--420",
+	slaccitation = "%\%CITATION = HEP-LAT 0110168;\%\%",
+	title = "{The static potential with hypercubic blocking}",
+	volume = "106",
+	year = "2002"
 }
 
-@Article{Sexton:1992nu,
-     author    = "Sexton, J. C. and Weingarten, D. H.",
-     title     = "Hamiltonian evolution for the hybrid monte carlo
-                  algorithm",
-     journal   = "Nucl. Phys.",
-     volume    = "B380",
-     year      = "1992",
-     pages     = "665-678",
-     SLACcitation  = "%%CITATION = NUPHA,B380,665;%%"
+@article{Hashimoto:2008xg,
+	archiveprefix = "arXiv",
+	author = "Hashimoto, Koichi and Izubuchi, Taku",
+	eprint = "0803.0186",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0803.0186;\%\%",
+	title = "{eta' meson from two flavor dynamical domain wall fermions}",
+	year = "2008"
 }
 
-@Article{Sharpe:1998xm,
-     author    = "Sharpe, S. R. and Singleton, R., Jr.",
-     title     = "Spontaneous flavor and parity breaking with {Wilson}
-                  fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D58",
-     year      = "1998",
-     pages     = "074501",
-     eprint    = "hep-lat/9804028",
-     SLACcitation  = "%%CITATION = HEP-LAT 9804028;%%"
-}
-@Article{Sharpe:2004ny,
-     author    = "Sharpe, S. R. and Wu, Jackson M. S.",
-     title     = "Twisted mass chiral perturbation theory at next-to-leading
-                  order",
-     journal   = "Phys. Rev.",
-     volume    = "D71",
-     year      = "2005",
-     pages     = "074501",
-     eprint    = "hep-lat/0411021",
-     SLACcitation  = "%%CITATION = HEP-LAT 0411021;%%"
-}
-@Article{Sharpe:2004ps,
-     author    = "Sharpe, S. R. and Wu, J. M. S.",
-     title     = "The phase diagram of twisted mass lattice {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "094029",
-     eprint    = "hep-lat/0407025",
-     SLACcitation  = "%%CITATION = HEP-LAT 0407025;%%"
-}
-@Article{Sharpe:2005rq,
-     author    = "Sharpe, Stephen R.",
-     title     = "Observations on discretization errors in twisted-mass
-                  lattice QCD",
-     journal   = "Phys. Rev.",
-     volume    = "D72",
-     year      = "2005",
-     pages     = "074510",
-     eprint    = "hep-lat/0509009",
-     SLACcitation  = "%%CITATION = HEP-LAT 0509009;%%"
-}
-@Article{Sheikholeslami:1985ij,
-     author    = "Sheikholeslami, B. and Wohlert, R.",
-     title     = "Improved continuum limit lattice action for qcd with {Wilson}
-                  fermions",
-     journal   = "Nucl. Phys.",
-     volume    = "B259",
-     year      = "1985",
-     pages     = "572",
-     SLACcitation  = "%%CITATION = NUPHA,B259,572;%%"
-}
-@Article{Shindler:2005vj,
-     author    = "Shindler, Andrea",
-     title     = "Twisted mass lattice {QCD}: Recent developments and results",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "014",
-     eprint    = "hep-lat/0511002",
-     SLACcitation  = "%%CITATION = HEP-LAT 0511002;%%"
-}
-@Article{Shindler:2006tm,
-     author    = "Shindler, A.",
- collaboration = "ETM",
-     title     = "Lattice QCD with light twisted quarks: First results",
-     year      = "2006",
-     eprint    = "hep-ph/0611264",
-     SLACcitation  = "%%CITATION = HEP-PH 0611264;%%"
-}
-@Article{Shindler:2007vp,
-     author    = "Shindler, A.",
-     title     = "{Twisted mass lattice QCD}",
-     journal   = "Phys. Rept.",
-     volume    = "461",
-     year      = "2008",
-     pages     = "37-110",
-     eprint    = "0707.4093",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     doi       = "10.1016/j.physrep.2008.03.001",
-     SLACcitation  = "%%CITATION = 0707.4093;%%"
-}
-@Article{Sleijpen:1996aa,
-     author    = "G. L. G. Sleijpen and H. A. Van der Vorst",
-     title     = "A Jacobi-Davidson iteration method for linear 
-                  eigenvalue problems",
-     journal   = "SIAM Journal on Matrix Analysis and Applications",
-     volume    = "17",
-     year      = "1996",
-     pages     = "401-425",
-}
-@Article{Sommer:1993ce,
-     author    = "Sommer, R.",
-     title     = "A New way to set the energy scale in lattice gauge theories
-                  and its applications to the static force and alpha-s in
-                  SU(2) Yang-Mills theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B411",
-     year      = "1994",
-     pages     = "839-854",
-     eprint    = "hep-lat/9310022",
-     SLACcitation  = "%%CITATION = HEP-LAT 9310022;%%"
-}
-@Article{Sonneveld:1989cgs,
- author = {Peter Sonneveld},
- title = {CGS, a fast Lanczos-type solver for nonsymmetric linear systems},
- journal = {SIAM J. Sci. Stat. Comput.},
- volume = {10},
- number = {1},
- year = {1989},
- issn = {0196-5204},
- pages = {36--52},
- publisher = {Society for Industrial and Applied Mathematics},
- address = {Philadelphia, PA, USA},
- }
-@Article{Sternbeck:2003gy,
-     author    = "Sternbeck, A. and Ilgenfritz, E.-M. and Kerler, W.
-                  and M{\"u}ller-Preu{\ss}ker, M. and St{\"u}ben, H.",
-     title     = "The {Aoki} phase for {N(f)} = 2 {Wilson} fermions revisited",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "129",
-     year      = "2004",
-     pages     = "898-900",
-     eprint    = "hep-lat/0309059",
-     SLACcitation  = "%%CITATION = HEP-LAT 0309059;%%"
-}
-@Article{Sternbeck:2005tk,
-     author    = "Sternbeck, A. and Ilgenfritz, E. -M. and Mueller-Preussker,
-                  M. and Schiller, A.",
-     title     = "{Going infrared in SU(3) Landau gauge gluodynamics}",
-     journal   = "Phys. Rev.",
-     volume    = "D72",
-     year      = "2005",
-     pages     = "014507",
-     eprint    = "hep-lat/0506007",
-     SLACcitation  = "%%CITATION = HEP-LAT/0506007;%%"
-}
-@Conference{Symanzik:1981hc,
-     author    = "Symanzik, K.",
-     title     = "Some topics in quantum field theory",
-     booktitle = "Mathematical problems in theoretical physics",
-     journal   = "Lecture Notes in Physics",
-     volume    = "153",
-     year      = "1981",
-     pages     = "47-58",
-     editor    = "R. Schrader et al.",
-     note      = "Presented at 6th Int. Conf. on Mathematical Physics,
-                  Berlin, West Germany"
-}
-@Article{Symanzik:1983dc,
-     author    = "Symanzik, K.",
-     title     = "Continuum limit and improved action in lattice theories. 1.
-                  principles and phi**4 theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B226",
-     year      = "1983",
-     pages     = "187",
-     SLACcitation  = "%%CITATION = NUPHA,B226,187;%%"
-}
-@Article{Symanzik:1983gh,
-     author    = "Symanzik, K.",
-     title     = "Continuum limit and improved action in lattice theories. 2.
-                  O(N) nonlinear sigma model in perturbation theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B226",
-     year      = "1983",
-     pages     = "205",
-     SLACcitation  = "%%CITATION = NUPHA,B226,205;%%"
-}
-@Article{Takaishi:1996xj,
-     author    = "Takaishi, T.",
-     title     = "Heavy quark potential and effective actions on blocked
-                  configurations",
-     journal   = "Phys. Rev.",
-     volume    = "D54",
-     year      = "1996",
-     pages     = "1050-1053",
-     SLACcitation  = "%%CITATION = PHRVA,D54,1050;%%"
-}
-@Article{Takaishi:2005tz,
-     author    = "Takaishi, T. and de Forcrand, P.",
-     title     = "Testing and tuning new symplectic integrators for hybrid
-                  Monte Carlo algorithm in lattice QCD",
-     year      = "2005",
-     eprint    = "hep-lat/0505020",
-     SLACcitation  = "%%CITATION = HEP-LAT 0505020;%%"
-}
-@Article{Takeda:2004xh,
-     author    = "Takeda, S. and others",
-     title     = "A scaling study of the step scaling function in SU(3) gauge
-                  theory with  improved gauge actions",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "074510",
-     eprint    = "hep-lat/0408010",
-     SLACcitation  = "%%CITATION = HEP-LAT 0408010;%%"
-}
-@Article{Ukawa:2002pc,
-     author    = "Ukawa, A.",
- collaboration = "CP-PACS and JL{QCD}",
-     title     = "Computational cost of full {QCD} simulations experienced by
-                  {CP-PACS and JLQCD Collaborations}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "195-196",
-     SLACcitation  = "%%CITATION = NUPHZ,106,195;%%"
-}
-@Article{Urbach:2005ji,
-     author    = "Urbach, C. and Jansen, K. and Shindler, A. and Wenger, U.",
-     title     = "{HMC} algorithm with multiple time scale integration and mass
-                  preconditioning",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "174",
-     year      = "2006",
-     pages     = "87-98",
-     eprint    = "hep-lat/0506011",
-     SLACcitation  = "%%CITATION = HEP-LAT 0506011;%%"
-}
-@Article{Urbach:2007rt,
-     author    = "Urbach, Carsten",
- collaboration = "ETM",
-     title     = "{Lattice QCD with two light Wilson quarks and maximally
-                  twisted mass}",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "022",
-     eprint    = "0710.1517",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0710.1517;%%"
-}
-@Article{WalkerLoud:2005bt,
-     author    = "Walker-Loud, Andre and Wu, Jackson M. S.",
-     title     = "{Nucleon and Delta masses in twisted mass chiral
-                  perturbation theory}",
-     journal   = "Phys. Rev.",
-     volume    = "D72",
-     year      = "2005",
-     pages     = "014506",
-     eprint    = "hep-lat/0504001",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.72.014506",
-     SLACcitation  = "%%CITATION = HEP-LAT/0504001;%%"
-}
-@Article{Weinberg:1973un,
-     author    = "Weinberg, S.",
-     title     = "Nonabelian gauge theories of the strong interactions",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "31",
-     year      = "1973",
-     pages     = "494-497",
-     SLACcitation  = "%%CITATION = PRLTA,31,494;%%"
-}
-@Article{Weinberg:1978kz,
-     author    = "Weinberg, S.",
-     title     = "Phenomenological Lagrangians",
-     journal   = "Physica",
-     volume    = "A96",
-     year      = "1979",
-     pages     = "327",
-     SLACcitation  = "%%CITATION = PHYSA,A96,327;%%"
-}
-@Book{Weinberg:1995mt,
-     author    = "Weinberg, S.",
-     title     = "The Quantum theory of fields. Vol. 1: Foundations",
-     publisher = "Cambridge University Press",
-     year      = "1995",
-     pages     = "609",
-}
-@Article{Weisz:1982zw,
-     author    = "Weisz, P.",
-     title     = "Continuum limit improved lattice action for pure {Yang-Mills}
-                  theory. 1",
-     journal   = "Nucl. Phys.",
-     volume    = "B212",
-     year      = "1983",
-     pages     = "1",
-     SLACcitation  = "%%CITATION = NUPHA,B212,1;%%"
-}
-@Article{Weisz:1983bn,
-     author    = "Weisz, P. and Wohlert, R.",
-     title     = "Continuum limit improved lattice action for pure {Yang-Mills}
-                  theory. 2",
-     journal   = "Nucl. Phys.",
-     volume    = "B236",
-     year      = 1984,
-     pages     = 397,
-     SLACcitation  = "%%CITATION = NUPHA,B236,397;%%"
-}
-@Article{Wennekers:2005wa,
-     author    = "Wennekers, J. and Wittig, H.",
-     title     = "On the renormalized scalar density in quenched QCD",
-     year      = "2005",
-     eprint    = "hep-lat/0507026",
-     SLACcitation  = "%%CITATION = HEP-LAT 0507026;%%"
-}
-@Article{Weyl:1918ib,
-     author    = "Weyl, H.",
-     title     = "Gravitation und Elektrizit{\"a}t",
-     journal   = "Sitzungsber. Preuss. Akad. Wiss. Berlin (Math. Phys. )",
-     volume    = "1918",
-     year      = "1918",
-     pages     = "465",
-     SLACcitation  = "%%CITATION = SPWPA,1918,465;%%"
-}
-@Article{Weyl:1929fm,
-     author    = "Weyl, H.",
-     title     = "Electron and gravitation",
-     journal   = "Z. Phys.",
-     volume    = "56",
-     year      = "1929",
-     pages     = "330-352",
-     SLACcitation  = "%%CITATION = ZEPYA,56,330;%%"
-}
-@Article{Wilson:1974sk,
-     author    = "Wilson, K. G.",
-     title     = "Confinement of quarks",
-     journal   = "Phys. Rev.",
-     volume    = "D10",
-     year      = "1974",
-     pages     = "2445-2459",
-     SLACcitation  = "%%CITATION = PHRVA,D10,2445;%%"
-}
-@Article{Wilson:1974sk,
-     author    = "Wilson, K. G.",
-     title     = "Confinement of quarks",
-     journal   = "Phys. Rev.",
-     volume    = "D10",
-     year      = "1974",
-     pages     = "2445-2459",
-     SLACcitation  = "%%CITATION = PHRVA,D10,2445;%%"
-}
-@Article{Wilson:1975mb,
-     author    = "Wilson, K. G.",
-     title     = "The renormalization group: Critical phenomena and the kondo
-                  problem",
-     journal   = "Rev. Mod. Phys.",
-     volume    = "47",
-     year      = "1975",
-     pages     = "773",
-     SLACcitation  = "%%CITATION = RMPHA,47,773;%%"
-}
-@Article{Wilson:1975mb,
-     author    = "Wilson, K. G.",
-     title     = "The renormalization group: Critical phenomena and the kondo
-                  problem",
-     journal   = "Rev. Mod. Phys.",
-     volume    = "47",
-     year      = "1975",
-     pages     = "773",
-     SLACcitation  = "%%CITATION = RMPHA,47,773;%%"
-}
-@Article{Wolff:2003sm,
-     author    = "Wolff, U.",
- collaboration = "ALPHA",
-     title     = "Monte Carlo errors with less errors",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "156",
-     year      = "2004",
-     pages     = "143-153",
-     eprint    = "hep-lat/0306017",
-     SLACcitation  = "%%CITATION = HEP-LAT 0306017;%%"
-}
-@Article{Yang:1954ek,
-     author    = "Yang, C.-N. and Mills, R. L.",
-     title     = "Conservation of isotopic spin and isotopic gauge
-                  invariance",
-     journal   = "Phys. Rev.",
-     volume    = "96",
-     year      = "1954",
-     pages     = "191-195",
-     SLACcitation  = "%%CITATION = PHRVA,96,191;%%"
-}
-@Article{Yoshie:2008aw,
-     author    = "Yoshie, Tomoteru",
-     title     = "{Making use of the International Lattice Data Grid}",
-     journal   = "PoS",
-     volume    = "LATTICE2008",
-     year      = "2008",
-     pages     = "019",
-     eprint    = "0812.0849",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0812.0849;%%"
-}
-@Article{Zweig:1964jf,
-     author    = "Zweig, G.",
-     title     = "An SU(3) model for strong interaction symmetry and its
-                  breaking. 2",
-     note     = "CERN-TH-412"
-}
-@Article{cln:web,
-  author = 	 {},
-  eprint =       {http://www.ginac.de/CLN/}
-}
-@Article{deForcrand:1995bs,
-     author    = "de Forcrand, P.",
-     title     = "Progress on lattice {QCD} algorithms",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "47",
-     year      = "1996",
-     pages     = "228-235",
-     eprint    = "hep-lat/9509082",
-     SLACcitation  = "%%CITATION = HEP-LAT 9509082;%%"
-}
-@Article{deForcrand:1996bx,
-     author    = "de Forcrand, P. and others",
- collaboration = "{QCD}-TARO",
-     title     = "Search for effective lattice action of pure {QCD}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "53",
-     year      = "1997",
-     pages     = "938-941",
-     eprint    = "hep-lat/9608094",
-     SLACcitation  = "%%CITATION = HEP-LAT 9608094;%%"
-}
-@Article{deForcrand:1996ck,
-     author    = "de Forcrand, P. and Takaishi, T.",
-     title     = "Fast fermion Monte Carlo",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "53",
-     year      = "1997",
-     pages     = "968-970",
-     eprint    = "hep-lat/9608093",
-     SLACcitation  = "%%CITATION = HEP-LAT 9608093;%%"
-}
-@Article{etmc:asqr,
-     author    = "Frezzotti, R. et al.",
-     title     = "{O(a^2) cutoff effects in Wilson fermion simulations}",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "277",
-     eprint    = "0710.2492",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0710.2492;%%"
-}
-@Article{ildg:web,
-  eprint = 	 {http://cssm.sasr.edu.au/ildg/},
-  author =	 {ILDG working groups}
-}
-@Book{kleinert:1,
-     author    = "Kleinert, H.",
-     title     = "Path integrals in quantum mechanics, statistics and polymer ph
-ysics",
-     publisher = "World Scientific, Singapore",
-     year      = "1995",
-     edition   = "2nd Edition",
-}
-@Article{lapack:web,
-  author = 	 {},
-  eprint =       {http://www.netlib.org/lapack/}
-}
-@Article{lime:web,
-  author = 	 {USQCD},
-  title = 	 {c-lime library},
-  eprint =       {http://usqcd.jlab.org/usqcd-docs/c-lime/}
-}
-@Book{meister:1999,
-  author = 	 {Meister, Andreas},
-  title = 	 {Numerik linearer Gleichungssysteme},
-  publisher = 	 {vieweg},
-  year = 	 {1999},
-  OPTkey = 	 {},
-  OPTvolume = 	 {},
-  OPTnumber = 	 {},
-  OPTseries = 	 {},
-  OPTaddress = 	 {},
-  OPTedition = 	 {},
-  OPTmonth = 	 {},
-  OPTnote = 	 {},
-  OPTannote = 	 {}
-}
-@Manual{minuit,
-  title = 	 {MINUIT home page},
-  note= {\\seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/home.html}
-}
-@Article{mpi:web,
-  author =       {},
-  title  =       {The message passing interface standard},
-  eprint =       {http://www-unix.mcs.anl.gov/mpi/}
-}
-@PhdThesis{orth:2004phd,
-  author = 	 {Orth, B.},
-  title = 	 {Finite size effects in lattice {QCD}
-                  with dynamical {Wilson} fermions},
-  school = 	 {Bergische Universit{\"a}t Wuppertal},
-  year = 	 {2004},
-  OPTkey = 	 {},
-  OPTtype = 	 {},
-  OPTaddress = 	 {},
-  OPTmonth = 	 {},
-  OPTnote = 	 {},
-  OPTannote = 	 {}
-}
-@PhdThesis{pleiter:phd,
-  author = 	 {Pleiter, D.},
-  title = 	 {XXX},
-  school = 	 {Freie {U}niversität {B}erlin},
-  year = 	 {2001}
-}
-@Manual{root,
-  title = 	 {The ROOT system home page},
-  note = {root.cern.ch/}
+@article{Heitger:2000ay,
+	author = "Heitger, J. and Sommer, R. and Wittig, H.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0006026",
+	journal = "Nucl. Phys.",
+	note = "and references therein",
+	pages = "377--399",
+	slaccitation = "%\%CITATION = HEP-LAT 0006026;\%\%",
+	title = "{Effective chiral Lagrangians and lattice {{QCD}}}",
+	volume = "B588",
+	year = "2000"
 }
 
-@Book{saad:2003a,
-     author    = "Y. Saad",
-     title     = "Iterative Methods for sparse linear systems",
-     publisher = "SIAM",
-     year      = "2003",
-     edition   = "2nd",
+@article{Hernandez:1998et,
+	author = "Hernandez, P. and Jansen, K. and L{\"u}scher, M.",
+	eprint = "hep-lat/9808010",
+	journal = "Nucl. Phys.",
+	pages = "363--378",
+	slaccitation = "%\%CITATION = HEP-LAT 9808010;\%\%",
+	title = "{Locality properties of Neuberger's lattice Dirac operator}",
+	volume = "B552",
+	year = "1999"
 }
 
-@Article{scidac,
-  author = 	 {},
-  eprint =       {http://www.scidac.gov/}
-}
-@MastersThesis{urbach:2002aa,
-  author = 	 {Urbach, C.},
-  title = 	 {Untersuchung der {R}eversibilit{\"a}tsverletzung im {H}ybrid
-                  {M}onte {C}arlo {A}lgorithmus},
-  school = 	 {Freie Universit{\"a}t Berlin, Fachbereich Physik},
-  year = 	 {2002}
+@article{Hernandez:2000sb,
+	author = "Hernandez, P. and Jansen, K. and Lellouch, L.",
+	eprint = "hep-lat/0001008",
+	slaccitation = "%\%CITATION = HEP-LAT 0001008;\%\%",
+	title = "{A numerical treatment of Neuberger's lattice Dirac operator}",
+	year = "2000"
 }
 
-@Article{'tHooft:1971fh,
-     author    = "'t Hooft, G.",
-     title     = "Renormalization of massless Yang-Mills fields",
-     journal   = "Nucl. Phys.",
-     volume    = "B33",
-     year      = "1971",
-     pages     = "173-199",
-     SLACcitation  = "%%CITATION = NUPHA,B33,173;%%"
-}
-@Article{'tHooft:1971rn,
-     author    = "'t Hooft, G.",
-     title     = "Renormalizable lagrangians for massive Yang-Mills fields",
-     journal   = "Nucl. Phys.",
-     volume    = "B35",
-     year      = "1971",
-     pages     = "167-188",
-     SLACcitation  = "%%CITATION = NUPHA,B35,167;%%"
-}
-@Unpublished{'tHooft:1972aa,
-  author = 	 "'t Hooft, G.",
-  title = 	 "",
-  note = 	 "Unpublished remarks at the 1972 Marseille Conference 
-                  on Yang-Mills Fields"
-}
-@Article{'tHooft:1972fi,
-     author    = "'t Hooft, G. and Veltman, M. J. G.",
-     title     = "Regularization and renormalization of gauge fields",
-     journal   = "Nucl. Phys.",
-     volume    = "B44",
-     year      = "1972",
-     pages     = "189-213",
-     SLACcitation  = "%%CITATION = NUPHA,B44,189;%%"
-}
-@Article{Abdel-Rehim:2004gx,
-     author    = "Abdel-Rehim, A. M. and Lewis, R.",
-     title     = "Twisted mass {QCD} for the pion electromagnetic form factor",
-     journal   = "Phys. Rev.",
-     volume    = "D71",
-     year      = "2005",
-     pages     = "014503",
-     eprint    = "hep-lat/0410047",
-     SLACcitation  = "%%CITATION = HEP-LAT 0410047;%%"
-}
-@Article{Abdel-Rehim:2005gz,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  ",
-     title     = "Spectrum of quenched twisted mass lattice QCD at maximal
-                  twist",
-     journal   = "Phys. Rev.",
-     volume    = "D71",
-     year      = "2005",
-     pages     = "094505",
-     eprint    = "hep-lat/0503007",
-     SLACcitation  = "%%CITATION = HEP-LAT/0503007;%%"
-}
-@Article{AbdelRehim:2004sp,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy",
-     title     = "Pion form factor with twisted mass QCD",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "299-301",
-     eprint    = "hep-lat/0408033",
-     SLACcitation  = "%%CITATION = HEP-LAT/0408033;%%"
-}
-@Article{AbdelRehim:2005gq,
-     author    = "Abdel-Rehim, A. M. and Lewis, R. and Woloshyn, R. M.",
-     title     = "Twisted mass lattice QCD and hadron phenomenology",
-     journal   = "Int. J. Mod. Phys.",
-     volume    = "A20",
-     year      = "2005",
-     pages     = "6159-6168",
-     SLACcitation  = "%%CITATION = IMPAE,A20,6159;%%"
-}
-@Article{AbdelRehim:2005gz,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  ",
-     title     = "{Spectrum of quenched twisted mass lattice QCD at maximal
-                  twist}",
-     journal   = "Phys. Rev.",
-     volume    = "D71",
-     year      = "2005",
-     pages     = "094505",
-     eprint    = "hep-lat/0503007",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.71.094505",
-     SLACcitation  = "%%CITATION = HEP-LAT/0503007;%%"
-}
-@Article{AbdelRehim:2005qv,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  ",
-     title     = "The hadron spectrum from twisted mass QCD with a strange
-                  quark",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "032",
-     eprint    = "hep-lat/0509056",
-     SLACcitation  = "%%CITATION = HEP-LAT/0509056;%%"
-}
-@Article{AbdelRehim:2005yx,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  ",
-     title     = "Maximal twist and the spectrum of quenched twisted mass
-                  lattice QCD",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "051",
-     eprint    = "hep-lat/0509098",
-     SLACcitation  = "%%CITATION = HEP-LAT/0509098;%%"
-}
-@Article{AbdelRehim:2006qu,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Petry, Robert G.
-                  and Woloshyn, R. M.",
-     title     = "The spectrum of tmLQCD with quark and link smearing",
-     journal   = "PoS",
-     volume    = "LAT2006",
-     year      = "2006",
-     pages     = "164",
-     eprint    = "hep-lat/0610004",
-     SLACcitation  = "%%CITATION = HEP-LAT/0610004;%%"
-}
-@Article{AbdelRehim:2006ra,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  and Wu, Jackson M. S.",
-     title     = "Lattice QCD with a twisted mass term and a strange quark",
-     journal   = "Eur. Phys. J.",
-     volume    = "A31",
-     year      = "2007",
-     pages     = "773-776",
-     eprint    = "hep-lat/0610090",
-     SLACcitation  = "%%CITATION = HEP-LAT/0610090;%%"
-}
-@Article{AbdelRehim:2006ve,
-     author    = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.
-                  and Wu, Jackson M. S.",
-     title     = "Strange quarks in quenched twisted mass lattice QCD",
-     journal   = "Phys. Rev.",
-     volume    = "D74",
-     year      = "2006",
-     pages     = "014507",
-     eprint    = "hep-lat/0601036",
-     SLACcitation  = "%%CITATION = HEP-LAT/0601036;%%"
-}
-@Article{Adler:1974gd,
-     author    = "Adler, Stephen L.",
-     title     = "{Some Simple Vacuum Polarization Phenomenology: e+ e- $\to$
-                  Hadrons: The mu - Mesic Atom x-Ray Discrepancy and (g-2) of
-                  the Muon}",
-     journal   = "Phys. Rev.",
-     volume    = "D10",
-     year      = "1974",
-     pages     = "3714",
-     SLACcitation  = "%%CITATION = PHRVA,D10,3714;%%"
-}
-@Article{Albanese:1987ds,
-     author    = "Albanese, M. and others",
- collaboration = "APE",
-     title     = "Glueball masses and string tension in lattice {QCD}",
-     journal   = "Phys. Lett.",
-     volume    = "B192",
-     year      = "1987",
-     pages     = "163",
-     SLACcitation  = "%%CITATION = PHLTA,B192,163;%%"
-}
-@Article{Alexandrou:2008tn,
-     author    = "Alexandrou, C. and others",
- collaboration = "ETM",
-     title     = "{Light baryon masses with dynamical twisted mass
-                  fermions}",
-     year      = "2008",
-     eprint    = "0803.3190",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0803.3190;%%"
-}
-@Article{AliKhan:2000iv,
-     author    = "Ali Khan, A. and others",
- collaboration = "CP-PACS",
-     title     = "Chiral properties of domain-wall quarks in quenched {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D63",
-     year      = "2001",
-     pages     = "114504",
-     eprint    = "hep-lat/0007014",
-     SLACcitation  = "%%CITATION = HEP-LAT 0007014;%%"
-}
-@Article{AliKhan:2003br,
-     author    = "Ali Khan, A. and others",
- collaboration = "QCDSF",
-     title     = "Accelerating the hybrid Monte Carlo algorithm",
-     journal   = "Phys. Lett.",
-     volume    = "B564",
-     year      = "2003",
-     pages     = "235-240",
-     eprint    = "hep-lat/0303026",
-     SLACcitation  = "%%CITATION = HEP-LAT 0303026;%%"
-}
-@Article{AliKhan:2003mu,
-     author    = "Ali Khan, A. and others",
-     title     = "Accelerating Hasenbusch's acceleration of hybrid Monte
-                  Carlo",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "129",
-     year      = "2004",
-     pages     = "853-855",
-     eprint    = "hep-lat/0309078",
-     SLACcitation  = "%%CITATION = HEP-LAT 0309078;%%"
-}
-@Article{Allton:1993wc,
-     author    = "Allton, C. R. and others",
- collaboration = "UK{QCD}",
-     title     = "Gauge invariant smearing and matrix correlators using
-                  {Wilson} fermions at Beta = 6.2",
-     journal   = "Phys. Rev.",
-     volume    = "D47",
-     year      = "1993",
-     pages     = "5128-5137",
-     eprint    = "hep-lat/9303009",
-     SLACcitation  = "%%CITATION = HEP-LAT 9303009;%%"
-}
-@Article{Allton:2004qq,
-     author    = "Allton, C. R. and others",
- collaboration = "UKQCD",
-     title     = "Improved Wilson QCD simulations with light quark masses",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "014501",
-     eprint    = "hep-lat/0403007",
-     SLACcitation  = "%%CITATION = HEP-LAT/0403007;%%"
-}
-@Article{Aoki:1984qi,
-     author    = "Aoki, S.",
-     title     = "New phase structure for lattice {QCD} with {Wilson} fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D30",
-     year      = "1984",
-     pages     = "2653",
-     SLACcitation  = "%%CITATION = PHRVA,D30,2653;%%"
-}
-@Article{Aoki:1985jj,
-     author    = "Aoki, S. and Higashijima, K.",
-     title     = "The recovery of the chiral symmetry in lattice {Gross-Neveu}
-                  model",
-     journal   = "Prog. Theor. Phys.",
-     volume    = "76",
-     year      = "1986",
-     pages     = "521",
-     SLACcitation  = "%%CITATION = PTPKA,76,521;%%"
-}
-@Article{Aoki:1986ua,
-     author    = "Aoki, Sinya",
-     title     = "NUMERICAL EVIDENCE FOR A PARITY VIOLATING PHASE IN LATTICE
-                  QCD WITH WILSON FERMION",
-     journal   = "Phys. Lett.",
-     volume    = "B190",
-     year      = "1987",
-     pages     = "140",
-     SLACcitation  = "%%CITATION = PHLTA,B190,140;%%"
-}
-@Article{Aoki:1986xr,
-     author    = "Aoki, S.",
-     title     = "A solution to the {U(1)} problem on a lattice",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "57",
-     year      = "1986",
-     pages     = "3136",
-     SLACcitation  = "%%CITATION = PRLTA,57,3136;%%"
-}
-@Article{Aoki:1993vs,
-     author    = "Aoki, S. and Boettcher, S. and Gocksch, A.",
-     title     = "Spontaneous breaking of flavor symmetry and parity in the
-                  Nambu-Jona-Lasinio model with {Wilson} fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B331",
-     year      = "1994",
-     pages     = "157-164",
-     eprint    = "hep-lat/9312084",
-     SLACcitation  = "%%CITATION = HEP-LAT 9312084;%%"
-}
-@Article{Aoki:1995ft,
-     author    = "Aoki, S.",
-     title     = "On the phase structure of {QCD} with {Wilson} fermions",
-     journal   = "Prog. Theor. Phys. Suppl.",
-     volume    = "122",
-     year      = "1996",
-     pages     = "179-186",
-     eprint    = "hep-lat/9509008",
-     SLACcitation  = "%%CITATION = HEP-LAT 9509008;%%"
-}
-@Article{Aoki:1995yf,
-     author    = "Aoki, S. and Ukawa, A. and Umemura, T.",
-     title     = "Finite temperature phase structure of lattice {QCD} with
-                  {Wilson} quark action",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "76",
-     year      = "1996",
-     pages     = "873-876",
-     eprint    = "hep-lat/9508008",
-     SLACcitation  = "%%CITATION = HEP-LAT 9508008;%%"
-}
-@Article{Aoki:1997fm,
-     author    = "Aoki, S.",
-     title     = "Phase structure of lattice {QCD} with {Wilson} fermion at
-                  finite  temperature",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "60A",
-     year      = "1998",
-     pages     = "206-219",
-     eprint    = "hep-lat/9707020",
-     SLACcitation  = "%%CITATION = HEP-LAT 9707020;%%"
-}
-@Article{Aoki:2001xq,
-     author    = "Aoki, S. and others",
- collaboration = "JL{QCD}",
-     title     = "Non-trivial phase structure of {N(f)} = 3 {QCD} with {O(a)}-
-                  improved {Wilson}  fermion at zero temperature",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "263-265",
-     eprint    = "hep-lat/0110088",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110088;%%"
-}
-@Article{Aoki:2002vt,
-     author    = "Aoki, Y. and others",
-     title     = "Domain wall fermions with improved gauge actions",
-     journal   = "Phys. Rev.",
-     volume    = "D69",
-     year      = "2004",
-     pages     = "074504",
-     eprint    = "hep-lat/0211023",
-     SLACcitation  = "%%CITATION = HEP-LAT 0211023;%%"
-}
-@Article{Aoki:2004iq,
-     author    = "Aoki, S. and others",
- collaboration = "JL{QCD}",
-     title     = "Bulk first-order phase transition in three-flavor lattice
-                  {QCD} with  {O(a)}-improved {Wilson} fermion action at zero
-                  temperature",
-     year      = "2004",
-     eprint    = "hep-lat/0409016",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409016;%%"
-}
-@Article{Aoki:2004ta,
-     author    = "Aoki, Sinya and B{\"a}r, Oliver",
-     title     = "Twisted-mass {QCD}, {O}(a) improvement and {Wilson} chiral
-                  perturbation  theory",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "116011",
-     eprint    = "hep-lat/0409006",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409006;%%"
-}
-@Article{Aoki:2005ii,
-     author    = "Aoki, S. and B{\"a}r, O.",
-     title     = "Determining the low energy parameters of {Wilson} chiral
-                  perturbation theory",
-     year      = "2005",
-     eprint    = "hep-lat/0509002",
-     SLACcitation  = "%%CITATION = HEP-LAT 0509002;%%"
-}
-@Article{Arnold:2003sx,
-     author    = "Arnold, Guido and others",
-     title     = "Numerical methods for the QCD overlap operator. II: Optimal
-                  Krylov subspace methods",
-     year      = "2003",
-     eprint    = "hep-lat/0311025",
-     SLACcitation  = "%%CITATION = HEP-LAT 0311025;%%"
-}
-@Article{Atiyah:1971rm,
-     author    = "Atiyah, M. F. and Singer, I. M.",
-     title     = "The Index of elliptic operators. 5",
-     journal   = "Annals Math.",
-     volume    = "93",
-     year      = "1971",
-     pages     = "139-149",
-     SLACcitation  = "%%CITATION = ANMAA,93,139;%%"
-}
-@Article{Aubin:2006cc,
-     author    = "Aubin, C. and Blum, T.",
-     title     = "{Hadronic contributions to the muon g-2 from the lattice}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "162",
-     year      = "2006",
-     pages     = "251-255",
-     SLACcitation  = "%%CITATION = NUPHZ,162,251;%%"
-}
-@Article{Aubin:2006xv,
-     author    = "Aubin, C. and Blum, T.",
-     title     = "{Calculating the hadronic vacuum polarization and leading
-                  hadronic  contribution to the muon anomalous magnetic
-                  moment with improved  staggered quarks}",
-     journal   = "Phys. Rev.",
-     volume    = "D75",
-     year      = "2007",
-     pages     = "114502",
-     eprint    = "hep-lat/0608011",
-     SLACcitation  = "%%CITATION = HEP-LAT/0608011;%%"
-}
-@Article{BAGEL,
- author="P.A. Boyle",
- year=2005,
- eprint=" http://www.ph.ed.ac.uk/\~{ }paboyle/bagel/Bagel.html"
- }
-@Article{Baikov:2004ku,
-     author    = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
-     title     = "{Vacuum polarization in pQCD: First complete O(alpha(s)**4)
-                  result}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "135",
-     year      = "2004",
-     pages     = "243-246",
-     SLACcitation  = "%%CITATION = NUPHZ,135,243;%%"
-}
-@Article{Baikov:2005rw,
-     author    = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
-     title     = "{Scalar correlator at O(alpha(s)**4), Higgs decay into b-
-                  quarks and  bounds on the light quark masses}",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "96",
-     year      = "2006",
-     pages     = "012003",
-     eprint    = "hep-ph/0511063",
-     SLACcitation  = "%%CITATION = HEP-PH/0511063;%%"
-}
-@Article{Baikov:2008jh,
-     author    = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
-     title     = "{Hadronic Z- and tau-Decays in Order alpha_s^4}",
-     year      = "2008",
-     eprint    = "0801.1821",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = ARXIV:0801.1821;%%"
-}
-@Article{Bali:2000vr,
-     author    = "Bali, G. S. and others",
- collaboration = "TXL",
-     title     = "Static potentials and glueball masses from {QCD} simulations
-                  with {Wilson}  sea quarks",
-     journal   = "Phys. Rev.",
-     volume    = "D62",
-     year      = "2000",
-     pages     = "054503",
-     eprint    = "hep-lat/0003012",
-     SLACcitation  = "%%CITATION = HEP-LAT 0003012;%%"
-}
-@Article{Bali:2004pb,
-     author    = "Bali, G. S. and others",
-     title     = "String breaking with dynamical {Wilson} fermions",
-     journal   = "Nucl. Phys. Proc. Supl.",
-     volume    = "140",
-     pages     = "609-611",
-     year      = "2004",
-     eprint    = "hep-lat/0409137",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409137;%%"
-}
-@Article{Bali:2005fu,
-     author    = "Bali, G. S. and Neff, H. and Duessel, T. and
-                  Lippert, T. and Schilling, K.",
- collaboration = "SESAM",
-     title     = "Observation of string breaking in {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D71",
-     year      = "2005",
-     pages     = "114513",
-     eprint    = "hep-lat/0505012",
-     SLACcitation  = "%%CITATION = HEP-LAT 0505012;%%"
-}
-@Article{Bar:2006zj,
-     author    = "B{\"a}r, O. and Jansen, K. and Schaefer, S. and Scorzato, L.
-                  and Shindler, A.",
-     title     = "Overlap fermions on a twisted mass sea",
-     year      = "2006",
-     eprint    = "hep-lat/0609039",
-     SLACcitation  = "%%CITATION = HEP-LAT 0609039;%%"
-}
-@Article{Baxter:1993bv,
-     author    = "Baxter, R. M. and others",
- collaboration = "UK{QCD}",
-     title     = "Quenched heavy light decay constants",
-     journal   = "Phys. Rev.",
-     volume    = "D49",
-     year      = "1994",
-     pages     = "1594-1605",
-     eprint    = "hep-lat/9308020",
-     SLACcitation  = "%%CITATION = HEP-LAT 9308020;%%"
-}
-@Article{Beane:2004tw,
-     author    = "Beane, Silas R.",
-     title     = "{Nucleon masses and magnetic moments in a finite volume}",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "034507",
-     eprint    = "hep-lat/0403015",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.70.034507",
-     SLACcitation  = "%%CITATION = HEP-LAT/0403015;%%"
-}
-@Article{Becher:1999he,
-     author    = "Becher, Thomas and Leutwyler, H.",
-     title     = "Baryon chiral perturbation theory in manifestly Lorentz
-                  invariant form",
-     journal   = "Eur. Phys. J.",
-     volume    = "C9",
-     year      = "1999",
-     pages     = "643-671",
-     eprint    = "hep-ph/9901384",
-     SLACcitation  = "%%CITATION = HEP-PH/9901384;%%"
-}
-@Article{Bietenholz:2004sa,
-     author    = "Bietenholz, W. and others",
- collaboration = "\xlf",
-     title     = "Comparison between overlap and twisted mass fermions
-                  towards the chiral  limit",
-     year      = "2004",
-     eprint    = "hep-lat/0409109",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409109;%%"
-}
-@Article{Bietenholz:2004wv,
-     author    = "Bietenholz, W. and others",
- collaboration = "\xlf",
-     title     = "Going chiral: Overlap versus twisted mass fermions",
-     journal   = "JHEP",
-     volume    = "12",
-     year      = "2004",
-     pages     = "044",
-     eprint    = "hep-lat/0411001",
-     SLACcitation  = "%%CITATION = HEP-LAT 0411001;%%"
-}
-@Article{Blossier:2007vv,
-     author    = "Blossier, B. and others",
- collaboration = "ETM",
-     title     = "{Light quark masses and pseudoscalar decay constants from
-                  Nf=2 Lattice QCD with twisted mass fermions}",
-     year      = "2007",
-     eprint    = "0709.4574",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = ARXIV:0709.4574;%%"
-}
-@Article{Blum:1994eh,
-     author    = "Blum, Tom and others",
-     title     = "QCD thermodynamics with Wilson quarks at large kappa",
-     journal   = "Phys. Rev.",
-     volume    = "D50",
-     year      = "1994",
-     pages     = "3377-3381",
-     eprint    = "hep-lat/9404006",
-     SLACcitation  = "%%CITATION = HEP-LAT 9404006;%%"
-}
-@Article{Blum:2000kn,
-     author    = "Blum, T. and others",
-     title     = "Quenched lattice {QCD} with domain wall fermions and the
-                  chiral limit",
-     journal   = "Phys. Rev.",
-     volume    = "D69",
-     year      = "2004",
-     pages     = "074502",
-     eprint    = "hep-lat/0007038",
-     SLACcitation  = "%%CITATION = HEP-LAT 0007038;%%"
-}
-@Article{Bodin:2005gg,
-     author    = "Bodin, F. and others",
- collaboration = "ApeNEXT",
-     title     = "The {apeNEXT} project",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "176-182",
-     SLACcitation  = "%%CITATION = NUPHZ,140,176;%%"
-}
-@Article{Bolder:2000un,
-     author    = "Bolder, B. and others",
-     title     = "A high precision study of the Q anti-Q potential from
-                  {Wilson} loops in  the regime of string breaking",
-     journal   = "Phys. Rev.",
-     volume    = "D63",
-     year      = "2001",
-     pages     = "074504",
-     eprint    = "hep-lat/0005018",
-     SLACcitation  = "%%CITATION = HEP-LAT 0005018;%%"
-}
-@Article{Boucaud:2007uk,
-     author    = "Boucaud, Ph. and others",
- collaboration = "ETM",
-     title     = "Dynamical twisted mass fermions with light quarks",
-     year      = "2007",
-     eprint    = "hep-lat/0701012",
-     SLACcitation  = "%%CITATION = HEP-LAT 0701012;%%"
-}
-@Article{Boucaud:2008xu,
-     author    = "Boucaud, Ph. and others",
- collaboration = "ETM",
-     title     = "{Dynamical Twisted Mass Fermions with Light Quarks:
-                  Simulation and Analysis Details}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "179",
-     year      = "2008",
-     pages     = "695-715",
-     eprint    = "0803.0224",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     doi       = "10.1016/j.cpc.2008.06.013",
-     SLACcitation  = "%%CITATION = 0803.0224;%%"
-}
-@Article{Boughezal:2006px,
-     author    = "Boughezal, R. and Czakon, M. and Schutzmeier, T.",
-     title     = "{Charm and bottom quark masses from perturbative QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D74",
-     year      = "2006",
-     pages     = "074006",
-     eprint    = "hep-ph/0605023",
-     SLACcitation  = "%%CITATION = HEP-PH/0605023;%%"
-}
-@Article{Boyle:2005fb,
-     author    = "Boyle, P. A. and others",
-     title     = "{QCDOC}: Project status and first results",
-     journal   = "J. Phys. Conf. Ser.",
-     volume    = "16",
-     year      = "2005",
-     pages     = "129-139",
-     SLACcitation  = "%%CITATION = 00462,16,129;%%"
-}
-@Article{Brower:1994er,
-     author    = "Brower, R. C. and Levi, A. R. and Orginos, K.",
-     title     = "Extrapolation methods for the Dirac inverter in hybrid
-                  Monte Carlo",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "42",
-     year      = "1995",
-     pages     = "855-857",
-     eprint    = "hep-lat/9412004",
-     SLACcitation  = "%%CITATION = HEP-LAT 9412004;%%"
+@article{Hernandez:2001hq,
+	author = "Hernandez, P. and Jansen, K. and Lellouch, L. and Wittig, H.",
+	eprint = "hep-lat/0110199",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "766--771",
+	slaccitation = "%\%CITATION = HEP-LAT 0110199;\%\%",
+	title = "{Scalar condensate and light quark masses from overlap fermions}",
+	volume = "106",
+	year = "2002"
 }
 
-@Article{Brower:1995vx,
-     author    = "Brower, R. C. and Ivanenko, T. and Levi, A. R. and Orginos,
-                  K. N.",
-     title     = "Chronological inversion method for the Dirac matrix in
-                  hybrid Monte  Carlo",
-     journal   = "Nucl. Phys.",
-     volume    = "B484",
-     year      = "1997",
-     pages     = "353-374",
-     eprint    = "hep-lat/9509012",
-     SLACcitation  = "%%CITATION = HEP-LAT 9509012;%%"
+@article{Hernandez:2001yn,
+	author = "Hernandez, P. and Jansen, K. and Lellouch, L. and Wittig, H.",
+	eprint = "hep-lat/0106011",
+	journal = "JHEP",
+	pages = "018",
+	slaccitation = "%\%CITATION = HEP-LAT 0106011;\%\%",
+	title = "{Non-perturbative renormalization of the quark condensate in {Ginsparg}-{Wilson} regularizations}",
+	volume = "07",
+	year = "2001"
 }
 
-@Article{Bunk:1995uv,
-     author    = "Bunk, B. and others",
-     title     = "A New simulation algorithm for lattice {QCD} with dynamical
-                  quarks",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "42",
-     year      = "1995",
-     pages     = "49-55",
-     eprint    = "hep-lat/9411016",
-     SLACcitation  = "%%CITATION = HEP-LAT 9411016;%%"
-}
-@Article{Bunk:1998rm,
-     author    = "Bunk, B. and Elser, Stephan and Frezzotti, R. and Jansen,
-                  K.",
-     title     = "{Ordering monomial factors of polynomials in the product
-                  representation}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "118",
-     year      = "1999",
-     pages     = "95-109",
-     eprint    = "hep-lat/9805026",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/S0010-4655(99)00198-8",
-     SLACcitation  = "%%CITATION = HEP-LAT/9805026;%%"
-}
-@Article{Bunk:1998rm,
-     author    = "Bunk, B. and Elser, S. and Frezzotti, R. and Jansen,
-                  K.",
-     title     = "Ordering monomial factors of polynomials in the product
-                  representation",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "118",
-     year      = "1999",
-     pages     = "95-109",
-     eprint    = "hep-lat/9805026",
-     SLACcitation  = "%%CITATION = HEP-LAT 9805026;%%"
-}
-@Article{Burrage:1998a,
-  author       = " K. Burrage and J. Erhel",
-  title        = "On the performance of various adaptive preconditioned GMRES strategies",
-  journal      = "Num. Lin. Alg. with Appl.",
-  year         = "1998",
-  volume       = "5",
-  pages        = "101-121"
-}
-@Article{Campbell:1987nv,
-     author    = "Campbell, N. A. and Huntley, A. and Michael, C.",
-     title     = "Heavy quark potentials and hybrid mesons from SU(3) lattice
-                  gauge theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B306",
-     year      = "1988",
-     pages     = "51",
-     SLACcitation  = "%%CITATION = NUPHA,B306,51;%%"
-}
-@Article{Capitani:2005jp,
-     author    = "Capitani, S. and others",
-     title     = "Parton distribution functions with twisted mass fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B639",
-     year      = "2006",
-     pages     = "520-526",
-     eprint    = "hep-lat/0511013",
-     SLACcitation  = "%%CITATION = HEP-LAT 0511013;%%"
-}
-@Article{Chen:2003im,
-     author    = "Chen, Y. and others",
-     title     = "Chiral logarithms in quenched {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "034502",
-     eprint    = "hep-lat/0304005",
-     SLACcitation  = "%%CITATION = HEP-LAT 0304005;%%"
-}
-@Book{Cheng:2000ct,
-     author    = "Cheng, T. P. and Li, L. F.",
-     title     = "Gauge theory of elementary particle physics: Problems and
-                  solutions",
-     publisher = "Oxford, UK: Clarendon",
-     year      = "2000",
-     pages     = "306",
-     edition   = "",
-}
-@Article{Chetyrkin:1990kr,
-     author    = "Chetyrkin, K. G. and K{\"u}hn, Johann H.",
-     title     = "{Mass corrections to the Z decay rate}",
-     journal   = "Phys. Lett.",
-     volume    = "B248",
-     year      = "1990",
-     pages     = "359-364",
-     SLACcitation  = "%%CITATION = PHLTA,B248,359;%%"
-}
-@Article{Chetyrkin:1996cf,
-     author    = "Chetyrkin, K. G. and K{\"u}hn, Johann H. and Steinhauser, M.",
-     title     = "{Three-loop polarization function and O(alpha(s)**2)
-                  corrections to the  production of heavy quarks}",
-     journal   = "Nucl. Phys.",
-     volume    = "B482",
-     year      = "1996",
-     pages     = "213-240",
-     eprint    = "hep-ph/9606230",
-     SLACcitation  = "%%CITATION = HEP-PH/9606230;%%"
-}
-@Article{Chetyrkin:1997mb,
-     author    = "Chetyrkin, K. G. and K{\"u}hn, Johann H. and Steinhauser, M.",
-     title     = "{Heavy quark current correlators to O(alpha(s)**2)}",
-     journal   = "Nucl. Phys.",
-     volume    = "B505",
-     year      = "1997",
-     pages     = "40-64",
-     eprint    = "hep-ph/9705254",
-     SLACcitation  = "%%CITATION = HEP-PH/9705254;%%"
-}
-@Article{Chetyrkin:1998ix,
-     author    = "Chetyrkin, K. G. and Harlander, R. and Steinhauser, M.",
-     title     = "{Singlet polarization functions at O(alpha(s)**2)}",
-     journal   = "Phys. Rev.",
-     volume    = "D58",
-     year      = "1998",
-     pages     = "014012",
-     eprint    = "hep-ph/9801432",
-     SLACcitation  = "%%CITATION = HEP-PH/9801432;%%"
-}
-@Article{Chetyrkin:2000zk,
-     author    = "Chetyrkin, K. G. and Harlander, R. V. and K{\"u}hn, Johann H.",
-     title     = "{Quartic mass corrections to R(had) at O(alpha(s)**3)}",
-     journal   = "Nucl. Phys.",
-     volume    = "B586",
-     year      = "2000",
-     pages     = "56-72",
-     eprint    = "hep-ph/0005139",
-     SLACcitation  = "%%CITATION = HEP-PH/0005139;%%"
-}
-@Article{Chetyrkin:2006xg,
-     author    = "Chetyrkin, K. G. and K{\"u}hn, J. H. and Sturm, C.",
-     title     = "{Four-loop moments of the heavy quark vacuum polarization
-                  function in  perturbative QCD}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C48",
-     year      = "2006",
-     pages     = "107-110",
-     eprint    = "hep-ph/0604234",
-     SLACcitation  = "%%CITATION = HEP-PH/0604234;%%"
-}
-@Article{Chiarappa:2004ry,
-     author    = "Chiarappa, T. and others",
-     title     = "{Comparing iterative methods for overlap and twisted mass
-                   fermions}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "853-855",
-     eprint    = "hep-lat/0409107",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/j.nuclphysbps.2004.11.281",
-     SLACcitation  = "%%CITATION = HEP-LAT/0409107;%%"
-}
-@Article{Chiarappa:2006ae,
-     author    = "Chiarappa, T. and others",
-     title     = "{Numerical simulation of {QCD} with u, d, s and c quarks in
-                  the twisted-mass {W}ilson formulation}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C50",
-     year      = "2007",
-     pages     = "373-383",
-     eprint    = "hep-lat/0606011",
-     archivePrefix = "arXiv",
-     doi       = "10.1140/epjc/s10052-006-0204-4",
-     SLACcitation  = "%%CITATION = HEP-LAT/0606011;%%"
-}
-@Article{Chiarappa:2006hz,
-     author    = "Chiarappa, T. and others",
-     title     = "{Iterative methods for overlap and twisted mass fermions}",
-     year      = "2008",
-     journal   = "Comput. Sci. Disc.",
-     volume    = "01",
-     pages     = "015001",
-     eprint    = "hep-lat/0609023",
-     archivePrefix = "arXiv",
-     SLACcitation  = "%%CITATION = HEP-LAT/0609023;%%"
-}
-@Article{Cichy:2008gk,
-     author    = "Cichy, K. and Gonzalez Lopez, J. and Jansen, K. and Kujawa,
-                  A. and Shindler, A.",
-     title     = "{Twisted Mass, Overlap and Creutz Fermions: Cut-off Effects
-                  at Tree-level of Perturbation Theory}",
-     journal   = "Nucl. Phys.",
-     volume    = "B800",
-     year      = "2008",
-     pages     = "94-108",
-     eprint    = "0802.3637",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     doi       = "10.1016/j.nuclphysb.2008.03.004",
-     SLACcitation  = "%%CITATION = 0802.3637;%%"
-}
-@Article{Clark:2004cq,
-     author    = "Clark, M. A. and Kennedy, A. D.",
-     title     = "Accelerating fermionic molecular dynamics",
-     year      = "2004",
-     eprint    = "hep-lat/0409134",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409134;%%"
+@article{Horsley:2004mx,
+	author = "Horsley, R. and Perlt, H. and Rakow, P. E. L. and Schierholz, G. and Schiller, A.",
+	collaboration = "QCDSF",
+	eprint = "hep-lat/0404007",
+	journal = "Nucl. Phys.",
+	pages = "3--35",
+	slaccitation = "%\%CITATION = HEP-LAT 0404007;\%\%",
+	title = "{One-loop renormalisation of quark bilinears for overlap fermions with improved gauge actions}",
+	volume = "B693",
+	year = "2004"
 }
 
-@Article{Clark:2005sq,
-     author    = "Clark, M. A. and de Forcrand, Ph. and Kennedy, A. D.",
-     title     = "Algorithm shootout: R versus RHMC",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2005",
-     pages     = "115",
-     eprint    = "hep-lat/0510004",
-     SLACcitation  = "%%CITATION = HEP-LAT 0510004;%%"
-}
-@Article{Clark:2006fx,
-     author    = "Clark, M. A. and Kennedy, A. D.",
-     title     = "{Accelerating Dynamical Fermion Computations using the
-                  Rational Hybrid Monte Carlo (RHMC) Algorithm with Multiple
-                  Pseudofermion Fields}",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "98",
-     year      = "2007",
-     pages     = "051601",
-     eprint    = "hep-lat/0608015",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevLett.98.051601",
-     SLACcitation  = "%%CITATION = HEP-LAT/0608015;%%"
-}
-@Article{Clark:2006wp,
-     author    = "Clark, M. A. and Kennedy, A. D.",
-     title     = "{Accelerating Staggered Fermion Dynamics with the Rational
-                  Hybrid Monte Carlo (RHMC) Algorithm}",
-     journal   = "Phys. Rev.",
-     volume    = "D75",
-     year      = "2007",
-     pages     = "011502",
-     eprint    = "hep-lat/0610047",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.75.011502",
-     SLACcitation  = "%%CITATION = HEP-LAT/0610047;%%"
-}
-@Article{Colangelo:2001df,
-     author    = "Colangelo, G. and Gasser, J. and Leutwyler, H.",
-     title     = "{pi pi scattering}",
-     journal   = "Nucl. Phys.",
-     volume    = "B603",
-     year      = "2001",
-     pages     = "125-179",
-     eprint    = "hep-ph/0103088",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/S0550-3213(01)00147-X",
-     SLACcitation  = "%%CITATION = HEP-PH/0103088;%%"
-}
-@Article{Colangelo:2003hf,
-     author    = "Colangelo, Gilberto and D{\"u}rr, Stephan",
-     title     = "The pion mass in finite volume",
-     journal   = "Eur. Phys. J.",
-     volume    = "C33",
-     year      = "2004",
-     pages     = "543-553",
-     eprint    = "hep-lat/0311023",
-     SLACcitation  = "%%CITATION = HEP-LAT/0311023;%%"
-}
-@Article{Colangelo:2005gd,
-     author    = "Colangelo, Gilberto and D{\"u}rr, Stephan and Haefeli,
-                  Christoph",
-     title     = "Finite volume effects for meson masses and decay
-                  constants",
-     journal   = "Nucl. Phys.",
-     volume    = "B721",
-     year      = "2005",
-     pages     = "136-174",
-     eprint    = "hep-lat/0503014",
-     SLACcitation  = "%%CITATION = HEP-LAT 0503014;%%"
-}
-@Article{Colangelo:2006mp,
-     author    = "Colangelo, Gilberto and Haefeli, Christoph",
-     title     = "{Finite volume effects for the pion mass at two loops}",
-     journal   = "Nucl. Phys.",
-     volume    = "B744",
-     year      = "2006",
-     pages     = "14-33",
-     eprint    = "hep-lat/0602017",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/j.nuclphysb.2006.03.010",
-     SLACcitation  = "%%CITATION = HEP-LAT/0602017;%%"
-}
-@Book{Collins:1994ab,
-     author    = "Collins, J.C.",
-     title     = "Renormalisation",
-     publisher = "Cambridge University Press",
-     series    = "Cambridge Monographs on Mathematical Physics",
-     year      = "1994",
-     edition   = "",
-}
-@Article{Creutz:1984fj,
-     author    = "Creutz, M. and Gocksch, A. and Ogilvie, M. and
-                  Okawa, M.",
-     title     = "Microcanonical renormalization group",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "53",
-     year      = "1984",
-     pages     = "875",
-     SLACcitation  = "%%CITATION = PRLTA,53,875;%%"
-}
-@Article{Creutz:1989wt,
-     author    = "Creutz, M. and Gocksch, A.",
-     title     = "Higher order hybrid monte carlo algorithms",
-     note     = "BNL-42601"
-}
-@Article{Creutz:1996bg,
-     author    = "Creutz, Michael",
-     title     = "Wilson fermions at finite temperature",
-     year      = "1996",
-     eprint    = "hep-lat/9608024",
-     SLACcitation  = "%%CITATION = HEP-LAT 9608024;%%"
-}
-@Article{Creutz:1998ee,
-     author    = "Creutz, M.",
-     title     = "Evaluating Grassmann integrals",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "81",
-     year      = "1998",
-     pages     = "3555-3558",
-     eprint    = "hep-lat/9806037",
-     SLACcitation  = "%%CITATION = HEP-LAT 9806037;%%"
-}
-@Article{Cundy:2005pi,
-     author    = "Cundy, N. and others",
-     title     = "Numerical Methods for the {QCD} Overlap Operator IV: Hybrid
-                  Monte Carlo",
-     year      = "2005",
-     eprint    = "hep-lat/0502007",
-     SLACcitation  = "%%CITATION = HEP-LAT 0502007;%%"
-}
-@Article{David:1984ys,
-     author    = "David, F. and Hamber, H. W.",
-     title     = "Chiral condensate with {Wilson} fermions",
-     journal   = "Nucl. Phys.",
-     volume    = "B248",
-     year      = "1984",
-     pages     = "381",
-     SLACcitation  = "%%CITATION = NUPHA,B248,381;%%"
-}
-@Article{Davies:2008sw,
-     author    = "Davies, C. T. H. and others",
- collaboration = "HPQCD",
-     title     = "{Update: Accurate Determinations of $\alpha_s$ from
-                  Realistic Lattice QCD}",
-     year      = "2008",
-     eprint    = "0807.1687",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0807.1687;%%"
-}
-@Article{DeGrand:1990dk,
-     author    = "DeGrand, T. A. and Rossi, P.",
-     title     = "Conditioning techniques for dynamical fermions",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "60",
-     year      = "1990",
-     pages     = "211-214",
-     SLACcitation  = "%%CITATION = CPHCB,60,211;%%"
-}
-@Article{DeGrand:1990ip,
-     author    = "DeGrand, T. A.",
-     title     = "Resonance masses from Monte Carlo simulations (with
-                  emphasis on the rho meson)",
-     journal   = "Phys. Rev.",
-     volume    = "D43",
-     year      = "1991",
-     pages     = "2296-2300",
-     SLACcitation  = "%%CITATION = PHRVA,D43,2296;%%"
-}
-@Article{DeGrand:2002vu,
-     author    = "DeGrand, Thomas and Hasenfratz, Anna and Kovacs, Tamas G.",
-     title     = "Improving the chiral properties of lattice fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D67",
-     year      = "2003",
-     pages     = "054501",
-     eprint    = "hep-lat/0211006",
-     SLACcitation  = "%%CITATION = HEP-LAT 0211006;%%"
-}
-@Article{DeTar:2007ni,
-     author    = "DeTar, Carleton and Levkova, L.",
-     title     = "Effects of the disconnected flavor singlet corrections on
-                  the hyperfine splitting in charmonium",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "116",
-     eprint    = "0710.1322",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = ARXIV:0710.1322;%%"
-}
-@Article{DelDebbio:2006cn,
-     author    = "Del Debbio, L. and Giusti, L. and L{\"u}scher, M. and
-                  Petronzio, R. and Tantalo, N.",
-     title     = "QCD with light Wilson quarks on fine lattices. I: First
-                  experiences and physics results",
-     journal   = "JHEP",
-     volume    = "02",
-     year      = "2007",
-     pages     = "056",
-     eprint    = "hep-lat/0610059",
-     SLACcitation  = "%%CITATION = HEP-LAT 0610059;%%"
-}
-@Article{DellaMorte:2000yp,
-     author    = "Della Morte, M. and Frezzotti, R. and Heitger, J. and Sint,
-                  S.",
-     title     = "Non-perturbative scaling tests of twisted mass {QCD}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "94",
-     year      = "2001",
-     pages     = "617-621",
-     eprint    = "hep-lat/0010091",
-     SLACcitation  = "%%CITATION = HEP-LAT 0010091;%%"
-}
-@Article{DellaMorte:2001tu,
-     author    = "Della Morte, M. and Frezzotti, R. and Heitger, J.",
-     title     = "Quenched twisted mass {QCD} at small quark masses and in
-                  large volume",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "260-262",
-     eprint    = "hep-lat/0110166",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110166;%%"
+@article{Ilgenfritz:2003gw,
+	author = "Ilgenfritz, E.-M. and Kerler, W. and M{\"u}ller-Preu{\ss}ker, M. and Sternbeck, A. and St{\"u}ben, H.",
+	eprint = "hep-lat/0309057",
+	journal = "Phys. Rev.",
+	pages = "074511",
+	slaccitation = "%\%CITATION = HEP-LAT 0309057;\%\%",
+	title = "{A numerical reinvestigation of the {Aoki} phase with {N(f)} = 2 {Wilson} fermions at zero temperature}",
+	volume = "D69",
+	year = "2004"
 }
 
-@Article{DellaMorte:2001ys,
-     author    = "Della Morte, M. and Frezzotti, R. and Heitger,
-                  J. and Sint, S.",
- collaboration = "ALPHA",
-     title     = "Cutoff effects in twisted mass lattice {QCD}",
-     journal   = "JHEP",
-     volume    = "10",
-     year      = "2001",
-     pages     = "041",
-     eprint    = "hep-lat/0108019",
-     SLACcitation  = "%%CITATION = HEP-LAT 0108019;%%"
-}                                                                               
-@Article{DellaMorte:2003jj,
-     author    = "Della Morte, M. and others",
- collaboration = "ALPHA",
-     title     = "Simulating the Schroedinger functional with two pseudo-
-                  fermions",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "156",
-     year      = "2003",
-     pages     = "62-72",
-     eprint    = "hep-lat/0307008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0307008;%%"
-}                                                                               
-@Article{DellaMorte:2003mn,
-     author    = "Della Morte, M. and others",
- collaboration = "ALPHA",
-     title     = "Lattice HQET with exponentially improved statistical
-                  precision",
-     journal   = "Phys. Lett.",
-     volume    = "B581",
-     year      = "2004",
-     pages     = "93-98",
-     eprint    = "hep-lat/0307021",
-     SLACcitation  = "%%CITATION = HEP-LAT 0307021;%%"
-}             
-@Article{DellaMorte:2003mw,
-     author    = "Della Morte, M. and others",
- collaboration = "ALPHA",
-     title     = "Static quarks with improved statistical precision",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "129",
-     year      = "2004",
-     pages     = "346-348",
-     eprint    = "hep-lat/0309080",
-     SLACcitation  = "%%CITATION = HEP-LAT 0309080;%%"
-}                                                                  
-@Article{DellaMorte:2005yc,
-     author    = "Della Morte, M. and Shindler, A. and Sommer,
-                  R.",
-     title     = "On lattice actions for static quarks",
-     year      = "2005",
-     eprint    = "hep-lat/0506008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0506008;%%"
+@article{Ilgenfritz:2006tz,
+	author = "Ilgenfritz, E. -M. and others",
+	eprint = "hep-lat/0610112",
+	slaccitation = "%\%CITATION = HEP-LAT 0610112;\%\%",
+	title = "{Twisted mass QCD thermodynamics: First results on apeNEXT}",
+	year = "2006"
 }
-@Article{Dimopoulos:2006dm,
-     author    = "Dimopoulos, P. and others",
- collaboration = "ALPHA",
-     title     = "A precise determination of B(K) in quenched QCD",
-     journal   = "Nucl. Phys.",
-     volume    = "B749",
-     year      = "2006",
-     pages     = "69-108",
-     eprint    = "hep-ph/0601002",
-     SLACcitation  = "%%CITATION = HEP-PH 0601002;%%"
+
+@article{Iwasaki:1983ck,
+	author = "Iwasaki, Y.",
+	note = "UTHEP-118",
+	title = "{Renormalization group analysis of lattice theories and improved lattice action. 2. four-dimensional nonabelian SU(N) gauge model}"
 }
-@Article{Dimopoulos:2007fn,
-     author    = "Dimopoulos, P. and others",
-     title     = "{Renormalisation of quark bilinears with Nf=2 Wilson
-                  fermions and tree-level improved gauge action}",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "241",
-     eprint    = "0710.0975",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0710.0975;%%"
+
+@article{Iwasaki:1985we,
+	author = "Iwasaki, Y.",
+	journal = "Nucl. Phys.",
+	pages = "141--156",
+	slaccitation = "%\%CITATION = NUPHA,B258,141;\%\%",
+	title = "{Renormalization group analysis of lattice theories and improved lattice action: two-dimensional nonlinear O(N) sigma model}",
+	volume = "B258",
+	year = "1985"
 }
-@Article{Dimopoulos:2007qy,
-     author    = "Dimopoulos, Petros and Frezzotti, Roberto and Herdoiza,
-                  Gregorio and Urbach, Carsten and Wenger, Urs",
- collaboration = "ETM",
-     title     = "{Scaling and low energy constants in lattice QCD with N_f=2
-                  maximally twisted Wilson quarks}",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "102",
-     eprint    = "0710.2498",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0710.2498;%%"
+
+@article{Iwasaki:1992hn,
+	author = "Iwasaki, Y. and Kanaya, K. and Sakai, S. and Yoshie, T.",
+	eprint = "hep-lat/9211035",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "327--330",
+	slaccitation = "%\%CITATION = HEP-LAT 9211035;\%\%",
+	title = "{Quark confinement in multi - flavor quantum chromodynamics}",
+	volume = "30",
+	year = "1993"
 }
-@Article{Dimopoulos:2008sy,
-     author    = "Dimopoulos, Petros and others",
- collaboration = "ETM",
-     title     = "{Scaling and chiral extrapolation of pion mass and decay
-                  constant with maximally twisted mass QCD}",
-     year      = "2008",
-     eprint    = "0810.2873",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0810.2873;%%"
+
+@article{Izubuchi:1998hy,
+	author = "Izubuchi, T. and Noaki, J. and Ukawa, A.",
+	eprint = "hep-lat/9805019",
+	journal = "Phys. Rev.",
+	pages = "114507",
+	slaccitation = "%\%CITATION = HEP-LAT 9805019;\%\%",
+	title = "{Two-dimensional lattice Gross-Neveu model with {Wilson} fermion action at finite temperature and chemical potential}",
+	volume = "D58",
+	year = "1998"
 }
-@Article{Dong:2001fm,
-     author    = "Dong, S. J. and others",
-     title     = "Chiral properties of pseudoscalar mesons on a quenched
-                  20**4 lattice  with overlap fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D65",
-     year      = "2002",
-     pages     = "054507",
-     eprint    = "hep-lat/0108020",
-     SLACcitation  = "%%CITATION = HEP-LAT 0108020;%%"
+
+@article{Jacobs:1983ph,
+	author = "Jacobs, L.",
+	journal = "Phys. Rev. Lett.",
+	pages = "172",
+	slaccitation = "%\%CITATION = PRLTA,51,172;\%\%",
+	title = "{Undoubling chirally symmetric lattice fermions}",
+	volume = "51",
+	year = "1983"
 }
-@Article{Duane:1987de,
-     author    = "Duane, S. and Kennedy, A. D. and Pendleton, B. J. and
-                  Roweth, D.",
-     title     = "{H}ybrid monte carlo",
-     journal   = "Phys. Lett.",
-     volume    = "B195",
-     year      = "1987",
-     pages     = "216-222",
-     SLACcitation  = "%%CITATION = PHLTA,B195,216;%%"
+
+@article{Jagels:1994a,
+	author = "Jagels, C. F. and Reichel, L.",
+	journal = "Numer. Linear Algebra Appl.",
+	pages = "555--570",
+	title = "{fast minimal residual algorithm for shifted unitary matrices}",
+	volume = "1(6)",
+	year = "1994"
 }
-@Article{Edwards:1996vs,
-     author    = "Edwards, R. G. and Horvath, I. and Kennedy, A. D.",
-     title     = "Instabilities and non-reversibility of molecular dynamics
-                  trajectories",
-     journal   = "Nucl. Phys.",
-     volume    = "B484",
-     year      = "1997",
-     pages     = "375-402",
-     eprint    = "hep-lat/9606004",
-     SLACcitation  = "%%CITATION = HEP-LAT 9606004;%%"
+
+@article{Jagels:1994aa,
+	author = "Jagels, C. F. and Reichel, L.",
+	journal = "Numerical Linear Algebra with Aplications",
+	pages = "555--570",
+	title = "{A Fast Minimal Residual Algorithm for Shifted Unitary Matrices}",
+	volume = "1(6)",
+	year = "1994"
 }
-@Article{Edwards:2004sx,
-     author    = "Edwards, Robert G. and Joo, Balint",
- collaboration = "SciDAC",
-     title     = "The {Chroma} software system for lattice {QCD}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "832",
-     eprint    = "hep-lat/0409003",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409003;%%"
+
+@article{Jansen:1994ym,
+	author = "Jansen, K.",
+	eprint = "hep-lat/9410018",
+	journal = "Phys. Rept.",
+	pages = "1--54",
+	slaccitation = "%\%CITATION = HEP-LAT 9410018;\%\%",
+	title = "{Domain wall fermions and chiral gauge theories}",
+	volume = "273",
+	year = "1996"
 }
-@Article{Eichten:1989zv,
-     author    = "Eichten, E. and Hill, B.",
-     title     = "An effective field theory for the calculation of matrix
-                  elements involving heavy quarks",
-     journal   = "Phys. Lett.",
-     volume    = "B234",
-     year      = "1990",
-     pages     = "511",
-     SLACcitation  = "%%CITATION = PHLTA,B234,511;%%"
+
+@article{Jansen:1995ck,
+	author = "Jansen, Karl and others",
+	eprint = "hep-lat/9512009",
+	journal = "Phys. Lett.",
+	pages = "275--282",
+	slaccitation = "%\%CITATION = HEP-LAT 9512009;\%\%",
+	title = "{Non-perturbative renormalization of lattice QCD at all scales}",
+	volume = "B372",
+	year = "1996"
 }
-@Article{Farchioni:2002vn,
-     author    = "Farchioni, F. and Gebert, C. and Montvay, I.
-                  and Scorzato, L.",
-     title     = "Numerical simulation tests with light dynamical quarks",
-     journal   = "Eur. Phys. J.",
-     volume    = "C26",
-     year      = "2002",
-     pages     = "237-251",
-     eprint    = "hep-lat/0206008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0206008;%%"
+
+@article{Jansen:1996cq,
+	author = "Jansen, K. and Liu, C.",
+	eprint = "hep-lat/9607057",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "974--976",
+	slaccitation = "%\%CITATION = HEP-LAT 9607057;\%\%",
+	title = "{Study of Liapunov exponents and the reversibility of molecular dynamics algorithms}",
+	volume = "53",
+	year = "1997"
 }
-@Article{Farchioni:2004fs,
-     author    = "Farchioni, F. and others",
-     title     = "The phase structure of lattice {QCD} with {Wilson} quarks and
-                  renormalization group improved gluons",
-     journal   = "Eur. Phys. J.",
-     volume    = "C42",
-     year      = "2005",
-     pages     = "73-87",
-     eprint    = "hep-lat/0410031",
-     SLACcitation  = "%%CITATION = HEP-LAT 0410031;%%"
+
+@article{Jansen:1996xp,
+	author = "Jansen, K.",
+	eprint = "hep-lat/9607051",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "127--133",
+	slaccitation = "%\%CITATION = HEP-LAT 9607051;\%\%",
+	title = "{Recent developments in fermion simulation algorithms}",
+	volume = "53",
+	year = "1997"
 }
-@Article{Farchioni:2004ma,
-     author    = "Farchioni, F. and others",
-     title     = "Exploring the phase structure of lattice {{QCD}} with twisted
-                  mass quarks",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "240-245",
-     eprint    = "hep-lat/0409098",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409098;%%"
+
+@article{Jansen:1997yt,
+	author = "Jansen, K. and Liu, C.",
+	eprint = "hep-lat/9603008",
+	journal = "Comput. Phys. Commun.",
+	pages = "221--234",
+	slaccitation = "%\%CITATION = HEP-LAT 9603008;\%\%",
+	title = "{Implementation of Symanzik's improvement program for simulations of dynamical {Wilson} fermions in lattice {QCD}}",
+	volume = "99",
+	year = "1997"
 }
-@Article{Farchioni:2004us,
-     author    = "Farchioni, F. and others",
-     title     = "Twisted mass quarks and the phase structure of lattice
-                  {QCD}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C39",
-     year      = "2005",
-     pages     = "421-433",
-     eprint    = "hep-lat/0406039",
-     SLACcitation  = "%%CITATION = HEP-LAT 0406039;%%"
+
+@article{Jansen:1998mx,
+	author = "Jansen, K. and Sommer, R.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/9803017",
+	journal = "Nucl. Phys.",
+	pages = "185--203",
+	slaccitation = "%\%CITATION = HEP-LAT 9803017;\%\%",
+	title = "{O(alpha) improvement of lattice {QCD} with two flavors of {Wilson} quarks}",
+	volume = "B530",
+	year = "1998"
 }
-@Article{Farchioni:2005ec,
-     author    = "Farchioni, Federico and others",
-     title     = "Dynamical twisted mass fermions",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "072",
-     eprint    = "hep-lat/0509131",
-     SLACcitation  = "%%CITATION = HEP-LAT 0509131;%%"
+
+@article{Jansen:2003ir,
+	author = "Jansen, K. and Shindler, A. and Urbach, C. and Wetzorke, I.",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0312013",
+	journal = "Phys. Lett.",
+	pages = "432--438",
+	slaccitation = "%\%CITATION = HEP-LAT 0312013;\%\%",
+	title = "{Scaling test for {Wilson} twisted mass {QCD}}",
+	volume = "B586",
+	year = "2004"
 }
-@Article{Farchioni:2005hf,
-     author    = "Farchioni, F. and others",
-     title     = "Twisted mass fermions: Neutral pion masses from
-                  disconnected contributions",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "033",
-     eprint    = "hep-lat/0509036",
-     SLACcitation  = "%%CITATION = HEP-LAT 0509036;%%"
+
+@article{Jansen:2003jq,
+	author = "Jansen, K. and Nagai, K.-I.",
+	eprint = "hep-lat/0305009",
+	journal = "JHEP",
+	pages = "038",
+	slaccitation = "%\%CITATION = HEP-LAT 0305009;\%\%",
+	title = "{Reducing residual-mass effects for domain-wall fermions}",
+	volume = "12",
+	year = "2003"
 }
-@Article{Farchioni:2005tu,
-     author    = "Farchioni, F. and others",
-     title     = "Lattice spacing dependence of the first order phase
-                  transition for  dynamical twisted mass fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B624",
-     year      = "2005",
-     pages     = "324-333",
-     eprint    = "hep-lat/0506025",
-     SLACcitation  = "%%CITATION = HEP-LAT 0506025;%%"
+
+@article{Jansen:2003nt,
+	author = "Jansen, K.",
+	eprint = "hep-lat/0311039",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "3--16",
+	slaccitation = "%\%CITATION = HEP-LAT 0311039;\%\%",
+	title = "{Actions for dynamical fermion simulations: Are we ready to go?}",
+	volume = "129",
+	year = "2004"
 }
-@Article{Feldmann:1999uf,
-     author    = "Feldmann, Thorsten",
-     title     = "{Quark structure of pseudoscalar mesons}",
-     journal   = "Int. J. Mod. Phys.",
-     volume    = "A15",
-     year      = "2000",
-     pages     = "159-207",
-     eprint    = "hep-ph/9907491",
-     SLACcitation  = "%%CITATION = HEP-PH/9907491;%%"
+
+@article{Jansen:2005cg,
+	author = "Jansen, K. and others",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0507032",
+	journal = "Phys. Lett.",
+	pages = "334--341",
+	slaccitation = "%\%CITATION = HEP-LAT 0507032;\%\%",
+	title = "{Flavour breaking effects of {Wilson} twisted mass fermions}",
+	volume = "B624",
+	year = "2005"
 }
-@Article{Feynman:1948aa,
-     author    = "Feynman, R. P.",
-     title     = "Space-time approach to non-relativistic quantum mechanics",
-     journal   = "Rev. Mod. Phys.",
-     volume    = "20",
-     year      = "1948",
-     pages     = "367-387",
-     SLACcitation  = "%%CITATION = RMPHA,20,367;%%"
+
+@unpublished{Jansen:2005chi,
+	author = "Jansen, K. and others",
+	collaborations = "\xlf",
+	note = "in preparation",
+	optannote = "",
+	optkey = "",
+	optmonth = "",
+	title = "{}",
+	year = "2005"
 }
-@Article{Fischer:1996th,
-     author    = "Fischer, S. and others",
-     title     = "A Parallel SSOR Preconditioner for Lattice {QCD}",
-     journal   = "Comp. Phys. Commun.",
-     volume    = "98",
-     year      = "1996",
-     pages     = "20-34",
-     eprint    = "hep-lat/9602019",
-     SLACcitation  = "%%CITATION = HEP-LAT 9602019;%%"
+
+@article{Jansen:2005gf,
+	author = "Jansen, K. and Papinutto, M. and Shindler, A. and Urbach, C. and Wetzorke, I.",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0503031",
+	journal = "Phys. Lett.",
+	pages = "184--191",
+	slaccitation = "%\%CITATION = HEP-LAT 0503031;\%\%",
+	title = "{Light quarks with twisted mass fermions}",
+	volume = "B619",
+	year = "2005"
 }
-@Article{Fokkema:1998aa,
-     author    = "Fokkema, D.~R. and Sleijpen, G.~L.~G. and Van~der~Vorst, H.~A.",
-     title     = "{J}acobi-{D}avidson style {QR} and {QZ} algorithms for
-                  the reduction of matrix pencils",
-     journal   = "J. Sci. Comput.",
-     volume    = "20",
-     year      = "1998",
-     pages     = "94-125",
+
+@article{Jansen:2005kk,
+	author = "Jansen, K. and Papinutto, M. and Shindler, A. and Urbach, C. and Wetzorke, I.",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0507010",
+	journal = "JHEP",
+	pages = "071",
+	slaccitation = "%\%CITATION = HEP-LAT 0507010;\%\%",
+	title = "{Quenched scaling of {Wilson} twisted mass fermions}",
+	volume = "09",
+	year = "2005"
 }
-@Article{Foster:1998vw,
-     author    = "Foster, M. and Michael, C.",
-     collaboration = "UKQCD",
-     title     = "Quark mass dependence of hadron masses from lattice {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D59",
-     year      = "1999",
-     pages     = "074503",
-     eprint    = "hep-lat/9810021",
-     SLACcitation  = "%%CITATION = HEP-LAT 9810021;%%"
+
+@article{Jansen:2005yp,
+	author = "Jansen, Karl and Shindler, Andrea and Urbach, Carsten and Wenger, Urs",
+	eprint = "hep-lat/0510064",
+	journal = "PoS",
+	pages = "118",
+	slaccitation = "%\%CITATION = HEP-LAT 0510064;\%\%",
+	title = "{{HMC} algorithm with multiple time scale integration and mass preconditioning}",
+	volume = "LAT2005",
+	year = "2006"
 }
-@Article{Freund,
-     author    = "Freund, R.W.",
-     journal   = "in Numerical Linear Algebra, L.\ Reichel, A.\ Ruttan and R.S.\ Varga (eds.)",
-     year      = "1993",
-     pages     = "p. 101",
+
+@article{Jansen:2006ks,
+	author = "Jansen, Karl",
+	eprint = "hep-lat/0609012",
+	slaccitation = "%\%CITATION = HEP-LAT 0609012;\%\%",
+	title = "{Status report on ILDG activities}",
+	year = "2006"
 }
-@Article{Frezzotti:1997ym,
-     author    = "Frezzotti, R. and Jansen, K.",
-     title     = "A polynomial hybrid Monte Carlo algorithm",
-     journal   = "Phys. Lett.",
-     volume    = "B402",
-     year      = "1997",
-     pages     = "328-334",
-     eprint    = "hep-lat/9702016",
-     SLACcitation  = "%%CITATION = HEP-LAT 9702016;%%"
+
+@article{Jansen:2006rf,
+	author = "Jansen, Karl and Urbach, Carsten",
+	collaboration = "ETM",
+	eprint = "hep-lat/0610015",
+	slaccitation = "%\%CITATION = HEP-LAT 0610015;\%\%",
+	title = "{First results with two light flavours of quarks with maximally twisted mass}",
+	year = "2006"
 }
-@Article{Frezzotti:1998eu,
-     author    = "Frezzotti, R. and Jansen, K.",
-     title     = "The {PHMC} algorithm for simulations of dynamical fermions.
-                  {I}: Description and properties",
-     journal   = "Nucl. Phys.",
-     volume    = "B555",
-     year      = "1999",
-     pages     = "395-431",
-     eprint    = "hep-lat/9808011",
-     SLACcitation  = "%%CITATION = HEP-LAT 9808011;%%"
+
+@article{Jansen:2008wv,
+	archiveprefix = "arXiv",
+	author = "Jansen, K. and Michael, C. and Urbach, C.",
+	collaboration = "ETM",
+	eprint = "0804.3871",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0804.3871;\%\%",
+	title = "{The eta' meson from lattice {QCD}}",
+	year = "2008"
 }
-@Article{Frezzotti:1998yp,
-     author    = "Frezzotti, R. and Jansen, K.",
-     title     = "The {PHMC} algorithm for simulations of dynamical fermions.
-                  {II}:  Performance analysis",
-     journal   = "Nucl. Phys.",
-     volume    = "B555",
-     year      = "1999",
-     pages     = "432-453",
-     eprint    = "hep-lat/9808038",
-     SLACcitation  = "%%CITATION = HEP-LAT 9808038;%%"
+
+@article{Jansen:2008zz,
+	author = "Jansen, K. and Michael, C. and Urbach, C.",
+	doi = "10.1140/epjc/s10052-008-0764-6",
+	journal = "Eur. Phys. J.",
+	pages = "261--269",
+	slaccitation = "%\%CITATION = EPHJA,C58,261;\%\%",
+	title = "{The eta-prime meson from lattice QCD}",
+	volume = "C58",
+	year = "2008"
 }
-@Article{Frezzotti:1999vv,
-     author    = "Frezzotti, R. and Grassi, P. A. and Sint,
-                  S. and Weisz, P.",
-     title     = "A local formulation of lattice {QCD} without unphysical
-                  fermion zero modes",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "83",
-     year      = "2000",
-     pages     = "941-946",
-     eprint    = "hep-lat/9909003",
-     SLACcitation  = "%%CITATION = HEP-LAT 9909003;%%"
+
+@unpublished{Jegerlehner:1996pm,
+	author = "Jegerlehner, Beat",
+	eprint = "hep-lat/9612014",
+	note = "unpublished",
+	slaccitation = "%\%CITATION = HEP-LAT 9612014;\%\%",
+	title = "{Krylov space solvers for shifted linear systems}",
+	year = "1996"
 }
-@Article{Frezzotti:2000nk,
-     author    = "Frezzotti, R. and Grassi, P. A. and Sint,
-                  S. and Weisz, P.",
- collaboration = "ALPHA",
-     title     = "Lattice {QCD} with a chirally twisted mass term",
-     journal   = "JHEP",
-     volume    = "08",
-     year      = "2001",
-     pages     = "058",
-     eprint    = "hep-lat/0101001",
-     SLACcitation  = "%%CITATION = HEP-LAT 0101001;%%"
+
+@article{Jegerlehner:1997rn,
+	author = "Jegerlehner, B.",
+	eprint = "hep-lat/9708029",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "958--960",
+	slaccitation = "%\%CITATION = HEP-LAT 9708029;\%\%",
+	title = "{Multiple mass solvers}",
+	volume = "63",
+	year = "1998"
 }
-@Article{Frezzotti:2001du,
-     author    = "Frezzotti, R. and Sint, S.",
-     title     = "Some remarks on {O(a)} improved twisted mass {QCD}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "814-816",
-     eprint    = "hep-lat/0110140",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110140;%%"
+
+@article{Jegerlehner:2003qp,
+	author = "Jegerlehner, F.",
+	eprint = "hep-ph/0310234",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "325--334",
+	slaccitation = "%\%CITATION = HEP-PH 0310234;\%\%",
+	title = "{Theoretical precision in estimates of the hadronic contributions to (g-2)mu and alpha(QED)(M(Z))}",
+	volume = "126",
+	year = "2004"
 }
-@Article{Frezzotti:2001ea,
-     author    = "Frezzotti, R. and Sint, S. and Weisz, P.",
- collaboration = "ALPHA",
-     title     = "{O(a)} improved twisted mass lattice {QCD}",
-     journal   = "JHEP",
-     volume    = "07",
-     year      = "2001",
-     pages     = "048",
-     eprint    = "hep-lat/0104014",
-     SLACcitation  = "%%CITATION = HEP-LAT 0104014;%%"
+
+@article{Jenkins:1990jv,
+	author = "Jenkins, Elizabeth Ellen and Manohar, Aneesh V.",
+	journal = "Phys. Lett.",
+	pages = "558--562",
+	slaccitation = "%\%CITATION = PHLTA,B255,558;\%\%",
+	title = "{Baryon chiral perturbation theory using a heavy fermion Lagrangian}",
+	volume = "B255",
+	year = "1991"
 }
-@Article{Frezzotti:2003ni,
-     author    = "Frezzotti, R. and Rossi, G. C.",
-     title     = "Chirally improving {Wilson} fermions. {I}: {O(a)} improvement",
-     journal   = "JHEP",
-     volume    = "08",
-     year      = "2004",
-     pages     = "007",
-     eprint    = "hep-lat/0306014",
-     SLACcitation  = "%%CITATION = HEP-LAT 0306014;%%"
+
+@article{Kaiser:1998ds,
+	author = "Kaiser, Roland and Leutwyler, H.",
+	eprint = "hep-ph/9806336",
+	slaccitation = "%\%CITATION = HEP-PH/9806336;\%\%",
+	title = "{Pseudoscalar decay constants at large N(c)}",
+	year = "1998"
 }
-@Article{Frezzotti:2003xj,
-     author    = "Frezzotti, R. and Rossi, G. C.",
-     title     = "Twisted-mass lattice {QCD} with mass non-degenerate quarks",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "128",
-     year      = "2004",
-     pages     = "193-202",
-     eprint    = "hep-lat/0311008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0311008;%%"
+
+@article{Kalkreuter:1995mm,
+	author = "Kalkreuter, Thomas and Simma, Hubert",
+	eprint = "hep-lat/9507023",
+	journal = "Comput. Phys. Commun.",
+	pages = "33--47",
+	slaccitation = "%\%CITATION = HEP-LAT 9507023;\%\%",
+	title = "{An Accelerated conjugate gradient algorithm to compute low lying eigenvalues: A Study for the Dirac operator in SU(2) lattice QCD}",
+	volume = "93",
+	year = "1996"
 }
-@Article{Frezzotti:2004wz,
-     author    = "Frezzotti, R. and Rossi, G. C.",
-     title     = "Chirally improving {Wilson} fermions. {II}: Four-quark
-                  operators",
-     journal   = "JHEP",
-     volume    = "10",
-     year      = "2004",
-     pages     = "070",
-     eprint    = "hep-lat/0407002",
-     SLACcitation  = "%%CITATION = HEP-LAT 0407002;%%"
+
+@article{Kalkreuter:1996mm,
+	author = "Kalkreuter, T. and Simma, H.",
+	eprint = "hep-lat/9507023",
+	journal = "Comput. Phys. Commun.",
+	pages = "33--47",
+	slaccitation = "%\%CITATION = HEP-LAT 9507023;\%\%",
+	title = "{An Accelerated conjugate gradient algorithm to compute low lying eigenvalues: A Study for the Dirac operator in SU(2) lattice {QCD}}",
+	volume = "93",
+	year = "1996"
 }
-@Article{Frezzotti:2005gi,
-     author    = "Frezzotti, R. and Martinelli, G. and Papinutto, M. and
-                  Rossi, G. C.",
-     title     = "Reducing cutoff effects in maximally twisted lattice {QCD}
-                  close to the  chiral limit",
-     journal   = "JHEP",
-     volume    = "04",
-     year      = "2006",
-     pages     = "038",
-     eprint    = "hep-lat/0503034",
-     SLACcitation  = "%%CITATION = HEP-LAT 0503034;%%"
+
+@article{Kaplan:1992bt,
+	author = "Kaplan, D. B.",
+	eprint = "hep-lat/9206013",
+	journal = "Phys. Lett.",
+	pages = "342--347",
+	slaccitation = "%\%CITATION = HEP-LAT 9206013;\%\%",
+	title = "{A Method for simulating chiral fermions on the lattice}",
+	volume = "B288",
+	year = "1992"
 }
-@Article{Frezzotti:2007qv,
-     author    = "Frezzotti, R. and Rossi, G.",
-     title     = "{O(a^2) cutoff effects in Wilson fermion simulations}",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "277",
-     eprint    = "0710.2492",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0710.2492;%%"
+
+@article{Karsten:1980wd,
+	author = "Karsten, L. H. and Smit, J.",
+	journal = "Nucl. Phys.",
+	pages = "103",
+	slaccitation = "%\%CITATION = NUPHA,B183,103;\%\%",
+	title = "{Lattice fermions: species doubling, chiral invariance, and the triangle anomaly}",
+	volume = "B183",
+	year = "1981"
 }
-@Article{Frezzotti:2008dr,
-     author    = "Frezzotti, R. and Lubicz, V. and Simula, S.",
- collaboration = "ETM",
-     title     = "{Electromagnetic form factor of the pion from twisted-mass
-                  lattice {QCD} at {Nf}=2}",
-     year      = "2008",
-     eprint    = "0812.4042",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0812.4042;%%"
+
+@article{Kennedy:1990bv,
+	author = "Kennedy, A. D. and Pendleton, B.",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "118--121",
+	slaccitation = "%\%CITATION = NUPHZ,20,118;\%\%",
+	title = "{Acceptances and autocorrelations in hybrid Monte Carlo}",
+	volume = "20",
+	year = "1991"
 }
-@Article{Fritzsch:1973pi,
-     author    = "Fritzsch, H. and Gell-Mann, M. and Leutwyler, H.",
-     title     = "Advantages of the color octet gluon picture",
-     journal   = "Phys. Lett.",
-     volume    = "B47",
-     year      = "1973",
-     pages     = "365-368",
-     SLACcitation  = "%%CITATION = PHLTA,B47,365;%%"
+
+@article{Knechtli:1998gf,
+	author = "Knechtli, F. and Sommer, R.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/9807022",
+	journal = "Phys. Lett.",
+	pages = "345--352",
+	slaccitation = "%\%CITATION = HEP-LAT 9807022;\%\%",
+	title = "{String breaking in SU(2) gauge theory with scalar matter fields}",
+	volume = "B440",
+	year = "1998"
 }
-@Article{Frommer:1994vn,
-     author    = "Frommer, A. and Hannemann, V. and Nockel, B. and Lippert,
-                  T. and Schilling, K.",
-     title     = "Accelerating {Wilson} fermion matrix inversions by means of
-                  the stabilized biconjugate gradient algorithm",
-     journal   = "Int. J. Mod. Phys.",
-     volume    = "C5",
-     year      = "1994",
-     pages     = "1073-1088",
-     eprint    = "hep-lat/9404013",
-     SLACcitation  = "%%CITATION = HEP-LAT 9404013;%%"
+
+@article{Knechtli:2000df,
+	author = "Knechtli, F. and Sommer, R.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0005021",
+	journal = "Nucl. Phys.",
+	pages = "309--328",
+	slaccitation = "%\%CITATION = HEP-LAT 0005021;\%\%",
+	title = "{String breaking as a mixing phenomenon in the SU(2) Higgs model}",
+	volume = "B590",
+	year = "2000"
 }
-@Article{Frommer:1995ik,
-     author    = "Frommer, Andreas and Nockel, Bertold and Gusken, Stephan
-                  and Lippert, Thomas and Schilling, Klaus",
-     title     = "Many masses on one stroke: Economic computation of quark
-                  propagators",
-     journal   = "Int. J. Mod. Phys.",
-     volume    = "C6",
-     year      = "1995",
-     pages     = "627-638",
-     eprint    = "hep-lat/9504020",
-     SLACcitation  = "%%CITATION = HEP-LAT 9504020;%%"
+
+@article{Lacock:1994qx,
+	author = "Lacock, P. and McKerrell, A. and Michael, C. and Stopher, I. M. and Stephenson, P. W.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/9412079",
+	journal = "Phys. Rev.",
+	pages = "6403--6410",
+	slaccitation = "%\%CITATION = HEP-LAT 9412079;\%\%",
+	title = "{Efficient hadronic operators in lattice gauge theory}",
+	volume = "D51",
+	year = "1995"
 }
+
+@article{Lepage:1992xa,
+	author = "Lepage, G. Peter and Mackenzie, Paul B.",
+	eprint = "hep-lat/9209022",
+	journal = "Phys. Rev.",
+	pages = "2250--2264",
+	slaccitation = "%\%CITATION = HEP-LAT 9209022;\%\%",
+	title = "{On the viability of lattice perturbation theory}",
+	volume = "D48",
+	year = "1993"
+}
+
+@article{Lepage:2001ym,
+	archiveprefix = "arXiv",
+	author = "Lepage, G. P. and others",
+	doi = "10.1016/S0920-5632(01)01638-3",
+	eprint = "hep-lat/0110175",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "12--20",
+	slaccitation = "%\%CITATION = HEP-LAT/0110175;\%\%",
+	title = "{Constrained curve fitting}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Lesk:2002gd,
+	author = "Lesk, V. I. and others",
+	collaboration = "CP-PACS",
+	eprint = "hep-lat/0211040",
+	journal = "Phys. Rev.",
+	pages = "074503",
+	slaccitation = "%\%CITATION = HEP-LAT/0211040;\%\%",
+	title = "{Flavor singlet meson mass in the continuum limit in two- flavor lattice QCD}",
+	volume = "D67",
+	year = "2003"
+}
+
+@article{Leutwyler:1997yr,
+	author = "Leutwyler, H.",
+	eprint = "hep-ph/9709408",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "223--231",
+	slaccitation = "%\%CITATION = HEP-PH/9709408;\%\%",
+	title = "{On the 1/N-expansion in chiral perturbation theory}",
+	volume = "64",
+	year = "1998"
+}
+
+@article{Leutwyler:2006qq,
+	author = "Leutwyler, H.",
+	eprint = "hep-ph/0612112",
+	slaccitation = "%\%CITATION = HEP-PH 0612112;\%\%",
+	title = "{pi pi scattering}",
+	year = "2006"
+}
+
+@article{Liu:1997fs,
+	author = "Liu, C. and Jaster, A. and Jansen, K.",
+	eprint = "hep-lat/9708017",
+	journal = "Nucl. Phys.",
+	pages = "603--617",
+	slaccitation = "%\%CITATION = HEP-LAT 9708017;\%\%",
+	title = "{Liapunov exponents and the reversibility of molecular dynamics algorithms}",
+	volume = "B524",
+	year = "1998"
+}
+
+@article{Luscher:1985dn,
+	author = "Luscher, M.",
+	doi = "10.1007/BF01211589",
+	journal = "Commun. Math. Phys.",
+	pages = "177",
+	slaccitation = "%\%CITATION = CMPHA,104,177;\%\%",
+	title = "{Volume Dependence of the Energy Spectrum in Massive Quantum Field Theories. 1. Stable Particle States}",
+	volume = "104",
+	year = "1986"
+}
+
+@article{Luscher:1990ck,
+	author = "L{\"u}scher, M. and Wolff, U.",
+	journal = "Nucl. Phys.",
+	pages = "222--252",
+	slaccitation = "%\%CITATION = NUPHA,B339,222;\%\%",
+	title = "{How to calculate the elastic scattering matrix in two- dimensional quantum field theories by numerical simulation}",
+	volume = "B339",
+	year = "1990"
+}
+
+@article{Luscher:1993dy,
+	archiveprefix = "arXiv",
+	author = "Luscher, Martin",
+	doi = "10.1016/0010-4655(94)90232-1",
+	eprint = "hep-lat/9309020",
+	journal = "Comput. Phys. Commun.",
+	pages = "100--110",
+	slaccitation = "%\%CITATION = HEP-LAT/9309020;\%\%",
+	title = "{A Portable high quality random number generator for lattice field theory simulations}",
+	volume = "79",
+	year = "1994"
+}
+
+@article{Luscher:1993xx,
+	author = "L{\"u}scher, M.",
+	eprint = "hep-lat/9311007",
+	journal = "Nucl. Phys.",
+	pages = "637--648",
+	slaccitation = "%\%CITATION = HEP-LAT 9311007;\%\%",
+	title = "{A New approach to the problem of dynamical quarks in numerical simulations of lattice {QCD}}",
+	volume = "B418",
+	year = "1994"
+}
+
+@article{Luscher:1996sc,
+	author = "L{\"u}scher, M. and Sint, S. and Sommer, R. and Weisz, P.",
+	eprint = "hep-lat/9605038",
+	journal = "Nucl. Phys.",
+	pages = "365--400",
+	slaccitation = "%\%CITATION = HEP-LAT 9605038;\%\%",
+	title = "{Chiral symmetry and {O(a)} improvement in lattice {QCD}}",
+	volume = "B478",
+	year = "1996"
+}
+
+@article{Luscher:1996ug,
+	author = "L{\"u}scher, M. and Sint, S. and Sommer, R. and Weisz, P. and Wolff, U.",
+	eprint = "hep-lat/9609035",
+	journal = "Nucl. Phys.",
+	pages = "323--343",
+	slaccitation = "%\%CITATION = HEP-LAT 9609035;\%\%",
+	title = "{Non-perturbative {O(a)} improvement of lattice {QCD}}",
+	volume = "B491",
+	year = "1997"
+}
+
+@article{Luscher:1998pq,
+	author = "L{\"u}scher, M.",
+	eprint = "hep-lat/9802011",
+	journal = "Phys. Lett.",
+	pages = "342--345",
+	slaccitation = "%\%CITATION = HEP-LAT 9802011;\%\%",
+	title = "{Exact chiral symmetry on the lattice and the {Ginsparg}- {Wilson} relation}",
+	volume = "B428",
+	year = "1998"
+}
+
+@article{Luscher:2001tx,
+	archiveprefix = "arXiv",
+	author = "L{\"u}scher, Martin",
+	doi = "10.1016/S0920-5632(01)01639-5",
+	eprint = "hep-lat/0110007",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "21--28",
+	slaccitation = "%\%CITATION = HEP-LAT/0110007;\%\%",
+	title = "{Lattice QCD on PCs?}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Luscher:2003qa,
+	author = "L{\"u}scher, M.",
+	eprint = "hep-lat/0310048",
+	journal = "Comput. Phys. Commun.",
+	pages = "209--220",
+	slaccitation = "%\%CITATION = HEP-LAT 0310048;\%\%",
+	title = "{Solution of the {D}irac equation in lattice {QCD} using a domain decomposition method}",
+	volume = "156",
+	year = "2004"
+}
+
+@article{Luscher:2004rx,
+	author = "L{\"u}scher, M.",
+	eprint = "hep-lat/0409106",
+	journal = "Comput. Phys. Commun.",
+	pages = "199",
+	slaccitation = "%\%CITATION = HEP-LAT 0409106;\%\%",
+	title = "{Schwarz-preconditioned {HMC} algorithm for two-flavour lattice {QCD}}",
+	volume = "165",
+	year = "2005"
+}
+
+@article{Luscher:2005mv,
+	author = "L{\"u}scher, Martin",
+	eprint = "hep-lat/0509152",
+	howpublished = "Talk presented at International Symposium on Lattice Field Theory (Lattice 2005)",
+	journal = "\href{http://pos.sissa.it/archive/conferences/020/008/LAT2005\_002.pdf}{PoS(LAT2005)002}",
+	slaccitation = "%\%CITATION = HEP-LAT 0509152;\%\%",
+	title = "{Lattice {QCD} with light {W}ilson quarks}",
+	year = "2005"
+}
+
+@article{Luscher:ranluxweb,
+	author = "L{\"u}scher, M.",
+	eprint = "http://luscher.web.cern.ch/luscher/ranlux/",
+	title = "{Ranlux random number generator}"
+}
+
+@article{Luscher:sse,
+	author = "L{\"u}scher, M.",
+	eprint = "http://luscher.web.cern.ch/luscher/QCDpbm/",
+	title = "{Lattice QCD parallel benchmark programs}"
+}
+
+@article{Madras:1988ei,
+	author = "Madras, N. and Sokal, A. D.",
+	journal = "J. Statist. Phys.",
+	pages = "109--186",
+	slaccitation = "%\%CITATION = JSTPB,50,109;\%\%",
+	title = "{The Pivot algorithm: a highly efficient Monte Carlo method for selfavoiding walk}",
+	volume = "50",
+	year = "1988"
+}
+
+@article{Martinelli:1982mw,
+	author = "Martinelli, G. and Zhang, Yi-Cheng",
+	journal = "Phys. Lett.",
+	pages = "433",
+	slaccitation = "%\%CITATION = PHLTA,B123,433;\%\%",
+	title = "{THE CONNECTION BETWEEN LOCAL OPERATORS ON THE LATTICE AND IN THE CONTINUUM AND ITS RELATION TO MESON DECAY CONSTANTS}",
+	volume = "B123",
+	year = "1983"
+}
+
+@article{Martinelli:1994ty,
+	archiveprefix = "arXiv",
+	author = "Martinelli, G. and Pittori, C. and Sachrajda, Christopher T. and Testa, M. and Vladikas, A.",
+	doi = "10.1016/0550-3213(95)00126-D",
+	eprint = "hep-lat/9411010",
+	journal = "Nucl. Phys.",
+	pages = "81--108",
+	slaccitation = "%\%CITATION = HEP-LAT/9411010;\%\%",
+	title = "{A General method for nonperturbative renormalization of lattice operators}",
+	volume = "B445",
+	year = "1995"
+}
+
+@article{McNeile:2000hf,
+	author = "McNeile, C. and Michael, C.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0006020",
+	journal = "Phys. Lett.",
+	pages = "123--129",
+	slaccitation = "%\%CITATION = HEP-LAT 0006020;\%\%",
+	title = "{The eta and eta' mesons in {QCD}}",
+	volume = "B491",
+	year = "2000"
+}
+
+@article{McNeile:2000xx,
+	author = "McNeile, Craig and Michael, Chris",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0010019",
+	journal = "Phys. Rev.",
+	pages = "114503",
+	slaccitation = "%\%CITATION = HEP-LAT0010019;\%\%",
+	title = "{Mixing of scalar glueballs and flavour-singlet scalar mesons}",
+	volume = "D63",
+	year = "2001"
+}
+
+@article{McNeile:2001cr,
+	author = "McNeile, C. and Michael, C. and Sharkey, K. J.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0107003",
+	journal = "Phys. Rev.",
+	pages = "014508",
+	slaccitation = "%\%CITATION = HEP-LAT 0107003;\%\%",
+	title = "{The flavor singlet mesons in {QCD}}",
+	volume = "D65",
+	year = "2002"
+}
+
+@article{McNeile:2002fh,
+	author = "McNeile, C. and Michael, C.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0212020",
+	journal = "Phys. Lett.",
+	pages = "177--184",
+	slaccitation = "%\%CITATION = HEP-LAT 0212020;\%\%",
+	title = "{Hadronic decay of a vector meson from the lattice}",
+	volume = "B556",
+	year = "2003"
+}
+
+@article{McNeile:2006bz,
+	author = "McNeile, C. and Michael, C.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0603007",
+	journal = "Phys. Rev.",
+	pages = "074506",
+	slaccitation = "%\%CITATION = HEP-LAT 0603007;\%\%",
+	title = "{Decay width of light quark hybrid meson from the lattice}",
+	volume = "D73",
+	year = "2006"
+}
+
+@article{Meyer:2006ty,
+	archiveprefix = "arXiv",
+	author = "Meyer, Harvey B. and others",
+	doi = "10.1016/j.cpc.2006.08.002",
+	eprint = "hep-lat/0606004",
+	journal = "Comput. Phys. Commun.",
+	pages = "91--97",
+	slaccitation = "%\%CITATION = HEP-LAT/0606004;\%\%",
+	title = "{Exploring the HMC trajectory-length dependence of autocorrelation times in lattice QCD}",
+	volume = "176",
+	year = "2007"
+}
+
+@article{Michael:1982gb,
+	author = "Michael, C. and Teasdale, I.",
+	journal = "Nucl. Phys.",
+	pages = "433",
+	slaccitation = "%\%CITATION = NUPHA,B215,433;\%\%",
+	title = "{EXTRACTING GLUEBALL MASSES FROM LATTICE QCD}",
+	volume = "B215",
+	year = "1983"
+}
+
+@article{Michael:1989mf,
+	author = "Michael, C.",
+	journal = "Nucl. Phys.",
+	pages = "515",
+	slaccitation = "%\%CITATION = NUPHA,B327,515;\%\%",
+	title = "{Particle decay in lattice gauge theory}",
+	volume = "B327",
+	year = "1989"
+}
+
+@article{Michael:1991nc,
+	author = "Michael, C.",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "417--419",
+	slaccitation = "%\%CITATION = NUPHZ,26,417;\%\%",
+	title = "{Hadronic forces from the lattice}",
+	volume = "26",
+	year = "1992"
+}
+
+@article{Michael:1993yj,
+	archiveprefix = "arXiv",
+	author = "Michael, Christopher",
+	doi = "10.1103/PhysRevD.49.2616",
+	eprint = "hep-lat/9310026",
+	journal = "Phys. Rev.",
+	pages = "2616--2619",
+	slaccitation = "%\%CITATION = HEP-LAT/9310026;\%\%",
+	title = "{Fitting correlated data}",
+	volume = "D49",
+	year = "1994"
+}
+
+@article{Michael:1994sz,
+	archiveprefix = "arXiv",
+	author = "Michael, Christopher and McKerrell, A.",
+	doi = "10.1103/PhysRevD.51.3745",
+	eprint = "hep-lat/9412087",
+	journal = "Phys. Rev.",
+	pages = "3745--3750",
+	slaccitation = "%\%CITATION = HEP-LAT/9412087;\%\%",
+	title = "{Fitting correlated hadron mass spectrum data}",
+	volume = "D51",
+	year = "1995"
+}
+
+@article{Michael:2007vn,
+	archiveprefix = "arXiv",
+	author = "Michael, C. and Urbach, C.",
+	collaboration = "ETM",
+	eprint = "0709.4564",
+	journal = "",
+	pages = "",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0709.4564;\%\%",
+	title = "{Neutral mesons and disconnected diagrams in Twisted Mass QCD}",
+	volume = "",
+	year = "2007"
+}
+
+@book{Montvay:1994cy,
+	author = "Montvay, I. and M{\"u}nster, G.",
+	publisher = "Cambridge University Press",
+	series = "{Cambridge Monographs on Mathematical Physics}",
+	title = "{Quantum fields on a lattice}",
+	year = "1994"
+}
+
+@article{Montvay:1995ea,
+	author = "Montvay, I.",
+	eprint = "hep-lat/9510042",
+	journal = "Nucl. Phys.",
+	pages = "259--284",
+	slaccitation = "%\%CITATION = HEP-LAT 9510042;\%\%",
+	title = "{An Algorithm for Gluinos on the Lattice}",
+	volume = "B466",
+	year = "1996"
+}
+
+@article{Montvay:2005tj,
+	author = "Montvay, I. and Scholz, E.",
+	eprint = "hep-lat/0506006",
+	journal = "Phys. Lett.",
+	pages = "73--79",
+	slaccitation = "%\%CITATION = HEP-LAT 0506006;\%\%",
+	title = "{Updating algorithms with multi-step stochastic correction}",
+	volume = "B623",
+	year = "2005"
+}
+
+@article{Morgan:2002a,
+	author = "Morgan, R. B.",
+	journal = "SIAM J. Sci. Comput.",
+	pages = "20",
+	title = "{GMRES with Deated Restarting}",
+	volume = "24",
+	year = "2002"
+}
+
+@article{Morningstar:2003gk,
+	archiveprefix = "arXiv",
+	author = "Morningstar, Colin and Peardon, Mike J.",
+	doi = "10.1103/PhysRevD.69.054501",
+	eprint = "hep-lat/0311018",
+	journal = "Phys. Rev.",
+	pages = "054501",
+	slaccitation = "%\%CITATION = HEP-LAT/0311018;\%\%",
+	title = "{Analytic smearing of SU(3) link variables in lattice QCD}",
+	volume = "D69",
+	year = "2004"
+}
+
+@article{Munster:2004am,
+	author = "M{\"u}nster, G.",
+	eprint = "hep-lat/0407006",
+	journal = "JHEP",
+	pages = "035",
+	slaccitation = "%\%CITATION = HEP-LAT 0407006;\%\%",
+	title = "{On the phase structure of twisted mass lattice {QCD}}",
+	volume = "09",
+	year = "2004"
+}
+
+@article{Munster:2004wt,
+	author = "M{\"u}nster, Gernot and Schmidt, Christian and Scholz, Enno E.",
+	eprint = "hep-lat/0409066",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "320--322",
+	slaccitation = "%\%CITATION = HEP-LAT 0409066;\%\%",
+	title = "{Chiral perturbation theory for twisted mass {QCD}}",
+	volume = "140",
+	year = "2005"
+}
+
+@article{Nagai:2005mi,
+	author = "Nagai, Kei-ichi and Jansen, Karl",
+	eprint = "hep-lat/0510076",
+	journal = "Phys. Lett.",
+	pages = "325--330",
+	slaccitation = "%\%CITATION = HEP-LAT 0510076;\%\%",
+	title = "{Two-dimensional lattice Gross-Neveu model with Wilson twisted mass fermions}",
+	volume = "B633",
+	year = "2006"
+}
+
+@unpublished{Nagai:priv,
+	author = "Nagai, K",
+	note = "private communication",
+	optannote = "",
+	optkey = "",
+	optmonth = "",
+	optyear = "",
+	title = "{Two-dimensional Gross-Neveu model with {Wilson} twisted mass fermions}"
+}
+
+@article{Necco:2001xg,
+	author = "Necco, S. and Sommer, R.",
+	eprint = "hep-lat/0108008",
+	journal = "Nucl. Phys.",
+	pages = "328--346",
+	slaccitation = "%\%CITATION = HEP-LAT 0108008;\%\%",
+	title = "{The {N(f)} = 0 heavy quark potential from short to intermediate distances}",
+	volume = "B622",
+	year = "2002"
+}
+
+@article{Necco:2003vh,
+	author = "Necco, Silvia",
+	eprint = "hep-lat/0309017",
+	journal = "Nucl. Phys.",
+	pages = "137--167",
+	slaccitation = "%\%CITATION = HEP-LAT 0309017;\%\%",
+	volume = "B683",
+	year = "2004"
+}
+
+@article{Neff:2001zr,
+	author = "Neff, H. and Eicker, N. and Lippert, T. and Negele, J. W. and Schilling, K.",
+	eprint = "hep-lat/0106016",
+	journal = "Phys. Rev.",
+	pages = "114509",
+	slaccitation = "%\%CITATION = HEP-LAT/0106016;\%\%",
+	title = "{On the low fermionic eigenmode dominance in {QCD} on the lattice}",
+	volume = "D64",
+	year = "2001"
+}
+
+@article{Neuberger:1997fp,
+	author = "Neuberger, H.",
+	eprint = "hep-lat/9707022",
+	journal = "Phys. Lett.",
+	pages = "141--144",
+	slaccitation = "%\%CITATION = HEP-LAT 9707022;\%\%",
+	title = "{Exactly massless quarks on the lattice}",
+	volume = "B417",
+	year = "1998"
+}
+
+@article{Neuberger:1998wv,
+	author = "Neuberger, H.",
+	eprint = "hep-lat/9801031",
+	journal = "Phys. Lett.",
+	pages = "353--355",
+	slaccitation = "%\%CITATION = HEP-LAT 9801031;\%\%",
+	title = "{More about exactly massless quarks on the lattice}",
+	volume = "B427",
+	year = "1998"
+}
+
+@article{Niedermayer:1998bi,
+	author = "Niedermayer, F.",
+	eprint = "hep-lat/9810026",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "105--119",
+	slaccitation = "%\%CITATION = HEP-LAT 9810026;\%\%",
+	title = "{Exact chiral symmetry, topological charge and related topics}",
+	volume = "73",
+	year = "1999"
+}
+
+@article{Nielsen:1980rz,
+	author = "Nielsen, H. B. and Ninomiya, M.",
+	journal = "Nucl. Phys.",
+	pages = "20",
+	slaccitation = "%\%CITATION = NUPHA,B185,20;\%\%",
+	title = "{Absence of neutrinos on a lattice. 1. proof by homotopy theory}",
+	volume = "B185",
+	year = "1981"
+}
+
+@article{Nielsen:1981hk,
+	author = "Nielsen, H. B. and Ninomiya, M.",
+	journal = "Phys. Lett.",
+	pages = "219",
+	slaccitation = "%\%CITATION = PHLTA,B105,219;\%\%",
+	title = "{No go theorem for regularizing chiral fermions}",
+	volume = "B105",
+	year = "1981"
+}
+
+@article{Nielsen:1981xu,
+	author = "Nielsen, H. B. and Ninomiya, M.",
+	journal = "Nucl. Phys.",
+	pages = "173",
+	slaccitation = "%\%CITATION = NUPHA,B193,173;\%\%",
+	title = "{Absence of neutrinos on a lattice. 2. intuitive topological proof}",
+	volume = "B193",
+	year = "1981"
+}
+
+@article{Noaki:1998zc,
+	author = "Noaki, J. and Izubuchi, T. and Ukawa, A.",
+	eprint = "hep-lat/9809071",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "483--485",
+	slaccitation = "%\%CITATION = HEP-LAT 9809071;\%\%",
+	title = "{Two-dimensional Gross-Neveu model with {Wilson} fermion action at finite temperature and density}",
+	volume = "73",
+	year = "1999"
+}
+
+@article{Orginos:2001xa,
+	author = "Orginos, K.",
+	collaboration = "RBC",
+	eprint = "hep-lat/0110074",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "721--723",
+	slaccitation = "%\%CITATION = HEP-LAT 0110074;\%\%",
+	title = "{Chiral properties of domain wall fermions with improved gauge actions}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Orth:2005kq,
+	author = "Orth, B. and Lippert, T. and Schilling, K.",
+	eprint = "hep-lat/0503016",
+	journal = "Phys. Rev.",
+	pages = "014503",
+	slaccitation = "%\%CITATION = HEP-LAT 0503016;\%\%",
+	title = "{Finite-size effects in lattice {QCD} with dynamical {Wilson} fermions}",
+	volume = "D72",
+	year = "2005"
+}
+
+@article{Osterwalder:1973dx,
+	author = "Osterwalder, K. and Schrader, R.",
+	journal = "Commun. Math. Phys.",
+	pages = "83--112",
+	slaccitation = "%\%CITATION = CMPHA,31,83;\%\%",
+	title = "{Axioms for euclidean Green's functions}",
+	volume = "31",
+	year = "1973"
+}
+
+@article{Osterwalder:1975tc,
+	author = "Osterwalder, K. and Schrader, R.",
+	journal = "Commun. Math. Phys.",
+	pages = "281",
+	slaccitation = "%\%CITATION = CMPHA,42,281;\%\%",
+	title = "{Axioms for euclidean Green's functions. 2}",
+	volume = "42",
+	year = "1975"
+}
+
+@article{Osterwalder:1977pc,
+	author = "Osterwalder, K. and Seiler, E.",
+	journal = "Ann. Phys.",
+	pages = "440",
+	slaccitation = "%\%CITATION = APNYA,110,440;\%\%",
+	title = "{Gauge field theories on the lattice}",
+	volume = "110",
+	year = "1978"
+}
+
+@article{PDBook,
+	author = "Eidelman, S. and others",
+	journal = "{Physics Letters B}",
+	pages = "1+",
+	title = "{Review of Particle Physics}",
+	url = "http://pdg.lbl.gov",
+	volume = "592",
+	year = "2004"
+}
+
+@article{Peardon:2002wb,
+	author = "Peardon, M. J. and Sexton, J.",
+	collaboration = "TrinLat",
+	eprint = "hep-lat/0209037",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "985--987",
+	slaccitation = "%\%CITATION = HEP-LAT 0209037;\%\%",
+	title = "{Multiple molecular dynamics time-scales in hybrid Monte Carlo fermion simulations}",
+	volume = "119",
+	year = "2003"
+}
+
+@book{Peskin:1995ev,
+	author = "Peskin, M. E. and Schroeder, D. V.",
+	optaddress = "Boulder, Colorado",
+	optannote = "",
+	optedition = "",
+	optkey = "",
+	optmonth = "",
+	optnote = "",
+	optnumber = "",
+	optseries = "Advanced Book Program",
+	optvolume = "",
+	publisher = "Westview Press",
+	title = "{An Introduction to quantum field theory}",
+	year = "1995"
+}
+
+@article{Politzer:1973fx,
+	author = "Politzer, H. D.",
+	journal = "Phys. Rev. Lett.",
+	pages = "1346--1349",
+	slaccitation = "%\%CITATION = PRLTA,30,1346;\%\%",
+	title = "{Reliable perturbative results for strong interactions?}",
+	volume = "30",
+	year = "1973"
+}
+
+@article{Politzer:1974fr,
+	author = "Politzer, H. D.",
+	journal = "Phys. Rept.",
+	pages = "129--180",
+	slaccitation = "%\%CITATION = PRPLC,14,129;\%\%",
+	title = "{Asymptotic freedom: an approach to strong interactions}",
+	volume = "14",
+	year = "1974"
+}
+
+@manual{R:2005,
+	address = "Vienna, Austria",
+	author = "{R Development Core Team}",
+	note = "{ISBN} 3-900051-07-0",
+	organization = "R Foundation for Statistical Computing",
+	title = "{R: A language and environment for statistical computing}",
+	url = "http://www.R-project.org",
+	year = "2005"
+}
+
+@book{Rothe:1992wy,
+	author = "Rothe, H.J.",
+	edition = "",
+	pages = "528",
+	publisher = "World Scientific, Singapore",
+	title = "{Lattice gauge theories}",
+	year = "1992"
+}
+
+@article{Rupak:2002sm,
+	author = "Rupak, G. and Shoresh, N.",
+	eprint = "hep-lat/0201019",
+	journal = "Phys. Rev.",
+	pages = "054503",
+	slaccitation = "%\%CITATION = HEP-LAT 0201019;\%\%",
+	title = "{Chiral perturbation theory for the {Wilson} lattice action}",
+	volume = "D66",
+	year = "2002"
+}
+
+@article{Saad:1993a,
+	author = "Saad, Y.",
+	journal = "SIAM J. Sci. Comput.",
+	page = "461-469",
+	title = "{A flexible inner-outer preconditioned GMRES altorithm}",
+	volume = "14 (2)",
+	year = "1993"
+}
+
+@article{Sachrajda:2004mi,
+	archiveprefix = "arXiv",
+	author = "Sachrajda, C. T. and Villadoro, G.",
+	doi = "10.1016/j.physletb.2005.01.033",
+	eprint = "hep-lat/0411033",
+	journal = "Phys. Lett.",
+	pages = "73--85",
+	slaccitation = "%\%CITATION = HEP-LAT/0411033;\%\%",
+	title = "{Twisted boundary conditions in lattice simulations}",
+	volume = "B609",
+	year = "2005"
+}
+
+@article{Scorzato:2004da,
+	author = "Scorzato, L.",
+	eprint = "hep-lat/0407023",
+	journal = "Eur. Phys. J.",
+	pages = "445--455",
+	slaccitation = "%\%CITATION = HEP-LAT 0407023;\%\%",
+	title = "{Pion mass splitting and phase structure in twisted mass {QCD}}",
+	volume = "C37",
+	year = "2004"
+}
+
+@article{Scorzato:2005rb,
+	author = "Scorzato, L. and others",
+	eprint = "hep-lat/0511036",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "283--290",
+	slaccitation = "%\%CITATION = HEP-LAT 0511036;\%\%",
+	title = "{N(f) = 2 lattice {QCD} and chiral perturbation theory}",
+	volume = "153",
+	year = "2006"
+}
+
+@article{Sexton:1992nu,
+	author = "Sexton, J. C. and Weingarten, D. H.",
+	journal = "Nucl. Phys.",
+	pages = "665--678",
+	slaccitation = "%\%CITATION = NUPHA,B380,665;\%\%",
+	title = "{Hamiltonian evolution for the hybrid monte carlo algorithm}",
+	volume = "B380",
+	year = "1992"
+}
+
+@article{Sharpe:1998xm,
+	author = "Sharpe, S. R. and Singleton, R. Jr.",
+	eprint = "hep-lat/9804028",
+	journal = "Phys. Rev.",
+	pages = "074501",
+	slaccitation = "%\%CITATION = HEP-LAT 9804028;\%\%",
+	title = "{Spontaneous flavor and parity breaking with {Wilson} fermions}",
+	volume = "D58",
+	year = "1998"
+}
+
+@article{Sharpe:2004ny,
+	author = "Sharpe, S. R. and Wu, Jackson M. S.",
+	eprint = "hep-lat/0411021",
+	journal = "Phys. Rev.",
+	pages = "074501",
+	slaccitation = "%\%CITATION = HEP-LAT 0411021;\%\%",
+	title = "{Twisted mass chiral perturbation theory at next-to-leading order}",
+	volume = "D71",
+	year = "2005"
+}
+
+@article{Sharpe:2004ps,
+	author = "Sharpe, S. R. and Wu, J. M. S.",
+	eprint = "hep-lat/0407025",
+	journal = "Phys. Rev.",
+	pages = "094029",
+	slaccitation = "%\%CITATION = HEP-LAT 0407025;\%\%",
+	title = "{The phase diagram of twisted mass lattice {QCD}}",
+	volume = "D70",
+	year = "2004"
+}
+
+@article{Sharpe:2005rq,
+	author = "Sharpe, Stephen R.",
+	eprint = "hep-lat/0509009",
+	journal = "Phys. Rev.",
+	pages = "074510",
+	slaccitation = "%\%CITATION = HEP-LAT 0509009;\%\%",
+	title = "{Observations on discretization errors in twisted-mass lattice QCD}",
+	volume = "D72",
+	year = "2005"
+}
+
+@article{Sheikholeslami:1985ij,
+	author = "Sheikholeslami, B. and Wohlert, R.",
+	journal = "Nucl. Phys.",
+	pages = "572",
+	slaccitation = "%\%CITATION = NUPHA,B259,572;\%\%",
+	title = "{Improved continuum limit lattice action for qcd with {Wilson} fermions}",
+	volume = "B259",
+	year = "1985"
+}
+
+@article{Shindler:2005vj,
+	author = "Shindler, Andrea",
+	eprint = "hep-lat/0511002",
+	journal = "PoS",
+	pages = "014",
+	slaccitation = "%\%CITATION = HEP-LAT 0511002;\%\%",
+	title = "{Twisted mass lattice {QCD}: Recent developments and results}",
+	volume = "LAT2005",
+	year = "2006"
+}
+
+@article{Shindler:2006tm,
+	author = "Shindler, A.",
+	collaboration = "ETM",
+	eprint = "hep-ph/0611264",
+	slaccitation = "%\%CITATION = HEP-PH 0611264;\%\%",
+	title = "{Lattice QCD with light twisted quarks: First results}",
+	year = "2006"
+}
+
+@article{Shindler:2007vp,
+	archiveprefix = "arXiv",
+	author = "Shindler, A.",
+	doi = "10.1016/j.physrep.2008.03.001",
+	eprint = "0707.4093",
+	journal = "Phys. Rept.",
+	pages = "37--110",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0707.4093;\%\%",
+	title = "{Twisted mass lattice QCD}",
+	volume = "461",
+	year = "2008"
+}
+
+@article{Sleijpen:1996aa,
+	author = "Sleijpen, G. L. G. and der Vorst, H. A. Van",
+	journal = "SIAM Journal on Matrix Analysis and Applications",
+	pages = "401--425",
+	title = "{A Jacobi-Davidson iteration method for linear eigenvalue problems}",
+	volume = "17",
+	year = "1996"
+}
+
+@article{Sommer:1993ce,
+	author = "Sommer, R.",
+	eprint = "hep-lat/9310022",
+	journal = "Nucl. Phys.",
+	pages = "839--854",
+	slaccitation = "%\%CITATION = HEP-LAT 9310022;\%\%",
+	title = "{A New way to set the energy scale in lattice gauge theories and its applications to the static force and alpha-s in SU(2) Yang-Mills theory}",
+	volume = "B411",
+	year = "1994"
+}
+
+@article{Sonneveld:1989cgs,
+	address = "Philadelphia, PA, USA",
+	author = "Sonneveld, Peter",
+	issn = "0196-5204",
+	journal = "SIAM J. Sci. Stat. Comput.",
+	number = "1",
+	pages = "36--52",
+	publisher = "Society for Industrial and Applied Mathematics",
+	title = "{CGS, a fast Lanczos-type solver for nonsymmetric linear systems}",
+	volume = "10",
+	year = "1989"
+}
+
+@article{Sternbeck:2003gy,
+	author = "Sternbeck, A. and Ilgenfritz, E.-M. and Kerler, W. and M{\"u}ller-Preu{\ss}ker, M. and St{\"u}ben, H.",
+	eprint = "hep-lat/0309059",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "898--900",
+	slaccitation = "%\%CITATION = HEP-LAT 0309059;\%\%",
+	title = "{The {Aoki} phase for {N(f)} = 2 {Wilson} fermions revisited}",
+	volume = "129",
+	year = "2004"
+}
+
+@article{Sternbeck:2005tk,
+	author = "Sternbeck, A. and Ilgenfritz, E. -M. and Mueller-Preussker, M. and Schiller, A.",
+	eprint = "hep-lat/0506007",
+	journal = "Phys. Rev.",
+	pages = "014507",
+	slaccitation = "%\%CITATION = HEP-LAT/0506007;\%\%",
+	title = "{Going infrared in SU(3) Landau gauge gluodynamics}",
+	volume = "D72",
+	year = "2005"
+}
+
+@conference{Symanzik:1981hc,
+	author = "Symanzik, K.",
+	booktitle = "{Mathematical problems in theoretical physics}",
+	editor = "et al., R. Schrader",
+	journal = "Lecture Notes in Physics",
+	note = "Presented at 6th Int. Conf. on Mathematical Physics, Berlin, West Germany",
+	pages = "47--58",
+	title = "{Some topics in quantum field theory}",
+	volume = "153",
+	year = "1981"
+}
+
+@article{Symanzik:1983dc,
+	author = "Symanzik, K.",
+	journal = "Nucl. Phys.",
+	pages = "187",
+	slaccitation = "%\%CITATION = NUPHA,B226,187;\%\%",
+	title = "{Continuum limit and improved action in lattice theories. 1. principles and phi**4 theory}",
+	volume = "B226",
+	year = "1983"
+}
+
+@article{Symanzik:1983gh,
+	author = "Symanzik, K.",
+	journal = "Nucl. Phys.",
+	pages = "205",
+	slaccitation = "%\%CITATION = NUPHA,B226,205;\%\%",
+	title = "{Continuum limit and improved action in lattice theories. 2. O(N) nonlinear sigma model in perturbation theory}",
+	volume = "B226",
+	year = "1983"
+}
+
+@article{Takaishi:1996xj,
+	author = "Takaishi, T.",
+	journal = "Phys. Rev.",
+	pages = "1050--1053",
+	slaccitation = "%\%CITATION = PHRVA,D54,1050;\%\%",
+	title = "{Heavy quark potential and effective actions on blocked configurations}",
+	volume = "D54",
+	year = "1996"
+}
+
+@article{Takaishi:2005tz,
+	author = "Takaishi, T. and de Forcrand, P.",
+	eprint = "hep-lat/0505020",
+	slaccitation = "%\%CITATION = HEP-LAT 0505020;\%\%",
+	title = "{Testing and tuning new symplectic integrators for hybrid Monte Carlo algorithm in lattice QCD}",
+	year = "2005"
+}
+
+@article{Takeda:2004xh,
+	author = "Takeda, S. and others",
+	eprint = "hep-lat/0408010",
+	journal = "Phys. Rev.",
+	pages = "074510",
+	slaccitation = "%\%CITATION = HEP-LAT 0408010;\%\%",
+	title = "{A scaling study of the step scaling function in SU(3) gauge theory with improved gauge actions}",
+	volume = "D70",
+	year = "2004"
+}
+
+@article{Ukawa:2002pc,
+	author = "Ukawa, A.",
+	collaboration = "CP-PACS and JL{QCD}",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "195--196",
+	slaccitation = "%\%CITATION = NUPHZ,106,195;\%\%",
+	title = "{Computational cost of full {QCD} simulations experienced by {CP-PACS and JLQCD Collaborations}}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Urbach:2005ji,
+	author = "Urbach, C. and Jansen, K. and Shindler, A. and Wenger, U.",
+	eprint = "hep-lat/0506011",
+	journal = "Comput. Phys. Commun.",
+	pages = "87--98",
+	slaccitation = "%\%CITATION = HEP-LAT 0506011;\%\%",
+	title = "{{HMC} algorithm with multiple time scale integration and mass preconditioning}",
+	volume = "174",
+	year = "2006"
+}
+
+@article{Urbach:2007rt,
+	archiveprefix = "arXiv",
+	author = "Urbach, Carsten",
+	collaboration = "ETM",
+	eprint = "0710.1517",
+	journal = "PoS",
+	pages = "022",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.1517;\%\%",
+	title = "{Lattice QCD with two light Wilson quarks and maximally twisted mass}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{WalkerLoud:2005bt,
+	archiveprefix = "arXiv",
+	author = "Walker-Loud, Andre and Wu, Jackson M. S.",
+	doi = "10.1103/PhysRevD.72.014506",
+	eprint = "hep-lat/0504001",
+	journal = "Phys. Rev.",
+	pages = "014506",
+	slaccitation = "%\%CITATION = HEP-LAT/0504001;\%\%",
+	title = "{Nucleon and Delta masses in twisted mass chiral perturbation theory}",
+	volume = "D72",
+	year = "2005"
+}
+
+@article{Weinberg:1973un,
+	author = "Weinberg, S.",
+	journal = "Phys. Rev. Lett.",
+	pages = "494--497",
+	slaccitation = "%\%CITATION = PRLTA,31,494;\%\%",
+	title = "{Nonabelian gauge theories of the strong interactions}",
+	volume = "31",
+	year = "1973"
+}
+
+@article{Weinberg:1978kz,
+	author = "Weinberg, S.",
+	journal = "Physica",
+	pages = "327",
+	slaccitation = "%\%CITATION = PHYSA,A96,327;\%\%",
+	title = "{Phenomenological Lagrangians}",
+	volume = "A96",
+	year = "1979"
+}
+
+@book{Weinberg:1995mt,
+	author = "Weinberg, S.",
+	pages = "609",
+	publisher = "Cambridge University Press",
+	title = "{The Quantum theory of fields. Vol. 1: Foundations}",
+	year = "1995"
+}
+
+@article{Weisz:1982zw,
+	author = "Weisz, P.",
+	journal = "Nucl. Phys.",
+	pages = "1",
+	slaccitation = "%\%CITATION = NUPHA,B212,1;\%\%",
+	title = "{Continuum limit improved lattice action for pure {Yang-Mills} theory. 1}",
+	volume = "B212",
+	year = "1983"
+}
+
+@article{Weisz:1983bn,
+	author = "Weisz, P. and Wohlert, R.",
+	journal = "Nucl. Phys.",
+	pages = 397,
+	slaccitation = "%\%CITATION = NUPHA,B236,397;\%\%",
+	title = "{Continuum limit improved lattice action for pure {Yang-Mills} theory. 2}",
+	volume = "B236",
+	year = 1984
+}
+
+@article{Wennekers:2005wa,
+	author = "Wennekers, J. and Wittig, H.",
+	eprint = "hep-lat/0507026",
+	slaccitation = "%\%CITATION = HEP-LAT 0507026;\%\%",
+	title = "{On the renormalized scalar density in quenched QCD}",
+	year = "2005"
+}
+
+@article{Weyl:1918ib,
+	author = "Weyl, H.",
+	journal = "Sitzungsber. Preuss. Akad. Wiss. Berlin (Math. Phys. )",
+	pages = "465",
+	slaccitation = "%\%CITATION = SPWPA,1918,465;\%\%",
+	title = "{Gravitation und Elektrizit{\"a}t}",
+	volume = "1918",
+	year = "1918"
+}
+
+@article{Weyl:1929fm,
+	author = "Weyl, H.",
+	journal = "Z. Phys.",
+	pages = "330--352",
+	slaccitation = "%\%CITATION = ZEPYA,56,330;\%\%",
+	title = "{Electron and gravitation}",
+	volume = "56",
+	year = "1929"
+}
+
+@article{Wilson:1974sk,
+	author = "Wilson, K. G.",
+	journal = "Phys. Rev.",
+	pages = "2445--2459",
+	slaccitation = "%\%CITATION = PHRVA,D10,2445;\%\%",
+	title = "{Confinement of quarks}",
+	volume = "D10",
+	year = "1974"
+}
+
+@article{Wilson:1974sk,
+	author = "Wilson, K. G.",
+	journal = "Phys. Rev.",
+	pages = "2445--2459",
+	slaccitation = "%\%CITATION = PHRVA,D10,2445;\%\%",
+	title = "{Confinement of quarks}",
+	volume = "D10",
+	year = "1974"
+}
+
+@article{Wilson:1975mb,
+	author = "Wilson, K. G.",
+	journal = "Rev. Mod. Phys.",
+	pages = "773",
+	slaccitation = "%\%CITATION = RMPHA,47,773;\%\%",
+	title = "{The renormalization group: Critical phenomena and the kondo problem}",
+	volume = "47",
+	year = "1975"
+}
+
+@article{Wilson:1975mb,
+	author = "Wilson, K. G.",
+	journal = "Rev. Mod. Phys.",
+	pages = "773",
+	slaccitation = "%\%CITATION = RMPHA,47,773;\%\%",
+	title = "{The renormalization group: Critical phenomena and the kondo problem}",
+	volume = "47",
+	year = "1975"
+}
+
+@article{Wolff:2003sm,
+	author = "Wolff, U.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0306017",
+	journal = "Comput. Phys. Commun.",
+	pages = "143--153",
+	slaccitation = "%\%CITATION = HEP-LAT 0306017;\%\%",
+	title = "{Monte Carlo errors with less errors}",
+	volume = "156",
+	year = "2004"
+}
+
+@article{Yang:1954ek,
+	author = "Yang, C.-N. and Mills, R. L.",
+	journal = "Phys. Rev.",
+	pages = "191--195",
+	slaccitation = "%\%CITATION = PHRVA,96,191;\%\%",
+	title = "{Conservation of isotopic spin and isotopic gauge invariance}",
+	volume = "96",
+	year = "1954"
+}
+
+@article{Yoshie:2008aw,
+	archiveprefix = "arXiv",
+	author = "Yoshie, Tomoteru",
+	eprint = "0812.0849",
+	journal = "PoS",
+	pages = "019",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0812.0849;\%\%",
+	title = "{Making use of the International Lattice Data Grid}",
+	volume = "LATTICE2008",
+	year = "2008"
+}
+
+@article{Zweig:1964jf,
+	author = "Zweig, G.",
+	note = "CERN-TH-412",
+	title = "{An SU(3) model for strong interaction symmetry and its breaking. 2}"
+}
+
+@article{cln:web,
+	eprint = "http://www.ginac.de/CLN/"
+}
+
+@article{deForcrand:1995bs,
+	author = "de Forcrand, P.",
+	eprint = "hep-lat/9509082",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "228--235",
+	slaccitation = "%\%CITATION = HEP-LAT 9509082;\%\%",
+	title = "{Progress on lattice {QCD} algorithms}",
+	volume = "47",
+	year = "1996"
+}
+
+@article{deForcrand:1996bx,
+	author = "de Forcrand, P. and others",
+	collaboration = "{QCD}-TARO",
+	eprint = "hep-lat/9608094",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "938--941",
+	slaccitation = "%\%CITATION = HEP-LAT 9608094;\%\%",
+	title = "{Search for effective lattice action of pure {QCD}}",
+	volume = "53",
+	year = "1997"
+}
+
+@article{deForcrand:1996ck,
+	author = "de Forcrand, P. and Takaishi, T.",
+	eprint = "hep-lat/9608093",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "968--970",
+	slaccitation = "%\%CITATION = HEP-LAT 9608093;\%\%",
+	title = "{Fast fermion Monte Carlo}",
+	volume = "53",
+	year = "1997"
+}
+
+@article{etmc:asqr,
+	archiveprefix = "arXiv",
+	author = "Frezzotti, R. et al.",
+	eprint = "0710.2492",
+	journal = "PoS",
+	pages = "277",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.2492;\%\%",
+	title = "{O(a^2) cutoff effects in Wilson fermion simulations}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{ildg:web,
+	author = "working groups, ILDG",
+	eprint = "http://cssm.sasr.edu.au/ildg/"
+}
+
+@book{kleinert:1,
+	author = "Kleinert, H.",
+	edition = "2nd Edition",
+	publisher = "World Scientific, Singapore",
+	title = "{Path integrals in quantum mechanics, statistics and polymer ph ysics}",
+	year = "1995"
+}
+
+@article{lapack:web,
+	eprint = "http://www.netlib.org/lapack/"
+}
+
+@article{lime:web,
+	author = "USQCD",
+	eprint = "http://usqcd.jlab.org/usqcd-docs/c-lime/",
+	title = "{c-lime library}"
+}
+
+@book{meister:1999,
+	author = "Meister, Andreas",
+	optaddress = "",
+	optannote = "",
+	optedition = "",
+	optkey = "",
+	optmonth = "",
+	optnote = "",
+	optnumber = "",
+	optseries = "",
+	optvolume = "",
+	publisher = "vieweg",
+	title = "{Numerik linearer Gleichungssysteme}",
+	year = "1999"
+}
+
+@manual{minuit,
+	note = "\\seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/home.html",
+	title = "{MINUIT home page}"
+}
+
+@article{mpi:web,
+	eprint = "http://www-unix.mcs.anl.gov/mpi/",
+	title = "{The message passing interface standard}"
+}
+
+@phdthesis{orth:2004phd,
+	author = "Orth, B.",
+	optaddress = "",
+	optannote = "",
+	optkey = "",
+	optmonth = "",
+	optnote = "",
+	opttype = "",
+	school = "Bergische Universit{\"a}t Wuppertal",
+	title = "{Finite size effects in lattice {QCD} with dynamical {Wilson} fermions}",
+	year = "2004"
+}
+
+@phdthesis{pleiter:phd,
+	author = "Pleiter, D.",
+	school = "Freie {U}niversitï¿½t {B}erlin",
+	title = "{XXX}",
+	year = "2001"
+}
+
+@manual{root,
+	note = "root.cern.ch/",
+	title = "{The ROOT system home page}"
+}
+
+@book{saad:2003a,
+	author = "Saad, Y.",
+	edition = "2nd",
+	publisher = "SIAM",
+	title = "{Iterative Methods for sparse linear systems}",
+	year = "2003"
+}
+
+@article{scidac,
+	eprint = "http://www.scidac.gov/"
+}
+
+@mastersthesis{urbach:2002aa,
+	author = "Urbach, C.",
+	school = "Freie Universit{\"a}t Berlin, Fachbereich Physik",
+	title = "{Untersuchung der {R}eversibilit{\"a}tsverletzung im {H}ybrid {M}onte {C}arlo {A}lgorithmus}",
+	year = "2002"
+}
+
+@article{'tHooft:1971fh,
+	author = "{'t Hooft}, G.",
+	journal = "Nucl. Phys.",
+	pages = "173--199",
+	slaccitation = "%\%CITATION = NUPHA,B33,173;\%\%",
+	title = "{Renormalization of massless Yang-Mills fields}",
+	volume = "B33",
+	year = "1971"
+}
+
+@article{'tHooft:1971rn,
+	author = "{'t Hooft}, G.",
+	journal = "Nucl. Phys.",
+	pages = "167--188",
+	slaccitation = "%\%CITATION = NUPHA,B35,167;\%\%",
+	title = "{Renormalizable lagrangians for massive Yang-Mills fields}",
+	volume = "B35",
+	year = "1971"
+}
+
+@unpublished{'tHooft:1972aa,
+	author = "{'t Hooft}, G.",
+	note = "Unpublished remarks at the 1972 Marseille Conference on Yang-Mills Fields",
+	title = "{}"
+}
+
+@article{'tHooft:1972fi,
+	author = "{'t Hooft}, G. and Veltman, M. J. G.",
+	journal = "Nucl. Phys.",
+	pages = "189--213",
+	slaccitation = "%\%CITATION = NUPHA,B44,189;\%\%",
+	title = "{Regularization and renormalization of gauge fields}",
+	volume = "B44",
+	year = "1972"
+}
+
+@article{Abdel-Rehim:2004gx,
+	author = "Abdel-Rehim, A. M. and Lewis, R.",
+	eprint = "hep-lat/0410047",
+	journal = "Phys. Rev.",
+	pages = "014503",
+	slaccitation = "%\%CITATION = HEP-LAT 0410047;\%\%",
+	title = "{Twisted mass {QCD} for the pion electromagnetic form factor}",
+	volume = "D71",
+	year = "2005"
+}
+
+@article{Abdel-Rehim:2005gz,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.",
+	eprint = "hep-lat/0503007",
+	journal = "Phys. Rev.",
+	pages = "094505",
+	slaccitation = "%\%CITATION = HEP-LAT/0503007;\%\%",
+	title = "{Spectrum of quenched twisted mass lattice QCD at maximal twist}",
+	volume = "D71",
+	year = "2005"
+}
+
+@article{AbdelRehim:2004sp,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy",
+	eprint = "hep-lat/0408033",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "299--301",
+	slaccitation = "%\%CITATION = HEP-LAT/0408033;\%\%",
+	title = "{Pion form factor with twisted mass QCD}",
+	volume = "140",
+	year = "2005"
+}
+
+@article{AbdelRehim:2005gq,
+	author = "Abdel-Rehim, A. M. and Lewis, R. and Woloshyn, R. M.",
+	journal = "Int. J. Mod. Phys.",
+	pages = "6159--6168",
+	slaccitation = "%\%CITATION = IMPAE,A20,6159;\%\%",
+	title = "{Twisted mass lattice QCD and hadron phenomenology}",
+	volume = "A20",
+	year = "2005"
+}
+
+@article{AbdelRehim:2005gz,
+	archiveprefix = "arXiv",
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.",
+	doi = "10.1103/PhysRevD.71.094505",
+	eprint = "hep-lat/0503007",
+	journal = "Phys. Rev.",
+	pages = "094505",
+	slaccitation = "%\%CITATION = HEP-LAT/0503007;\%\%",
+	title = "{Spectrum of quenched twisted mass lattice QCD at maximal twist}",
+	volume = "D71",
+	year = "2005"
+}
+
+@article{AbdelRehim:2005qv,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.",
+	eprint = "hep-lat/0509056",
+	journal = "PoS",
+	pages = "032",
+	slaccitation = "%\%CITATION = HEP-LAT/0509056;\%\%",
+	title = "{The hadron spectrum from twisted mass QCD with a strange quark}",
+	volume = "LAT2005",
+	year = "2006"
+}
+
+@article{AbdelRehim:2005yx,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M.",
+	eprint = "hep-lat/0509098",
+	journal = "PoS",
+	pages = "051",
+	slaccitation = "%\%CITATION = HEP-LAT/0509098;\%\%",
+	title = "{Maximal twist and the spectrum of quenched twisted mass lattice QCD}",
+	volume = "LAT2005",
+	year = "2006"
+}
+
+@article{AbdelRehim:2006qu,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Petry, Robert G. and Woloshyn, R. M.",
+	eprint = "hep-lat/0610004",
+	journal = "PoS",
+	pages = "164",
+	slaccitation = "%\%CITATION = HEP-LAT/0610004;\%\%",
+	title = "{The spectrum of tmLQCD with quark and link smearing}",
+	volume = "LAT2006",
+	year = "2006"
+}
+
+@article{AbdelRehim:2006ra,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M. and Wu, Jackson M. S.",
+	eprint = "hep-lat/0610090",
+	journal = "Eur. Phys. J.",
+	pages = "773--776",
+	slaccitation = "%\%CITATION = HEP-LAT/0610090;\%\%",
+	title = "{Lattice QCD with a twisted mass term and a strange quark}",
+	volume = "A31",
+	year = "2007"
+}
+
+@article{AbdelRehim:2006ve,
+	author = "Abdel-Rehim, Abdou M. and Lewis, Randy and Woloshyn, R. M. and Wu, Jackson M. S.",
+	eprint = "hep-lat/0601036",
+	journal = "Phys. Rev.",
+	pages = "014507",
+	slaccitation = "%\%CITATION = HEP-LAT/0601036;\%\%",
+	title = "{Strange quarks in quenched twisted mass lattice QCD}",
+	volume = "D74",
+	year = "2006"
+}
+
+@article{Adler:1974gd,
+	author = "Adler, Stephen L.",
+	journal = "Phys. Rev.",
+	pages = "3714",
+	slaccitation = "%\%CITATION = PHRVA,D10,3714;\%\%",
+	title = "{Some Simple Vacuum Polarization Phenomenology: e+ e- $\to$ Hadrons: The mu - Mesic Atom x-Ray Discrepancy and (g-2) of the Muon}",
+	volume = "D10",
+	year = "1974"
+}
+
+@article{Albanese:1987ds,
+	author = "Albanese, M. and others",
+	collaboration = "APE",
+	journal = "Phys. Lett.",
+	pages = "163",
+	slaccitation = "%\%CITATION = PHLTA,B192,163;\%\%",
+	title = "{Glueball masses and string tension in lattice {QCD}}",
+	volume = "B192",
+	year = "1987"
+}
+
+@article{Alexandrou:2008tn,
+	archiveprefix = "arXiv",
+	author = "Alexandrou, C. and others",
+	collaboration = "ETM",
+	eprint = "0803.3190",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0803.3190;\%\%",
+	title = "{Light baryon masses with dynamical twisted mass fermions}",
+	year = "2008"
+}
+
+@article{AliKhan:2000iv,
+	author = "{Ali Khan}, A. and others",
+	collaboration = "CP-PACS",
+	eprint = "hep-lat/0007014",
+	journal = "Phys. Rev.",
+	pages = "114504",
+	slaccitation = "%\%CITATION = HEP-LAT 0007014;\%\%",
+	title = "{Chiral properties of domain-wall quarks in quenched {QCD}}",
+	volume = "D63",
+	year = "2001"
+}
+
+@article{AliKhan:2003br,
+	author = "{Ali Khan}, A. and others",
+	collaboration = "QCDSF",
+	eprint = "hep-lat/0303026",
+	journal = "Phys. Lett.",
+	pages = "235--240",
+	slaccitation = "%\%CITATION = HEP-LAT 0303026;\%\%",
+	title = "{Accelerating the hybrid Monte Carlo algorithm}",
+	volume = "B564",
+	year = "2003"
+}
+
+@article{AliKhan:2003mu,
+	author = "{Ali Khan}, A. and others",
+	eprint = "hep-lat/0309078",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "853--855",
+	slaccitation = "%\%CITATION = HEP-LAT 0309078;\%\%",
+	title = "{Accelerating Hasenbusch's acceleration of hybrid Monte Carlo}",
+	volume = "129",
+	year = "2004"
+}
+
+@article{Allton:1993wc,
+	author = "Allton, C. R. and others",
+	collaboration = "UK{QCD}",
+	eprint = "hep-lat/9303009",
+	journal = "Phys. Rev.",
+	pages = "5128--5137",
+	slaccitation = "%\%CITATION = HEP-LAT 9303009;\%\%",
+	title = "{Gauge invariant smearing and matrix correlators using {Wilson} fermions at Beta = 6.2}",
+	volume = "D47",
+	year = "1993"
+}
+
+@article{Allton:2004qq,
+	author = "Allton, C. R. and others",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0403007",
+	journal = "Phys. Rev.",
+	pages = "014501",
+	slaccitation = "%\%CITATION = HEP-LAT/0403007;\%\%",
+	title = "{Improved Wilson QCD simulations with light quark masses}",
+	volume = "D70",
+	year = "2004"
+}
+
+@article{Aoki:1984qi,
+	author = "Aoki, S.",
+	journal = "Phys. Rev.",
+	pages = "2653",
+	slaccitation = "%\%CITATION = PHRVA,D30,2653;\%\%",
+	title = "{New phase structure for lattice {QCD} with {Wilson} fermions}",
+	volume = "D30",
+	year = "1984"
+}
+
+@article{Aoki:1985jj,
+	author = "Aoki, S. and Higashijima, K.",
+	journal = "Prog. Theor. Phys.",
+	pages = "521",
+	slaccitation = "%\%CITATION = PTPKA,76,521;\%\%",
+	title = "{The recovery of the chiral symmetry in lattice {Gross-Neveu} model}",
+	volume = "76",
+	year = "1986"
+}
+
+@article{Aoki:1986ua,
+	author = "Aoki, Sinya",
+	journal = "Phys. Lett.",
+	pages = "140",
+	slaccitation = "%\%CITATION = PHLTA,B190,140;\%\%",
+	title = "{NUMERICAL EVIDENCE FOR A PARITY VIOLATING PHASE IN LATTICE QCD WITH WILSON FERMION}",
+	volume = "B190",
+	year = "1987"
+}
+
+@article{Aoki:1986xr,
+	author = "Aoki, S.",
+	journal = "Phys. Rev. Lett.",
+	pages = "3136",
+	slaccitation = "%\%CITATION = PRLTA,57,3136;\%\%",
+	title = "{A solution to the {U(1)} problem on a lattice}",
+	volume = "57",
+	year = "1986"
+}
+
+@article{Aoki:1993vs,
+	author = "Aoki, S. and Boettcher, S. and Gocksch, A.",
+	eprint = "hep-lat/9312084",
+	journal = "Phys. Lett.",
+	pages = "157--164",
+	slaccitation = "%\%CITATION = HEP-LAT 9312084;\%\%",
+	title = "{Spontaneous breaking of flavor symmetry and parity in the Nambu-Jona-Lasinio model with {Wilson} fermions}",
+	volume = "B331",
+	year = "1994"
+}
+
+@article{Aoki:1995ft,
+	author = "Aoki, S.",
+	eprint = "hep-lat/9509008",
+	journal = "Prog. Theor. Phys. Suppl.",
+	pages = "179--186",
+	slaccitation = "%\%CITATION = HEP-LAT 9509008;\%\%",
+	title = "{On the phase structure of {QCD} with {Wilson} fermions}",
+	volume = "122",
+	year = "1996"
+}
+
+@article{Aoki:1995yf,
+	author = "Aoki, S. and Ukawa, A. and Umemura, T.",
+	eprint = "hep-lat/9508008",
+	journal = "Phys. Rev. Lett.",
+	pages = "873--876",
+	slaccitation = "%\%CITATION = HEP-LAT 9508008;\%\%",
+	title = "{Finite temperature phase structure of lattice {QCD} with {Wilson} quark action}",
+	volume = "76",
+	year = "1996"
+}
+
+@article{Aoki:1997fm,
+	author = "Aoki, S.",
+	eprint = "hep-lat/9707020",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "206--219",
+	slaccitation = "%\%CITATION = HEP-LAT 9707020;\%\%",
+	title = "{Phase structure of lattice {QCD} with {Wilson} fermion at finite temperature}",
+	volume = "60A",
+	year = "1998"
+}
+
+@article{Aoki:2001xq,
+	author = "Aoki, S. and others",
+	collaboration = "JL{QCD}",
+	eprint = "hep-lat/0110088",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "263--265",
+	slaccitation = "%\%CITATION = HEP-LAT 0110088;\%\%",
+	title = "{Non-trivial phase structure of {N(f)} = 3 {QCD} with {O(a)}- improved {Wilson} fermion at zero temperature}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Aoki:2002vt,
+	author = "Aoki, Y. and others",
+	eprint = "hep-lat/0211023",
+	journal = "Phys. Rev.",
+	pages = "074504",
+	slaccitation = "%\%CITATION = HEP-LAT 0211023;\%\%",
+	title = "{Domain wall fermions with improved gauge actions}",
+	volume = "D69",
+	year = "2004"
+}
+
+@article{Aoki:2004iq,
+	author = "Aoki, S. and others",
+	collaboration = "JL{QCD}",
+	eprint = "hep-lat/0409016",
+	slaccitation = "%\%CITATION = HEP-LAT 0409016;\%\%",
+	title = "{Bulk first-order phase transition in three-flavor lattice {QCD} with {O(a)}-improved {Wilson} fermion action at zero temperature}",
+	year = "2004"
+}
+
+@article{Aoki:2004ta,
+	author = "Aoki, Sinya and B{\"a}r, Oliver",
+	eprint = "hep-lat/0409006",
+	journal = "Phys. Rev.",
+	pages = "116011",
+	slaccitation = "%\%CITATION = HEP-LAT 0409006;\%\%",
+	title = "{Twisted-mass {QCD}, {O}(a) improvement and {Wilson} chiral perturbation theory}",
+	volume = "D70",
+	year = "2004"
+}
+
+@article{Aoki:2005ii,
+	author = "Aoki, S. and B{\"a}r, O.",
+	eprint = "hep-lat/0509002",
+	slaccitation = "%\%CITATION = HEP-LAT 0509002;\%\%",
+	title = "{Determining the low energy parameters of {Wilson} chiral perturbation theory}",
+	year = "2005"
+}
+
+@article{Arnold:2003sx,
+	author = "Arnold, Guido and others",
+	eprint = "hep-lat/0311025",
+	slaccitation = "%\%CITATION = HEP-LAT 0311025;\%\%",
+	title = "{Numerical methods for the QCD overlap operator. II: Optimal Krylov subspace methods}",
+	year = "2003"
+}
+
+@article{Atiyah:1971rm,
+	author = "Atiyah, M. F. and Singer, I. M.",
+	journal = "Annals Math.",
+	pages = "139--149",
+	slaccitation = "%\%CITATION = ANMAA,93,139;\%\%",
+	title = "{The Index of elliptic operators. 5}",
+	volume = "93",
+	year = "1971"
+}
+
+@article{Aubin:2006cc,
+	author = "Aubin, C. and Blum, T.",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "251--255",
+	slaccitation = "%\%CITATION = NUPHZ,162,251;\%\%",
+	title = "{Hadronic contributions to the muon g-2 from the lattice}",
+	volume = "162",
+	year = "2006"
+}
+
+@article{Aubin:2006xv,
+	author = "Aubin, C. and Blum, T.",
+	eprint = "hep-lat/0608011",
+	journal = "Phys. Rev.",
+	pages = "114502",
+	slaccitation = "%\%CITATION = HEP-LAT/0608011;\%\%",
+	title = "{Calculating the hadronic vacuum polarization and leading hadronic contribution to the muon anomalous magnetic moment with improved staggered quarks}",
+	volume = "D75",
+	year = "2007"
+}
+
+@article{BAGEL,
+	author = "Boyle, P.A.",
+	eprint = "http://www.ph.ed.ac.uk/\~{ }paboyle/bagel/Bagel.html",
+	year = 2005
+}
+
+@article{Baikov:2004ku,
+	author = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "243--246",
+	slaccitation = "%\%CITATION = NUPHZ,135,243;\%\%",
+	title = "{Vacuum polarization in pQCD: First complete O(alpha(s)**4) result}",
+	volume = "135",
+	year = "2004"
+}
+
+@article{Baikov:2005rw,
+	author = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
+	eprint = "hep-ph/0511063",
+	journal = "Phys. Rev. Lett.",
+	pages = "012003",
+	slaccitation = "%\%CITATION = HEP-PH/0511063;\%\%",
+	title = "{Scalar correlator at O(alpha(s)**4), Higgs decay into b- quarks and bounds on the light quark masses}",
+	volume = "96",
+	year = "2006"
+}
+
+@article{Baikov:2008jh,
+	archiveprefix = "arXiv",
+	author = "Baikov, P. A. and Chetyrkin, K. G. and K{\"u}hn, J. H.",
+	eprint = "0801.1821",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0801.1821;\%\%",
+	title = "{Hadronic Z- and tau-Decays in Order alpha\_s^4}",
+	year = "2008"
+}
+
+@article{Bali:2000vr,
+	author = "Bali, G. S. and others",
+	collaboration = "TXL",
+	eprint = "hep-lat/0003012",
+	journal = "Phys. Rev.",
+	pages = "054503",
+	slaccitation = "%\%CITATION = HEP-LAT 0003012;\%\%",
+	title = "{Static potentials and glueball masses from {QCD} simulations with {Wilson} sea quarks}",
+	volume = "D62",
+	year = "2000"
+}
+
+@article{Bali:2004pb,
+	author = "Bali, G. S. and others",
+	eprint = "hep-lat/0409137",
+	journal = "Nucl. Phys. Proc. Supl.",
+	pages = "609--611",
+	slaccitation = "%\%CITATION = HEP-LAT 0409137;\%\%",
+	title = "{String breaking with dynamical {Wilson} fermions}",
+	volume = "140",
+	year = "2004"
+}
+
+@article{Bali:2005fu,
+	author = "Bali, G. S. and Neff, H. and Duessel, T. and Lippert, T. and Schilling, K.",
+	collaboration = "SESAM",
+	eprint = "hep-lat/0505012",
+	journal = "Phys. Rev.",
+	pages = "114513",
+	slaccitation = "%\%CITATION = HEP-LAT 0505012;\%\%",
+	title = "{Observation of string breaking in {QCD}}",
+	volume = "D71",
+	year = "2005"
+}
+
+@article{Bar:2006zj,
+	author = "B{\"a}r, O. and Jansen, K. and Schaefer, S. and Scorzato, L. and Shindler, A.",
+	eprint = "hep-lat/0609039",
+	slaccitation = "%\%CITATION = HEP-LAT 0609039;\%\%",
+	title = "{Overlap fermions on a twisted mass sea}",
+	year = "2006"
+}
+
+@article{Baxter:1993bv,
+	author = "Baxter, R. M. and others",
+	collaboration = "UK{QCD}",
+	eprint = "hep-lat/9308020",
+	journal = "Phys. Rev.",
+	pages = "1594--1605",
+	slaccitation = "%\%CITATION = HEP-LAT 9308020;\%\%",
+	title = "{Quenched heavy light decay constants}",
+	volume = "D49",
+	year = "1994"
+}
+
+@article{Beane:2004tw,
+	archiveprefix = "arXiv",
+	author = "Beane, Silas R.",
+	doi = "10.1103/PhysRevD.70.034507",
+	eprint = "hep-lat/0403015",
+	journal = "Phys. Rev.",
+	pages = "034507",
+	slaccitation = "%\%CITATION = HEP-LAT/0403015;\%\%",
+	title = "{Nucleon masses and magnetic moments in a finite volume}",
+	volume = "D70",
+	year = "2004"
+}
+
+@article{Becher:1999he,
+	author = "Becher, Thomas and Leutwyler, H.",
+	eprint = "hep-ph/9901384",
+	journal = "Eur. Phys. J.",
+	pages = "643--671",
+	slaccitation = "%\%CITATION = HEP-PH/9901384;\%\%",
+	title = "{Baryon chiral perturbation theory in manifestly Lorentz invariant form}",
+	volume = "C9",
+	year = "1999"
+}
+
+@article{Bietenholz:2004sa,
+	author = "Bietenholz, W. and others",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0409109",
+	slaccitation = "%\%CITATION = HEP-LAT 0409109;\%\%",
+	title = "{Comparison between overlap and twisted mass fermions towards the chiral limit}",
+	year = "2004"
+}
+
+@article{Bietenholz:2004wv,
+	author = "Bietenholz, W. and others",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0411001",
+	journal = "JHEP",
+	pages = "044",
+	slaccitation = "%\%CITATION = HEP-LAT 0411001;\%\%",
+	title = "{Going chiral: Overlap versus twisted mass fermions}",
+	volume = "12",
+	year = "2004"
+}
+
+@article{Blossier:2007vv,
+	archiveprefix = "arXiv",
+	author = "Blossier, B. and others",
+	collaboration = "ETM",
+	eprint = "0709.4574",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0709.4574;\%\%",
+	title = "{Light quark masses and pseudoscalar decay constants from Nf=2 Lattice QCD with twisted mass fermions}",
+	year = "2007"
+}
+
+@article{Blum:1994eh,
+	author = "Blum, Tom and others",
+	eprint = "hep-lat/9404006",
+	journal = "Phys. Rev.",
+	pages = "3377--3381",
+	slaccitation = "%\%CITATION = HEP-LAT 9404006;\%\%",
+	title = "{QCD thermodynamics with Wilson quarks at large kappa}",
+	volume = "D50",
+	year = "1994"
+}
+
+@article{Blum:2000kn,
+	author = "Blum, T. and others",
+	eprint = "hep-lat/0007038",
+	journal = "Phys. Rev.",
+	pages = "074502",
+	slaccitation = "%\%CITATION = HEP-LAT 0007038;\%\%",
+	title = "{Quenched lattice {QCD} with domain wall fermions and the chiral limit}",
+	volume = "D69",
+	year = "2004"
+}
+
+@article{Bodin:2005gg,
+	author = "Bodin, F. and others",
+	collaboration = "ApeNEXT",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "176--182",
+	slaccitation = "%\%CITATION = NUPHZ,140,176;\%\%",
+	title = "{The {apeNEXT} project}",
+	volume = "140",
+	year = "2005"
+}
+
+@article{Bolder:2000un,
+	author = "Bolder, B. and others",
+	eprint = "hep-lat/0005018",
+	journal = "Phys. Rev.",
+	pages = "074504",
+	slaccitation = "%\%CITATION = HEP-LAT 0005018;\%\%",
+	title = "{A high precision study of the Q anti-Q potential from {Wilson} loops in the regime of string breaking}",
+	volume = "D63",
+	year = "2001"
+}
+
+@article{Boucaud:2007uk,
+	author = "Boucaud, Ph. and others",
+	collaboration = "ETM",
+	eprint = "hep-lat/0701012",
+	slaccitation = "%\%CITATION = HEP-LAT 0701012;\%\%",
+	title = "{Dynamical twisted mass fermions with light quarks}",
+	year = "2007"
+}
+
+@article{Boucaud:2008xu,
+	archiveprefix = "arXiv",
+	author = "Boucaud, Ph. and others",
+	collaboration = "ETM",
+	doi = "10.1016/j.cpc.2008.06.013",
+	eprint = "0803.0224",
+	journal = "Comput. Phys. Commun.",
+	pages = "695--715",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0803.0224;\%\%",
+	title = "{Dynamical Twisted Mass Fermions with Light Quarks: Simulation and Analysis Details}",
+	volume = "179",
+	year = "2008"
+}
+
+@article{Boughezal:2006px,
+	author = "Boughezal, R. and Czakon, M. and Schutzmeier, T.",
+	eprint = "hep-ph/0605023",
+	journal = "Phys. Rev.",
+	pages = "074006",
+	slaccitation = "%\%CITATION = HEP-PH/0605023;\%\%",
+	title = "{Charm and bottom quark masses from perturbative QCD}",
+	volume = "D74",
+	year = "2006"
+}
+
+@article{Boyle:2005fb,
+	author = "Boyle, P. A. and others",
+	journal = "J. Phys. Conf. Ser.",
+	pages = "129--139",
+	slaccitation = "%\%CITATION = 00462,16,129;\%\%",
+	title = "{{QCDOC}: Project status and first results}",
+	volume = "16",
+	year = "2005"
+}
+
+@article{Brower:1994er,
+	author = "Brower, R. C. and Levi, A. R. and Orginos, K.",
+	eprint = "hep-lat/9412004",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "855--857",
+	slaccitation = "%\%CITATION = HEP-LAT 9412004;\%\%",
+	title = "{Extrapolation methods for the Dirac inverter in hybrid Monte Carlo}",
+	volume = "42",
+	year = "1995"
+}
+
+@article{Brower:1995vx,
+	author = "Brower, R. C. and Ivanenko, T. and Levi, A. R. and Orginos, K. N.",
+	eprint = "hep-lat/9509012",
+	journal = "Nucl. Phys.",
+	pages = "353--374",
+	slaccitation = "%\%CITATION = HEP-LAT 9509012;\%\%",
+	title = "{Chronological inversion method for the Dirac matrix in hybrid Monte Carlo}",
+	volume = "B484",
+	year = "1997"
+}
+
+@article{Bunk:1995uv,
+	author = "Bunk, B. and others",
+	eprint = "hep-lat/9411016",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "49--55",
+	slaccitation = "%\%CITATION = HEP-LAT 9411016;\%\%",
+	title = "{A New simulation algorithm for lattice {QCD} with dynamical quarks}",
+	volume = "42",
+	year = "1995"
+}
+
+@article{Bunk:1998rm,
+	archiveprefix = "arXiv",
+	author = "Bunk, B. and Elser, Stephan and Frezzotti, R. and Jansen, K.",
+	doi = "10.1016/S0010-4655(99)00198-8",
+	eprint = "hep-lat/9805026",
+	journal = "Comput. Phys. Commun.",
+	pages = "95--109",
+	slaccitation = "%\%CITATION = HEP-LAT/9805026;\%\%",
+	title = "{Ordering monomial factors of polynomials in the product representation}",
+	volume = "118",
+	year = "1999"
+}
+
+@article{Bunk:1998rm,
+	author = "Bunk, B. and Elser, S. and Frezzotti, R. and Jansen, K.",
+	eprint = "hep-lat/9805026",
+	journal = "Comput. Phys. Commun.",
+	pages = "95--109",
+	slaccitation = "%\%CITATION = HEP-LAT 9805026;\%\%",
+	title = "{Ordering monomial factors of polynomials in the product representation}",
+	volume = "118",
+	year = "1999"
+}
+
+@article{Burrage:1998a,
+	author = "Burrage, K. and Erhel, J.",
+	journal = "Num. Lin. Alg. with Appl.",
+	pages = "101--121",
+	title = "{On the performance of various adaptive preconditioned GMRES strategies}",
+	volume = "5",
+	year = "1998"
+}
+
+@article{Campbell:1987nv,
+	author = "Campbell, N. A. and Huntley, A. and Michael, C.",
+	journal = "Nucl. Phys.",
+	pages = "51",
+	slaccitation = "%\%CITATION = NUPHA,B306,51;\%\%",
+	title = "{Heavy quark potentials and hybrid mesons from SU(3) lattice gauge theory}",
+	volume = "B306",
+	year = "1988"
+}
+
+@article{Capitani:2005jp,
+	author = "Capitani, S. and others",
+	eprint = "hep-lat/0511013",
+	journal = "Phys. Lett.",
+	pages = "520--526",
+	slaccitation = "%\%CITATION = HEP-LAT 0511013;\%\%",
+	title = "{Parton distribution functions with twisted mass fermions}",
+	volume = "B639",
+	year = "2006"
+}
+
+@article{Chen:2003im,
+	author = "Chen, Y. and others",
+	eprint = "hep-lat/0304005",
+	journal = "Phys. Rev.",
+	pages = "034502",
+	slaccitation = "%\%CITATION = HEP-LAT 0304005;\%\%",
+	title = "{Chiral logarithms in quenched {QCD}}",
+	volume = "D70",
+	year = "2004"
+}
+
+@book{Cheng:2000ct,
+	author = "Cheng, T. P. and Li, L. F.",
+	edition = "",
+	pages = "306",
+	publisher = "Oxford, UK: Clarendon",
+	title = "{Gauge theory of elementary particle physics: Problems and solutions}",
+	year = "2000"
+}
+
+@article{Chetyrkin:1990kr,
+	author = "Chetyrkin, K. G. and K{\"u}hn, Johann H.",
+	journal = "Phys. Lett.",
+	pages = "359--364",
+	slaccitation = "%\%CITATION = PHLTA,B248,359;\%\%",
+	title = "{Mass corrections to the Z decay rate}",
+	volume = "B248",
+	year = "1990"
+}
+
+@article{Chetyrkin:1996cf,
+	author = "Chetyrkin, K. G. and K{\"u}hn, Johann H. and Steinhauser, M.",
+	eprint = "hep-ph/9606230",
+	journal = "Nucl. Phys.",
+	pages = "213--240",
+	slaccitation = "%\%CITATION = HEP-PH/9606230;\%\%",
+	title = "{Three-loop polarization function and O(alpha(s)**2) corrections to the production of heavy quarks}",
+	volume = "B482",
+	year = "1996"
+}
+
+@article{Chetyrkin:1997mb,
+	author = "Chetyrkin, K. G. and K{\"u}hn, Johann H. and Steinhauser, M.",
+	eprint = "hep-ph/9705254",
+	journal = "Nucl. Phys.",
+	pages = "40--64",
+	slaccitation = "%\%CITATION = HEP-PH/9705254;\%\%",
+	title = "{Heavy quark current correlators to O(alpha(s)**2)}",
+	volume = "B505",
+	year = "1997"
+}
+
+@article{Chetyrkin:1998ix,
+	author = "Chetyrkin, K. G. and Harlander, R. and Steinhauser, M.",
+	eprint = "hep-ph/9801432",
+	journal = "Phys. Rev.",
+	pages = "014012",
+	slaccitation = "%\%CITATION = HEP-PH/9801432;\%\%",
+	title = "{Singlet polarization functions at O(alpha(s)**2)}",
+	volume = "D58",
+	year = "1998"
+}
+
+@article{Chetyrkin:2000zk,
+	author = "Chetyrkin, K. G. and Harlander, R. V. and K{\"u}hn, Johann H.",
+	eprint = "hep-ph/0005139",
+	journal = "Nucl. Phys.",
+	pages = "56--72",
+	slaccitation = "%\%CITATION = HEP-PH/0005139;\%\%",
+	title = "{Quartic mass corrections to R(had) at O(alpha(s)**3)}",
+	volume = "B586",
+	year = "2000"
+}
+
+@article{Chetyrkin:2006xg,
+	author = "Chetyrkin, K. G. and K{\"u}hn, J. H. and Sturm, C.",
+	eprint = "hep-ph/0604234",
+	journal = "Eur. Phys. J.",
+	pages = "107--110",
+	slaccitation = "%\%CITATION = HEP-PH/0604234;\%\%",
+	title = "{Four-loop moments of the heavy quark vacuum polarization function in perturbative QCD}",
+	volume = "C48",
+	year = "2006"
+}
+
+@article{Chiarappa:2004ry,
+	archiveprefix = "arXiv",
+	author = "Chiarappa, T. and others",
+	doi = "10.1016/j.nuclphysbps.2004.11.281",
+	eprint = "hep-lat/0409107",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "853--855",
+	slaccitation = "%\%CITATION = HEP-LAT/0409107;\%\%",
+	title = "{Comparing iterative methods for overlap and twisted mass fermions}",
+	volume = "140",
+	year = "2005"
+}
+
+@article{Chiarappa:2006ae,
+	archiveprefix = "arXiv",
+	author = "Chiarappa, T. and others",
+	doi = "10.1140/epjc/s10052-006-0204-4",
+	eprint = "hep-lat/0606011",
+	journal = "Eur. Phys. J.",
+	pages = "373--383",
+	slaccitation = "%\%CITATION = HEP-LAT/0606011;\%\%",
+	title = "{Numerical simulation of {QCD} with u, d, s and c quarks in the twisted-mass {W}ilson formulation}",
+	volume = "C50",
+	year = "2007"
+}
+
+@article{Chiarappa:2006hz,
+	archiveprefix = "arXiv",
+	author = "Chiarappa, T. and others",
+	eprint = "hep-lat/0609023",
+	journal = "Comput. Sci. Disc.",
+	pages = "015001",
+	slaccitation = "%\%CITATION = HEP-LAT/0609023;\%\%",
+	title = "{Iterative methods for overlap and twisted mass fermions}",
+	volume = "01",
+	year = "2008"
+}
+
+@article{Cichy:2008gk,
+	archiveprefix = "arXiv",
+	author = "Cichy, K. and {Gonzalez Lopez}, J. and Jansen, K. and Kujawa, A. and Shindler, A.",
+	doi = "10.1016/j.nuclphysb.2008.03.004",
+	eprint = "0802.3637",
+	journal = "Nucl. Phys.",
+	pages = "94--108",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0802.3637;\%\%",
+	title = "{Twisted Mass, Overlap and Creutz Fermions: Cut-off Effects at Tree-level of Perturbation Theory}",
+	volume = "B800",
+	year = "2008"
+}
+
+@article{Clark:2004cq,
+	author = "Clark, M. A. and Kennedy, A. D.",
+	eprint = "hep-lat/0409134",
+	slaccitation = "%\%CITATION = HEP-LAT 0409134;\%\%",
+	title = "{Accelerating fermionic molecular dynamics}",
+	year = "2004"
+}
+
+@article{Clark:2005sq,
+	author = "Clark, M. A. and de Forcrand, Ph. and Kennedy, A. D.",
+	eprint = "hep-lat/0510004",
+	journal = "PoS",
+	pages = "115",
+	slaccitation = "%\%CITATION = HEP-LAT 0510004;\%\%",
+	title = "{Algorithm shootout: R versus RHMC}",
+	volume = "LAT2005",
+	year = "2005"
+}
+
+@article{Clark:2006fx,
+	archiveprefix = "arXiv",
+	author = "Clark, M. A. and Kennedy, A. D.",
+	doi = "10.1103/PhysRevLett.98.051601",
+	eprint = "hep-lat/0608015",
+	journal = "Phys. Rev. Lett.",
+	pages = "051601",
+	slaccitation = "%\%CITATION = HEP-LAT/0608015;\%\%",
+	title = "{Accelerating Dynamical Fermion Computations using the Rational Hybrid Monte Carlo (RHMC) Algorithm with Multiple Pseudofermion Fields}",
+	volume = "98",
+	year = "2007"
+}
+
+@article{Clark:2006wp,
+	archiveprefix = "arXiv",
+	author = "Clark, M. A. and Kennedy, A. D.",
+	doi = "10.1103/PhysRevD.75.011502",
+	eprint = "hep-lat/0610047",
+	journal = "Phys. Rev.",
+	pages = "011502",
+	slaccitation = "%\%CITATION = HEP-LAT/0610047;\%\%",
+	title = "{Accelerating Staggered Fermion Dynamics with the Rational Hybrid Monte Carlo (RHMC) Algorithm}",
+	volume = "D75",
+	year = "2007"
+}
+
+@article{Colangelo:2001df,
+	archiveprefix = "arXiv",
+	author = "Colangelo, G. and Gasser, J. and Leutwyler, H.",
+	doi = "10.1016/S0550-3213(01)00147-X",
+	eprint = "hep-ph/0103088",
+	journal = "Nucl. Phys.",
+	pages = "125--179",
+	slaccitation = "%\%CITATION = HEP-PH/0103088;\%\%",
+	title = "{pi pi scattering}",
+	volume = "B603",
+	year = "2001"
+}
+
+@article{Colangelo:2003hf,
+	author = "Colangelo, Gilberto and D{\"u}rr, Stephan",
+	eprint = "hep-lat/0311023",
+	journal = "Eur. Phys. J.",
+	pages = "543--553",
+	slaccitation = "%\%CITATION = HEP-LAT/0311023;\%\%",
+	title = "{The pion mass in finite volume}",
+	volume = "C33",
+	year = "2004"
+}
+
+@article{Colangelo:2005gd,
+	author = "Colangelo, Gilberto and D{\"u}rr, Stephan and Haefeli, Christoph",
+	eprint = "hep-lat/0503014",
+	journal = "Nucl. Phys.",
+	pages = "136--174",
+	slaccitation = "%\%CITATION = HEP-LAT 0503014;\%\%",
+	title = "{Finite volume effects for meson masses and decay constants}",
+	volume = "B721",
+	year = "2005"
+}
+
+@article{Colangelo:2006mp,
+	archiveprefix = "arXiv",
+	author = "Colangelo, Gilberto and Haefeli, Christoph",
+	doi = "10.1016/j.nuclphysb.2006.03.010",
+	eprint = "hep-lat/0602017",
+	journal = "Nucl. Phys.",
+	pages = "14--33",
+	slaccitation = "%\%CITATION = HEP-LAT/0602017;\%\%",
+	title = "{Finite volume effects for the pion mass at two loops}",
+	volume = "B744",
+	year = "2006"
+}
+
+@book{Collins:1994ab,
+	author = "Collins, J.C.",
+	edition = "",
+	publisher = "Cambridge University Press",
+	series = "{Cambridge Monographs on Mathematical Physics}",
+	title = "{Renormalisation}",
+	year = "1994"
+}
+
+@article{Creutz:1984fj,
+	author = "Creutz, M. and Gocksch, A. and Ogilvie, M. and Okawa, M.",
+	journal = "Phys. Rev. Lett.",
+	pages = "875",
+	slaccitation = "%\%CITATION = PRLTA,53,875;\%\%",
+	title = "{Microcanonical renormalization group}",
+	volume = "53",
+	year = "1984"
+}
+
+@article{Creutz:1989wt,
+	author = "Creutz, M. and Gocksch, A.",
+	note = "BNL-42601",
+	title = "{Higher order hybrid monte carlo algorithms}"
+}
+
+@article{Creutz:1996bg,
+	author = "Creutz, Michael",
+	eprint = "hep-lat/9608024",
+	slaccitation = "%\%CITATION = HEP-LAT 9608024;\%\%",
+	title = "{Wilson fermions at finite temperature}",
+	year = "1996"
+}
+
+@article{Creutz:1998ee,
+	author = "Creutz, M.",
+	eprint = "hep-lat/9806037",
+	journal = "Phys. Rev. Lett.",
+	pages = "3555--3558",
+	slaccitation = "%\%CITATION = HEP-LAT 9806037;\%\%",
+	title = "{Evaluating Grassmann integrals}",
+	volume = "81",
+	year = "1998"
+}
+
+@article{Cundy:2005pi,
+	author = "Cundy, N. and others",
+	eprint = "hep-lat/0502007",
+	slaccitation = "%\%CITATION = HEP-LAT 0502007;\%\%",
+	title = "{Numerical Methods for the {QCD} Overlap Operator IV: Hybrid Monte Carlo}",
+	year = "2005"
+}
+
+@article{David:1984ys,
+	author = "David, F. and Hamber, H. W.",
+	journal = "Nucl. Phys.",
+	pages = "381",
+	slaccitation = "%\%CITATION = NUPHA,B248,381;\%\%",
+	title = "{Chiral condensate with {Wilson} fermions}",
+	volume = "B248",
+	year = "1984"
+}
+
+@article{Davies:2008sw,
+	archiveprefix = "arXiv",
+	author = "Davies, C. T. H. and others",
+	collaboration = "HPQCD",
+	eprint = "0807.1687",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0807.1687;\%\%",
+	title = "{Update: Accurate Determinations of $\alpha_s$ from Realistic Lattice QCD}",
+	year = "2008"
+}
+
+@article{DeGrand:1990dk,
+	author = "DeGrand, T. A. and Rossi, P.",
+	journal = "Comput. Phys. Commun.",
+	pages = "211--214",
+	slaccitation = "%\%CITATION = CPHCB,60,211;\%\%",
+	title = "{Conditioning techniques for dynamical fermions}",
+	volume = "60",
+	year = "1990"
+}
+
+@article{DeGrand:1990ip,
+	author = "DeGrand, T. A.",
+	journal = "Phys. Rev.",
+	pages = "2296--2300",
+	slaccitation = "%\%CITATION = PHRVA,D43,2296;\%\%",
+	title = "{Resonance masses from Monte Carlo simulations (with emphasis on the rho meson)}",
+	volume = "D43",
+	year = "1991"
+}
+
+@article{DeGrand:2002vu,
+	author = "DeGrand, Thomas and Hasenfratz, Anna and Kovacs, Tamas G.",
+	eprint = "hep-lat/0211006",
+	journal = "Phys. Rev.",
+	pages = "054501",
+	slaccitation = "%\%CITATION = HEP-LAT 0211006;\%\%",
+	title = "{Improving the chiral properties of lattice fermions}",
+	volume = "D67",
+	year = "2003"
+}
+
+@article{DeTar:2007ni,
+	archiveprefix = "arXiv",
+	author = "DeTar, Carleton and Levkova, L.",
+	eprint = "0710.1322",
+	journal = "PoS",
+	pages = "116",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0710.1322;\%\%",
+	title = "{Effects of the disconnected flavor singlet corrections on the hyperfine splitting in charmonium}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{DelDebbio:2006cn,
+	author = "{Del Debbio}, L. and Giusti, L. and L{\"u}scher, M. and Petronzio, R. and Tantalo, N.",
+	eprint = "hep-lat/0610059",
+	journal = "JHEP",
+	pages = "056",
+	slaccitation = "%\%CITATION = HEP-LAT 0610059;\%\%",
+	title = "{QCD with light Wilson quarks on fine lattices. I: First experiences and physics results}",
+	volume = "02",
+	year = "2007"
+}
+
+@article{DellaMorte:2000yp,
+	author = "{Della Morte}, M. and Frezzotti, R. and Heitger, J. and Sint, S.",
+	eprint = "hep-lat/0010091",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "617--621",
+	slaccitation = "%\%CITATION = HEP-LAT 0010091;\%\%",
+	title = "{Non-perturbative scaling tests of twisted mass {QCD}}",
+	volume = "94",
+	year = "2001"
+}
+
+@article{DellaMorte:2001tu,
+	author = "{Della Morte}, M. and Frezzotti, R. and Heitger, J.",
+	eprint = "hep-lat/0110166",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "260--262",
+	slaccitation = "%\%CITATION = HEP-LAT 0110166;\%\%",
+	title = "{Quenched twisted mass {QCD} at small quark masses and in large volume}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{DellaMorte:2001ys,
+	author = "{Della Morte}, M. and Frezzotti, R. and Heitger, J. and Sint, S.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0108019",
+	journal = "JHEP",
+	pages = "041",
+	slaccitation = "%\%CITATION = HEP-LAT 0108019;\%\%",
+	title = "{Cutoff effects in twisted mass lattice {QCD}}",
+	volume = "10",
+	year = "2001"
+}
+
+@article{DellaMorte:2003jj,
+	author = "{Della Morte}, M. and others",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0307008",
+	journal = "Comput. Phys. Commun.",
+	pages = "62--72",
+	slaccitation = "%\%CITATION = HEP-LAT 0307008;\%\%",
+	title = "{Simulating the Schroedinger functional with two pseudo- fermions}",
+	volume = "156",
+	year = "2003"
+}
+
+@article{DellaMorte:2003mn,
+	author = "{Della Morte}, M. and others",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0307021",
+	journal = "Phys. Lett.",
+	pages = "93--98",
+	slaccitation = "%\%CITATION = HEP-LAT 0307021;\%\%",
+	title = "{Lattice HQET with exponentially improved statistical precision}",
+	volume = "B581",
+	year = "2004"
+}
+
+@article{DellaMorte:2003mw,
+	author = "{Della Morte}, M. and others",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0309080",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "346--348",
+	slaccitation = "%\%CITATION = HEP-LAT 0309080;\%\%",
+	title = "{Static quarks with improved statistical precision}",
+	volume = "129",
+	year = "2004"
+}
+
+@article{DellaMorte:2005yc,
+	author = "{Della Morte}, M. and Shindler, A. and Sommer, R.",
+	eprint = "hep-lat/0506008",
+	slaccitation = "%\%CITATION = HEP-LAT 0506008;\%\%",
+	title = "{On lattice actions for static quarks}",
+	year = "2005"
+}
+
+@article{Dimopoulos:2006dm,
+	author = "Dimopoulos, P. and others",
+	collaboration = "ALPHA",
+	eprint = "hep-ph/0601002",
+	journal = "Nucl. Phys.",
+	pages = "69--108",
+	slaccitation = "%\%CITATION = HEP-PH 0601002;\%\%",
+	title = "{A precise determination of B(K) in quenched QCD}",
+	volume = "B749",
+	year = "2006"
+}
+
+@article{Dimopoulos:2007fn,
+	archiveprefix = "arXiv",
+	author = "Dimopoulos, P. and others",
+	eprint = "0710.0975",
+	journal = "PoS",
+	pages = "241",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.0975;\%\%",
+	title = "{Renormalisation of quark bilinears with Nf=2 Wilson fermions and tree-level improved gauge action}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{Dimopoulos:2007qy,
+	archiveprefix = "arXiv",
+	author = "Dimopoulos, Petros and Frezzotti, Roberto and Herdoiza, Gregorio and Urbach, Carsten and Wenger, Urs",
+	collaboration = "ETM",
+	eprint = "0710.2498",
+	journal = "PoS",
+	pages = "102",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.2498;\%\%",
+	title = "{Scaling and low energy constants in lattice QCD with N\_f=2 maximally twisted Wilson quarks}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{Dimopoulos:2008sy,
+	archiveprefix = "arXiv",
+	author = "Dimopoulos, Petros and others",
+	collaboration = "ETM",
+	eprint = "0810.2873",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0810.2873;\%\%",
+	title = "{Scaling and chiral extrapolation of pion mass and decay constant with maximally twisted mass QCD}",
+	year = "2008"
+}
+
+@article{Dong:2001fm,
+	author = "Dong, S. J. and others",
+	eprint = "hep-lat/0108020",
+	journal = "Phys. Rev.",
+	pages = "054507",
+	slaccitation = "%\%CITATION = HEP-LAT 0108020;\%\%",
+	title = "{Chiral properties of pseudoscalar mesons on a quenched 20**4 lattice with overlap fermions}",
+	volume = "D65",
+	year = "2002"
+}
+
+@article{Duane:1987de,
+	author = "Duane, S. and Kennedy, A. D. and Pendleton, B. J. and Roweth, D.",
+	journal = "Phys. Lett.",
+	pages = "216--222",
+	slaccitation = "%\%CITATION = PHLTA,B195,216;\%\%",
+	title = "{{H}ybrid monte carlo}",
+	volume = "B195",
+	year = "1987"
+}
+
+@article{Edwards:1996vs,
+	author = "Edwards, R. G. and Horvath, I. and Kennedy, A. D.",
+	eprint = "hep-lat/9606004",
+	journal = "Nucl. Phys.",
+	pages = "375--402",
+	slaccitation = "%\%CITATION = HEP-LAT 9606004;\%\%",
+	title = "{Instabilities and non-reversibility of molecular dynamics trajectories}",
+	volume = "B484",
+	year = "1997"
+}
+
+@article{Eichten:1989zv,
+	author = "Eichten, E. and Hill, B.",
+	journal = "Phys. Lett.",
+	pages = "511",
+	slaccitation = "%\%CITATION = PHLTA,B234,511;\%\%",
+	title = "{An effective field theory for the calculation of matrix elements involving heavy quarks}",
+	volume = "B234",
+	year = "1990"
+}
+
+@article{Farchioni:2002vn,
+	author = "Farchioni, F. and Gebert, C. and Montvay, I. and Scorzato, L.",
+	eprint = "hep-lat/0206008",
+	journal = "Eur. Phys. J.",
+	pages = "237--251",
+	slaccitation = "%\%CITATION = HEP-LAT 0206008;\%\%",
+	title = "{Numerical simulation tests with light dynamical quarks}",
+	volume = "C26",
+	year = "2002"
+}
+
+@article{Farchioni:2004fs,
+	author = "Farchioni, F. and others",
+	eprint = "hep-lat/0410031",
+	journal = "Eur. Phys. J.",
+	pages = "73--87",
+	slaccitation = "%\%CITATION = HEP-LAT 0410031;\%\%",
+	title = "{The phase structure of lattice {QCD} with {Wilson} quarks and renormalization group improved gluons}",
+	volume = "C42",
+	year = "2005"
+}
+
+@article{Farchioni:2004ma,
+	author = "Farchioni, F. and others",
+	eprint = "hep-lat/0409098",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "240--245",
+	slaccitation = "%\%CITATION = HEP-LAT 0409098;\%\%",
+	title = "{Exploring the phase structure of lattice {{QCD}} with twisted mass quarks}",
+	volume = "140",
+	year = "2005"
+}
+
+@article{Farchioni:2004us,
+	author = "Farchioni, F. and others",
+	eprint = "hep-lat/0406039",
+	journal = "Eur. Phys. J.",
+	pages = "421--433",
+	slaccitation = "%\%CITATION = HEP-LAT 0406039;\%\%",
+	title = "{Twisted mass quarks and the phase structure of lattice {QCD}}",
+	volume = "C39",
+	year = "2005"
+}
+
+@article{Farchioni:2005ec,
+	author = "Farchioni, Federico and others",
+	eprint = "hep-lat/0509131",
+	journal = "PoS",
+	pages = "072",
+	slaccitation = "%\%CITATION = HEP-LAT 0509131;\%\%",
+	title = "{Dynamical twisted mass fermions}",
+	volume = "LAT2005",
+	year = "2006"
+}
+
+@article{Farchioni:2005hf,
+	author = "Farchioni, F. and others",
+	eprint = "hep-lat/0509036",
+	journal = "PoS",
+	pages = "033",
+	slaccitation = "%\%CITATION = HEP-LAT 0509036;\%\%",
+	title = "{Twisted mass fermions: Neutral pion masses from disconnected contributions}",
+	volume = "LAT2005",
+	year = "2006"
+}
+
+@article{Farchioni:2005tu,
+	author = "Farchioni, F. and others",
+	eprint = "hep-lat/0506025",
+	journal = "Phys. Lett.",
+	pages = "324--333",
+	slaccitation = "%\%CITATION = HEP-LAT 0506025;\%\%",
+	title = "{Lattice spacing dependence of the first order phase transition for dynamical twisted mass fermions}",
+	volume = "B624",
+	year = "2005"
+}
+
+@article{Feldmann:1999uf,
+	author = "Feldmann, Thorsten",
+	eprint = "hep-ph/9907491",
+	journal = "Int. J. Mod. Phys.",
+	pages = "159--207",
+	slaccitation = "%\%CITATION = HEP-PH/9907491;\%\%",
+	title = "{Quark structure of pseudoscalar mesons}",
+	volume = "A15",
+	year = "2000"
+}
+
+@article{Feynman:1948aa,
+	author = "Feynman, R. P.",
+	journal = "Rev. Mod. Phys.",
+	pages = "367--387",
+	slaccitation = "%\%CITATION = RMPHA,20,367;\%\%",
+	title = "{Space-time approach to non-relativistic quantum mechanics}",
+	volume = "20",
+	year = "1948"
+}
+
+@article{Fischer:1996th,
+	author = "Fischer, S. and others",
+	eprint = "hep-lat/9602019",
+	journal = "Comp. Phys. Commun.",
+	pages = "20--34",
+	slaccitation = "%\%CITATION = HEP-LAT 9602019;\%\%",
+	title = "{A Parallel SSOR Preconditioner for Lattice {QCD}}",
+	volume = "98",
+	year = "1996"
+}
+
+@article{Fokkema:1998aa,
+	author = "Fokkema, D.~R. and Sleijpen, G.~L.~G. and Van~der~Vorst, H.~A.",
+	journal = "J. Sci. Comput.",
+	pages = "94--125",
+	title = "{{J}acobi-{D}avidson style {QR} and {QZ} algorithms for the reduction of matrix pencils}",
+	volume = "20",
+	year = "1998"
+}
+
+@article{Foster:1998vw,
+	author = "Foster, M. and Michael, C.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/9810021",
+	journal = "Phys. Rev.",
+	pages = "074503",
+	slaccitation = "%\%CITATION = HEP-LAT 9810021;\%\%",
+	title = "{Quark mass dependence of hadron masses from lattice {QCD}}",
+	volume = "D59",
+	year = "1999"
+}
+
+@article{Freund,
+	author = "Freund, R.W.",
+	journal = "in Numerical Linear Algebra, L.\ Reichel, A.\ Ruttan and R.S.\ Varga (eds.)",
+	pages = "p. 101",
+	year = "1993"
+}
+
+@article{Frezzotti:1997ym,
+	author = "Frezzotti, R. and Jansen, K.",
+	eprint = "hep-lat/9702016",
+	journal = "Phys. Lett.",
+	pages = "328--334",
+	slaccitation = "%\%CITATION = HEP-LAT 9702016;\%\%",
+	title = "{A polynomial hybrid Monte Carlo algorithm}",
+	volume = "B402",
+	year = "1997"
+}
+
+@article{Frezzotti:1998eu,
+	author = "Frezzotti, R. and Jansen, K.",
+	eprint = "hep-lat/9808011",
+	journal = "Nucl. Phys.",
+	pages = "395--431",
+	slaccitation = "%\%CITATION = HEP-LAT 9808011;\%\%",
+	title = "{The {PHMC} algorithm for simulations of dynamical fermions. {I}: Description and properties}",
+	volume = "B555",
+	year = "1999"
+}
+
+@article{Frezzotti:1998yp,
+	author = "Frezzotti, R. and Jansen, K.",
+	eprint = "hep-lat/9808038",
+	journal = "Nucl. Phys.",
+	pages = "432--453",
+	slaccitation = "%\%CITATION = HEP-LAT 9808038;\%\%",
+	title = "{The {PHMC} algorithm for simulations of dynamical fermions. {II}: Performance analysis}",
+	volume = "B555",
+	year = "1999"
+}
+
+@article{Frezzotti:1999vv,
+	author = "Frezzotti, R. and Grassi, P. A. and Sint, S. and Weisz, P.",
+	eprint = "hep-lat/9909003",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "941--946",
+	slaccitation = "%\%CITATION = HEP-LAT 9909003;\%\%",
+	title = "{A local formulation of lattice {QCD} without unphysical fermion zero modes}",
+	volume = "83",
+	year = "2000"
+}
+
+@article{Frezzotti:2000nk,
+	author = "Frezzotti, R. and Grassi, P. A. and Sint, S. and Weisz, P.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0101001",
+	journal = "JHEP",
+	pages = "058",
+	slaccitation = "%\%CITATION = HEP-LAT 0101001;\%\%",
+	title = "{Lattice {QCD} with a chirally twisted mass term}",
+	volume = "08",
+	year = "2001"
+}
+
+@article{Frezzotti:2001du,
+	author = "Frezzotti, R. and Sint, S.",
+	eprint = "hep-lat/0110140",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "814--816",
+	slaccitation = "%\%CITATION = HEP-LAT 0110140;\%\%",
+	title = "{Some remarks on {O(a)} improved twisted mass {QCD}}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Frezzotti:2001ea,
+	author = "Frezzotti, R. and Sint, S. and Weisz, P.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0104014",
+	journal = "JHEP",
+	pages = "048",
+	slaccitation = "%\%CITATION = HEP-LAT 0104014;\%\%",
+	title = "{{O(a)} improved twisted mass lattice {QCD}}",
+	volume = "07",
+	year = "2001"
+}
+
+@article{Frezzotti:2003ni,
+	author = "Frezzotti, R. and Rossi, G. C.",
+	eprint = "hep-lat/0306014",
+	journal = "JHEP",
+	pages = "007",
+	slaccitation = "%\%CITATION = HEP-LAT 0306014;\%\%",
+	title = "{Chirally improving {Wilson} fermions. {I}: {O(a)} improvement}",
+	volume = "08",
+	year = "2004"
+}
+
+@article{Frezzotti:2003xj,
+	author = "Frezzotti, R. and Rossi, G. C.",
+	eprint = "hep-lat/0311008",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "193--202",
+	slaccitation = "%\%CITATION = HEP-LAT 0311008;\%\%",
+	title = "{Twisted-mass lattice {QCD} with mass non-degenerate quarks}",
+	volume = "128",
+	year = "2004"
+}
+
+@article{Frezzotti:2004wz,
+	author = "Frezzotti, R. and Rossi, G. C.",
+	eprint = "hep-lat/0407002",
+	journal = "JHEP",
+	pages = "070",
+	slaccitation = "%\%CITATION = HEP-LAT 0407002;\%\%",
+	title = "{Chirally improving {Wilson} fermions. {II}: Four-quark operators}",
+	volume = "10",
+	year = "2004"
+}
+
+@article{Frezzotti:2005gi,
+	author = "Frezzotti, R. and Martinelli, G. and Papinutto, M. and Rossi, G. C.",
+	eprint = "hep-lat/0503034",
+	journal = "JHEP",
+	pages = "038",
+	slaccitation = "%\%CITATION = HEP-LAT 0503034;\%\%",
+	title = "{Reducing cutoff effects in maximally twisted lattice {QCD} close to the chiral limit}",
+	volume = "04",
+	year = "2006"
+}
+
+@article{Frezzotti:2007qv,
+	archiveprefix = "arXiv",
+	author = "Frezzotti, R. and Rossi, G.",
+	eprint = "0710.2492",
+	journal = "PoS",
+	pages = "277",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.2492;\%\%",
+	title = "{O(a^2) cutoff effects in Wilson fermion simulations}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{Frezzotti:2008dr,
+	archiveprefix = "arXiv",
+	author = "Frezzotti, R. and Lubicz, V. and Simula, S.",
+	collaboration = "ETM",
+	eprint = "0812.4042",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0812.4042;\%\%",
+	title = "{Electromagnetic form factor of the pion from twisted-mass lattice {QCD} at {Nf}=2}",
+	year = "2008"
+}
+
+@article{Fritzsch:1973pi,
+	author = "Fritzsch, H. and Gell-Mann, M. and Leutwyler, H.",
+	journal = "Phys. Lett.",
+	pages = "365--368",
+	slaccitation = "%\%CITATION = PHLTA,B47,365;\%\%",
+	title = "{Advantages of the color octet gluon picture}",
+	volume = "B47",
+	year = "1973"
+}
+
+@article{Frommer:1994vn,
+	author = "Frommer, A. and Hannemann, V. and Nockel, B. and Lippert, T. and Schilling, K.",
+	eprint = "hep-lat/9404013",
+	journal = "Int. J. Mod. Phys.",
+	pages = "1073--1088",
+	slaccitation = "%\%CITATION = HEP-LAT 9404013;\%\%",
+	title = "{Accelerating {Wilson} fermion matrix inversions by means of the stabilized biconjugate gradient algorithm}",
+	volume = "C5",
+	year = "1994"
+}
+
+@article{Frommer:1995ik,
+	author = "Frommer, Andreas and Nockel, Bertold and Gusken, Stephan and Lippert, Thomas and Schilling, Klaus",
+	eprint = "hep-lat/9504020",
+	journal = "Int. J. Mod. Phys.",
+	pages = "627--638",
+	slaccitation = "%\%CITATION = HEP-LAT 9504020;\%\%",
+	title = "{Many masses on one stroke: Economic computation of quark propagators}",
+	volume = "C6",
+	year = "1995"
+}
+
 @article{Frommer:2013fsa,
-	author         = "Frommer, Andreas and Kahl, Karsten and Krieg, Stefan and
-	Leder, Björn and Rottmann, Matthias",
-	title          = "{Adaptive Aggregation Based Domain Decomposition
-	Multigrid for the Lattice Wilson Dirac Operator}",
-	journal        = "SIAM J. Sci. Comput.",
-	volume         = "36",
-	year           = "2014",
-	pages          = "A1581-A1608",
-	doi            = "10.1137/130919507",
-	eprint         = "1303.1377",
-	archivePrefix  = "arXiv",
-	primaryClass   = "hep-lat",
-	SLACcitation   = "%%CITATION = ARXIV:1303.1377;%%"
+	archiveprefix = "arXiv",
+	author = "Frommer, Andreas and Kahl, Karsten and Krieg, Stefan and Leder, Bjï¿½rn and Rottmann, Matthias",
+	doi = "10.1137/130919507",
+	eprint = "1303.1377",
+	journal = "SIAM J. Sci. Comput.",
+	pages = "A1581--A1608",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:1303.1377;\%\%",
+	title = "{Adaptive Aggregation Based Domain Decomposition Multigrid for the Lattice Wilson Dirac Operator}",
+	volume = "36",
+	year = "2014"
 }
+
 @article{Alexandrou:2016izb,
-      author         = "Alexandrou, Constantia and Bacchio, Simone and
-                        Finkenrath, Jacob and Frommer, Andreas and Kahl, Karsten
-                        and Rottmann, Matthias",
-      title          = "{Adaptive Aggregation-based Domain Decomposition
-                        Multigrid for Twisted Mass Fermions}",
-      year           = "2016",
-      eprint         = "1610.02370",
-      archivePrefix  = "arXiv",
-      primaryClass   = "hep-lat",
-      SLACcitation   = "%%CITATION = ARXIV:1610.02370;%%"
-}
-@Article{Furman:1994ky,
-     author    = "Furman, V. and Shamir, Y.",
-     title     = "Axial symmetries in lattice QCD with Kaplan fermions",
-     journal   = "Nucl. Phys.",
-     volume    = "B439",
-     year      = "1995",
-     pages     = "54-78",
-     eprint    = "hep-lat/9405004",
-     SLACcitation  = "%%CITATION = HEP-LAT 9405004;%%"
-}
-@Article{Garden:1999fg,
-     author    = "Garden, J. and Heitger, J. and Sommer, R. and
-                  Wittig H.",
- collaboration = "ALPHA",
-     title     = "Precision computation of the strange quark's mass in
-                  quenched {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B571",
-     year      = "2000",
-     pages     = "237-256",
-     eprint    = "hep-lat/9906013",
-     SLACcitation  = "%%CITATION = HEP-LAT 9906013;%%"
-}
-@Article{Garron:2003cb,
-     author    = "Garron, N. and Giusti, L. and Hoelbling,
-                  C. and Lellouch, L. and Rebbi, C.",
-     title     = "B(K) from quenched {QCD} with exact chiral symmetry",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "92",
-     year      = "2004",
-     pages     = "042001",
-     eprint    = "hep-ph/0306295",
-     SLACcitation  = "%%CITATION = HEP-PH 0306295;%%"
-}
-@Article{Gasser:1982ap,
-     author    = "Gasser, J. and Leutwyler, H.",
-     title     = "Quark masses",
-     journal   = "Phys. Rept.",
-     volume    = "87",
-     year      = "1982",
-     pages     = "77-169",
-     SLACcitation  = "%%CITATION = PRPLC,87,77;%%"
-}
-@Article{Gasser:1983yg,
-     author    = "Gasser, J. and Leutwyler, H.",
-     title     = "Chiral perturbation theory to one loop",
-     journal   = "Ann. Phys.",
-     volume    = "158",
-     year      = "1984",
-     pages     = "142",
-     SLACcitation  = "%%CITATION = APNYA,158,142;%%"
+	archiveprefix = "arXiv",
+	author = "Alexandrou, Constantia and Bacchio, Simone and Finkenrath, Jacob and Frommer, Andreas and Kahl, Karsten and Rottmann, Matthias",
+	eprint = "1610.02370",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:1610.02370;\%\%",
+	title = "{Adaptive Aggregation-based Domain Decomposition Multigrid for Twisted Mass Fermions}",
+	year = "2016"
 }
 
-@Article{Gasser:1985gg,
-     author    = "Gasser, J. and Leutwyler, H.",
-     title     = "Chiral perturbation theory: expansions in the mass of the
-                  strange quark",
-     journal   = "Nucl. Phys.",
-     volume    = "B250",
-     year      = "1985",
-     pages     = "465",
-     SLACcitation  = "%%CITATION = NUPHA,B250,465;%%"
-}
-@Article{Gasser:1986vb,
-     author    = "Gasser, J. and Leutwyler, H.",
-     title     = "LIGHT QUARKS AT LOW TEMPERATURES",
-     journal   = "Phys. Lett.",
-     volume    = "B184",
-     year      = "1987",
-     pages     = "83",
-     SLACcitation  = "%%CITATION = PHLTA,B184,83;%%"
-}
-@Article{Gattringer:2003qx,
-     author    = "Gattringer, C. and others",
- collaboration = "BGR",
-     title     = "Quenched spectroscopy with fixed-point and chirally
-                  improved fermions",
-     journal   = "Nucl. Phys.",
-     volume    = "B677",
-     year      = "2004",
-     pages     = "3-51",
-     eprint    = "hep-lat/0307013",
-     SLACcitation  = "%%CITATION = HEP-LAT 0307013;%%"
-}
-@Article{Gell-Mann:1964nj,
-     author    = "Gell-Mann, M.",
-     title     = "A Schematic model of baryons and mesons",
-     journal   = "Phys. Lett.",
-     volume    = "8",
-     year      = "1964",
-     pages     = "214-215",
-     SLACcitation  = "%%CITATION = PHLTA,8,214;%%"
-}
-@Article{Gell-Mann:1968rz,
-     author    = "Gell-Mann, M. and Oakes, R. J. and Renner, B.",
-     title     = "Behavior of current divergences under SU(3) x SU(3)",
-     journal   = "Phys. Rev.",
-     volume    = "175",
-     year      = "1968",
-     pages     = "2195-2199",
-     SLACcitation  = "%%CITATION = PHRVA,175,2195;%%"
-}
-@PhdThesis{Geus:2002,
-  author = 	 {R. Geus},
-  title = 	 {The Jacobi-Davidson algorithm for solving large
-                  sparse symmetric eigenvalue problems with
-                  application to the design of accelerator cavities}, 
-  school = 	 {Swiss Federal Institute Of Technology Z{\"u}rich},
-  year = 	 {2002},
-  OPTkey = 	 {DISS. ETH NO. 14734},
-  OPTtype = 	 {},
-  OPTaddress = 	 {},
-  OPTmonth = 	 {},
-  OPTnote = 	 {},
-  OPTannote = 	 {}
-}
-@Article{Gimenez:1998ue,
-     author    = "Gimenez, V. and Giusti, L. and Rapuano, F. and Talevi, M.",
-     title     = "Non-perturbative renormalization of quark bilinears",
-     journal   = "Nucl. Phys.",
-     volume    = "B531",
-     year      = "1998",
-     pages     = "429-445",
-     eprint    = "hep-lat/9806006",
-     SLACcitation  = "%%CITATION = HEP-LAT 9806006;%%"
-}
-@Article{Gimenez:2005nt,
-     author    = "Gimenez, V. and Lubicz, V. and Mescia, F. and Porretti, V.
-                  and Reyes, J.",
-     title     = "{Operator product expansion and quark condensate from
-                  lattice QCD in  coordinate space}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C41",
-     year      = "2005",
-     pages     = "535-544",
-     eprint    = "hep-lat/0503001",
-     SLACcitation  = "%%CITATION = HEP-LAT/0503001;%%"
-}
-@Article{Ginsparg:1981bj,
-     author    = "Ginsparg, P. H. and {Wilson}, K. G.",
-     title     = "A remnant of chiral symmetry on the lattice",
-     journal   = "Phys. Rev.",
-     volume    = "D25",
-     year      = "1982",
-     pages     = "2649",
-     SLACcitation  = "%%CITATION = PHRVA,D25,2649;%%"
-}
-@Article{Giusti:1998wy,
-     author    = "Giusti, L. and Rapuano, F. and Talevi, M. and Vladikas, A.
-                  ",
-     title     = "The QCD chiral condensate from the lattice",
-     journal   = "Nucl. Phys.",
-     volume    = "B538",
-     year      = "1999",
-     pages     = "249-277",
-     eprint    = "hep-lat/9807014",
-     SLACcitation  = "%%CITATION = HEP-LAT 9807014;%%"
-}
-@Article{Giusti:2001pk,
-     author    = "Giusti, L. and Hoelbling, C. and Rebbi, C.",
-     title     = "Light quark masses with overlap fermions in quenched {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D64",
-     year      = "2001",
-     pages     = "114508",
-     eprint    = "hep-lat/0108007",
-     note      = "Erratum-ibid.D65:079903,2002",
-     SLACcitation  = "%%CITATION = HEP-LAT 0108007;%%"
-}
-@Article{Giusti:2002sm,
-     author    = "Giusti, L. and Hoelbling, C. and L{\"u}scher, M. and Wittig, H.
-                  ",
-     title     = "Numerical techniques for lattice QCD in the epsilon-
-                  regime",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "153",
-     year      = "2003",
-     pages     = "31-51",
-     eprint    = "hep-lat/0212012",
-     SLACcitation  = "%%CITATION = HEP-LAT 0212012;%%"
-}
-@Article{Giusti:2007hk,
-     author    = "Giusti, Leonardo",
-     title     = "Light dynamical fermions on the lattice: Toward the chiral
-                  regime of QCD",
-     journal   = "PoS.",
-     volume    = "LAT2006",
-     year      = "2007",
-     pages     = "",
-     eprint    = "hep-lat/0702014",
-     SLACcitation  = "%%CITATION = HEP-LAT/0702014;%%"
-}
-@Article{Glassner:1996gz,
-     author    = "Gl{\"a}ssner, U. and others",
-     title     = "How to compute {G}reen's functions for entire mass
-                  trajectories within {K}rylov solvers",
-     year      = "1996",
-     eprint    = "hep-lat/9605008",
-     SLACcitation  = "%%CITATION = HEP-LAT 9605008;%%"
-}
-@Article{Gockeler:1998fn,
-     author    = "G{\"o}ckeler, M. and others",
-     title     = "Scaling of non-perturbatively {O(a)} improved {Wilson}
-                  fermions: Hadron  spectrum, quark masses and decay
-                  constants",
-     journal   = "Phys. Rev.",
-     volume    = "D57",
-     year      = "1998",
-     pages     = "5562-5580",
-     eprint    = "hep-lat/9707021",
-     SLACcitation  = "%%CITATION = HEP-LAT 9707021;%%"
-}
-@Article{Gorishnii:1990vf,
-     author    = "Gorishnii, S. G. and Kataev, A. L. and Larin, S. A.",
-     title     = "{The O (alpha-s**3) corrections to sigma-tot (e+ e- $\to$
-                  hadrons) and Gamma (tau- $\to$ tau-neutrino + hadrons) in
-                  QCD}",
-     journal   = "Phys. Lett.",
-     volume    = "B259",
-     year      = "1991",
-     pages     = "144-150",
-     SLACcitation  = "%%CITATION = PHLTA,B259,144;%%"
-}
-@Article{Greenberg:1964pe,
-     author    = "Greenberg, O. W.",
-     title     = "Spin and unitary spin independence in a paraquark model of
-                  baryons and mesons",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "13",
-     year      = "1964",
-     pages     = "598-602",
-     SLACcitation  = "%%CITATION = PRLTA,13,598;%%"
-}
-@Article{Gregory:2007ce,
-     author    = "Gregory, Eric B. and Irving, Alan and Richards, Chris M.
-                  and McNeile, Craig and Hart, Alistair",
-     title     = "Pseudoscalar Flavor-Singlet Physics with Staggered
-                  Fermions",
-     year      = "2007",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     eprint    = "0710.1725",
-     SLACcitation  = "%%CITATION = ARXIV:0710.1725;%%"
-}
-@Article{Gross:1973id,
-     author    = "Gross, D. J. and Wilczek, F.",
-     title     = "Ultraviolet behavior of non-Abelian gauge theories",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "30",
-     year      = "1973",
-     pages     = "1343-1346",
-     SLACcitation  = "%%CITATION = PRLTA,30,1343;%%"
-}
-@Article{Gross:1973ju,
-     author    = "Gross, D. J. and Wilczek, F.",
-     title     = "Asymptotically free gauge theories. 1",
-     journal   = "Phys. Rev.",
-     volume    = "D8",
-     year      = "1973",
-     pages     = "3633-3652",
-     SLACcitation  = "%%CITATION = PHRVA,D8,3633;%%"
-}
-@Article{Gross:1974jv,
-     author    = "Gross, D. J. and Neveu, A.",
-     title     = "Dynamical symmetry breaking in asymptotically free field
-                  theories",
-     journal   = "Phys. Rev.",
-     volume    = "D10",
-     year      = "1974",
-     pages     = "3235",
-     SLACcitation  = "%%CITATION = PHRVA,D10,3235;%%"
-}
-@Article{Guagnelli:1998ud,
-     author    = "Guagnelli, M. and Sommer, R. and Wittig, H.",
- collaboration = "ALPHA",
-     title     = "Precision computation of a low-energy reference scale in
-                  quenched  lattice {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B535",
-     year      = "1998",
-     pages     = "389-402",
-     eprint    = "hep-lat/9806005",
-     SLACcitation  = "%%CITATION = HEP-LAT 9806005;%%"
-}
-@Article{Guagnelli:2004ga,
-     author    = "Guagnelli, M. and others",
- collaboration = "Zeuthen-Rome (ZeRo)",
-     title     = "Non-perturbative pion matrix element of a twist-2 operator
-                  from the  lattice",
-     journal   = "Eur. Phys. J.",
-     volume    = "C40",
-     year      = "2005",
-     pages     = "69-80",
-     eprint    = "hep-lat/0405027",
-     SLACcitation  = "%%CITATION = HEP-LAT 0405027;%%"
-}
-@Article{Guagnelli:2004ww,
-     author    = "Guagnelli, M. and others",
- collaboration = "Zeuthen-Rome (ZeRo)",
-     title     = "Finite size effects of a pion matrix element",
-     journal   = "Phys. Lett.",
-     volume    = "B597",
-     year      = "2004",
-     pages     = "216-221",
-     eprint    = "hep-lat/0403009",
-     SLACcitation  = "%%CITATION = HEP-LAT 0403009;%%"
-}
-@Article{Guagnelli:2005zc,
-     author    = "Guagnelli, M. and Heitger, J. and Pena, C. and Sint, S. and
-                  Vladikas, A.",
- collaboration = "ALPHA",
-     title     = "Non-perturbative renormalization of left-left four-fermion
-                  operators in  quenched lattice QCD",
-     journal   = "JHEP",
-     volume    = "03",
-     year      = "2006",
-     pages     = "088",
-     eprint    = "hep-lat/0505002",
-     SLACcitation  = "%%CITATION = HEP-LAT 0505002;%%"
-}
-@Article{Gupta:1988js,
-     author    = "Gupta, R. and Kilcup, G. W. and Sharpe, S. R.
-                  ",
-     title     = "Tuning the hybrid monte carlo algorithm",
-     journal   = "Phys. Rev.",
-     volume    = "D38",
-     year      = "1988",
-     pages     = "1278",
-     SLACcitation  = "%%CITATION = PHRVA,D38,1278;%%"
-}
-@Article{Gupta:1989kx,
-     author    = "Gupta, R. and others",
-     title     = "{QCD} with dynamical {Wilson} fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D40",
-     year      = "1989",
-     pages     = "2072",
-     SLACcitation  = "%%CITATION = PHRVA,D40,2072;%%"
-}
-@Article{Gupta:1990ka,
-     author    = "Gupta, S. and Irback, A. and Karsch, F. and
-                  Petersson, B.",
-     title     = "The acceptance probability in the hybrid monte carlo
-                  method",
-     journal   = "Phys. Lett.",
-     volume    = "B242",
-     year      = "1990",
-     pages     = "437-443",
-     SLACcitation  = "%%CITATION = PHLTA,B242,437;%%"
-}
-@Article{Gupta:1991sn,
-     author    = "Gupta, R. and others",
-     title     = "{QCD} with dynamical {Wilson} fermions. 2",
-     journal   = "Phys. Rev.",
-     volume    = "D44",
-     year      = "1991",
-     pages     = "3272-3292",
-     SLACcitation  = "%%CITATION = PHRVA,D44,3272;%%"
-}
-@Unpublished{Gupta:1997nd,
-     author    = "Gupta, R.",
-     title     = "Introduction to lattice {QCD}",
-     year      = "1997",
-     eprint    = "hep-lat/9807028",
-     note      = "Lectures given at Les Houches Summer School in Theoretical Physics, Session 68",
-     SLACcitation  = "%%CITATION = HEP-LAT 9807028;%%"
-}
-@Article{Han:1965pf,
-     author    = "Han, M. Y. and Nambu, Yoichiro",
-     title     = "Three-triplet model with double SU(3) symmetry",
-     journal   = "Phys. Rev.",
-     volume    = "139",
-     year      = "1965",
-     pages     = "B1006-B1010",
-     SLACcitation  = "%%CITATION = PHRVA,139,B1006;%%"
-}
-@Article{Hasenbusch:2001ne,
-     author    = "Hasenbusch, M.",
-     title     = "Speeding up the {H}ybrid-{M}onte-{C}arlo algorithm for dynamical
-                  fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B519",
-     year      = "2001",
-     pages     = "177-182",
-     eprint    = "hep-lat/0107019",
-     SLACcitation  = "%%CITATION = HEP-LAT 0107019;%%"
-}
-@Article{Hasenbusch:2002ai,
-     author    = "Hasenbusch, M. and Jansen, K.",
-     title     = "Speeding up lattice {QCD} simulations with clover-improved
-                  {Wilson} fermions",
-     journal   = "Nucl. Phys.",
-     volume    = "B659",
-     year      = "2003",
-     pages     = "299-320",
-     eprint    = "hep-lat/0211042",
-     SLACcitation  = "%%CITATION = HEP-LAT 0211042;%%"
-}
-@Article{Hasenbusch:2003vg,
-     author    = "Hasenbusch, Martin",
-     title     = "{Full QCD algorithms towards the chiral limit}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "129",
-     year      = "2004",
-     pages     = "27-33",
-     eprint    = "hep-lat/0310029",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/S0920-5632(03)02504-0",
-     SLACcitation  = "%%CITATION = HEP-LAT/0310029;%%"
-}
-@Article{Hasenfratz:1998jp,
-     author    = "Hasenfratz, P.",
-     title     = "Lattice {QCD} without tuning, mixing and current
-                  renormalization",
-     journal   = "Nucl. Phys.",
-     volume    = "B525",
-     year      = "1998",
-     pages     = "401-409",
-     eprint    = "hep-lat/9802007",
-     SLACcitation  = "%%CITATION = HEP-LAT 9802007;%%"
-}
-@Article{Hasenfratz:1998ri,
-     author    = "Hasenfratz, P. and Laliena, V. and Niedermayer,
-                  F.",
-     title     = "The index theorem in {QCD} with a finite cut-off",
-     journal   = "Phys. Lett.",
-     volume    = "B427",
-     year      = "1998",
-     pages     = "125-131",
-     eprint    = "hep-lat/9801021",
-     SLACcitation  = "%%CITATION = HEP-LAT 9801021;%%"
-}
-@Article{Hasenfratz:2001hp,
-     author    = "Hasenfratz, A. and Knechtli, F.",
-     title     = "Flavor symmetry and the static potential with hypercubic
-                  blocking",
-     journal   = "Phys. Rev.",
-     volume    = "D64",
-     year      = "2001",
-     pages     = "034504",
-     eprint    = "hep-lat/0103029",
-     SLACcitation  = "%%CITATION = HEP-LAT 0103029;%%"
-}
-@Article{Hasenfratz:2001tw,
-     author    = "Hasenfratz, A. and Hoffmann, R. and Knechtli, F.",
-     title     = "The static potential with hypercubic blocking",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "418-420",
-     eprint    = "hep-lat/0110168",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110168;%%"
-}
-@Article{Hashimoto:2008xg,
-     author    = "Hashimoto, Koichi and Izubuchi, Taku",
-     title     = "{eta' meson from two flavor dynamical domain wall
-                  fermions}",
-     year      = "2008",
-     eprint    = "0803.0186",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = ARXIV:0803.0186;%%"
-}
-@Article{Heitger:2000ay,
-     author    = "Heitger, J. and Sommer, R. and Wittig, H.",
- collaboration = "ALPHA",
-     title     = "Effective chiral Lagrangians and lattice {{QCD}}",
-     journal   = "Nucl. Phys.",
-     volume    = "B588",
-     year      = "2000",
-     pages     = "377-399",
-     eprint    = "hep-lat/0006026",
-     note      = "and references therein",
-     SLACcitation  = "%%CITATION = HEP-LAT 0006026;%%"
-}
-@Article{Hernandez:1998et,
-     author    = "Hernandez, P. and Jansen, K. and L{\"u}scher, M.",
-     title     = "Locality properties of Neuberger's lattice Dirac operator",
-     journal   = "Nucl. Phys.",
-     volume    = "B552",
-     year      = "1999",
-     pages     = "363-378",
-     eprint    = "hep-lat/9808010",
-     SLACcitation  = "%%CITATION = HEP-LAT 9808010;%%"
-}
-@Article{Hernandez:2000sb,
-     author    = "Hernandez, P. and Jansen, K. and Lellouch, L.",
-     title     = "A numerical treatment of Neuberger's lattice Dirac
-                  operator",
-     year      = "2000",
-     eprint    = "hep-lat/0001008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0001008;%%"
-}
-@Article{Hernandez:2001hq,
-     author    = "Hernandez, P. and Jansen, K. and Lellouch, L. and
-                  Wittig, H.",
-     title     = "Scalar condensate and light quark masses from overlap
-                  fermions",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "766-771",
-     eprint    = "hep-lat/0110199",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110199;%%"
-}
-@Article{Hernandez:2001yn,
-     author    = "Hernandez, P. and Jansen, K. and Lellouch, L. and
-                  Wittig, H.",
-     title     = "Non-perturbative renormalization of the quark condensate in
-                  {Ginsparg}-{Wilson} regularizations",
-     journal   = "JHEP",
-     volume    = "07",
-     year      = "2001",
-     pages     = "018",
-     eprint    = "hep-lat/0106011",
-     SLACcitation  = "%%CITATION = HEP-LAT 0106011;%%"
-}
-@Article{Horsley:2004mx,
-     author    = "Horsley, R. and Perlt, H. and Rakow, P. E. L. and
-                  Schierholz, G. and Schiller, A.",
- collaboration = "QCDSF",
-     title     = "One-loop renormalisation of quark bilinears for overlap
-                  fermions with  improved gauge actions",
-     journal   = "Nucl. Phys.",
-     volume    = "B693",
-     year      = "2004",
-     pages     = "3-35",
-     eprint    = "hep-lat/0404007",
-     SLACcitation  = "%%CITATION = HEP-LAT 0404007;%%"
-}
-@Article{Ilgenfritz:2003gw,
-     author    = "Ilgenfritz, E.-M. and Kerler, W. and
-                  M{\"u}ller-Preu{\ss}ker, M. and Sternbeck, A. and St{\"u}ben, H.",
-     title     = "A numerical reinvestigation of the {Aoki} phase with {N(f)} = 2
-                  {Wilson}  fermions at zero temperature",
-     journal   = "Phys. Rev.",
-     volume    = "D69",
-     year      = "2004",
-     pages     = "074511",
-     eprint    = "hep-lat/0309057",
-     SLACcitation  = "%%CITATION = HEP-LAT 0309057;%%"
-}
-@Article{Ilgenfritz:2006tz,
-     author    = "Ilgenfritz, E. -M. and others",
-     title     = "Twisted mass QCD thermodynamics: First results on apeNEXT",
-     year      = "2006",
-     eprint    = "hep-lat/0610112",
-     SLACcitation  = "%%CITATION = HEP-LAT 0610112;%%"
-}
-@Article{Iwasaki:1983ck,
-     author    = "Iwasaki, Y.",
-     title     = "Renormalization group analysis of lattice theories and
-                  improved lattice action. 2. four-dimensional nonabelian
-                  SU(N) gauge model",
-     note     = "UTHEP-118"
-}
-@Article{Iwasaki:1985we,
-     author    = "Iwasaki, Y.",
-     title     = "Renormalization group analysis of lattice theories and
-                  improved lattice action: two-dimensional nonlinear O(N)
-                  sigma model",
-     journal   = "Nucl. Phys.",
-     volume    = "B258",
-     year      = "1985",
-     pages     = "141-156",
-     SLACcitation  = "%%CITATION = NUPHA,B258,141;%%"
-}
-@Article{Iwasaki:1992hn,
-     author    = "Iwasaki, Y. and Kanaya, K. and Sakai, S. and Yoshie, T.",
-     title     = "Quark confinement in multi - flavor quantum
-                  chromodynamics",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "30",
-     year      = "1993",
-     pages     = "327-330",
-     eprint    = "hep-lat/9211035",
-     SLACcitation  = "%%CITATION = HEP-LAT 9211035;%%"
-}
-@Article{Izubuchi:1998hy,
-     author    = "Izubuchi, T. and Noaki, J. and Ukawa, A.",
-     title     = "Two-dimensional lattice Gross-Neveu model with {Wilson}
-                  fermion action at  finite temperature and chemical
-                  potential",
-     journal   = "Phys. Rev.",
-     volume    = "D58",
-     year      = "1998",
-     pages     = "114507",
-     eprint    = "hep-lat/9805019",
-     SLACcitation  = "%%CITATION = HEP-LAT 9805019;%%"
-}
-@Article{Jacobs:1983ph,
-     author    = "Jacobs, L.",
-     title     = "Undoubling chirally symmetric lattice fermions",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "51",
-     year      = "1983",
-     pages     = "172",
-     SLACcitation  = "%%CITATION = PRLTA,51,172;%%"
-}
-@Article{Jagels:1994a,
-     author    = "Jagels, C. F. and Reichel, L.",
-     title     = " fast minimal residual algorithm for shifted unitary matrices",
-     journal   = "Numer. Linear Algebra Appl.",
-     volume    = "1(6)",
-     pages     = "555-570",
-     year      = "1994"
-}
-@Article{Jagels:1994aa,
-     author    = "Jagels, C. F. and Reichel, L.",
-     title     = "A Fast Minimal Residual Algorithm for Shifted Unitary 
-                  Matrices",
-     journal   = "Numerical Linear Algebra with Aplications",
-     volume    = "1(6)",
-     year      = "1994",
-     pages     = "555-570",
-}
-@Article{Jansen:1994ym,
-     author    = "Jansen, K.",
-     title     = "Domain wall fermions and chiral gauge theories",
-     journal   = "Phys. Rept.",
-     volume    = "273",
-     year      = "1996",
-     pages     = "1-54",
-     eprint    = "hep-lat/9410018",
-     SLACcitation  = "%%CITATION = HEP-LAT 9410018;%%"
-}
-@Article{Jansen:1995ck,
-     author    = "Jansen, Karl and others",
-     title     = "Non-perturbative renormalization of lattice QCD at all
-                  scales",
-     journal   = "Phys. Lett.",
-     volume    = "B372",
-     year      = "1996",
-     pages     = "275-282",
-     eprint    = "hep-lat/9512009",
-     SLACcitation  = "%%CITATION = HEP-LAT 9512009;%%"
-}
-@Article{Jansen:1996cq,
-     author    = "Jansen, K. and Liu, C.",
-     title     = "Study of Liapunov exponents and the reversibility of
-                  molecular dynamics  algorithms",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "53",
-     year      = "1997",
-     pages     = "974-976",
-     eprint    = "hep-lat/9607057",
-     SLACcitation  = "%%CITATION = HEP-LAT 9607057;%%"
-}
-@Article{Jansen:1996xp,
-     author    = "Jansen, K.",
-     title     = "Recent developments in fermion simulation algorithms",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "53",
-     year      = "1997",
-     pages     = "127-133",
-     eprint    = "hep-lat/9607051",
-     SLACcitation  = "%%CITATION = HEP-LAT 9607051;%%"
-}
-@Article{Jansen:1997yt,
-     author    = "Jansen, K. and Liu, C.",
-     title     = "Implementation of Symanzik's improvement program for
-                  simulations of  dynamical {Wilson} fermions in lattice {QCD}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "99",
-     year      = "1997",
-     pages     = "221-234",
-     eprint    = "hep-lat/9603008",
-     SLACcitation  = "%%CITATION = HEP-LAT 9603008;%%"
-}
-@Article{Jansen:1998mx,
-     author    = "Jansen, K. and Sommer, R.",
- collaboration = "ALPHA",
-     title     = "O(alpha) improvement of lattice {QCD} with two flavors of
-                  {Wilson} quarks",
-     journal   = "Nucl. Phys.",
-     volume    = "B530",
-     year      = "1998",
-     pages     = "185-203",
-     eprint    = "hep-lat/9803017",
-     SLACcitation  = "%%CITATION = HEP-LAT 9803017;%%"
-}
-@Article{Jansen:2003ir,
-     author    = "Jansen, K. and Shindler, A. and Urbach, C. and
-                  Wetzorke, I.",
- collaboration = "\xlf",
-     title     = "Scaling test for {Wilson} twisted mass {QCD}",
-     journal   = "Phys. Lett.",
-     volume    = "B586",
-     year      = "2004",
-     pages     = "432-438",
-     eprint    = "hep-lat/0312013",
-     SLACcitation  = "%%CITATION = HEP-LAT 0312013;%%"
-}
-@Article{Jansen:2003jq,
-     author    = "Jansen, K. and Nagai, K.-I.",
-     title     = "Reducing residual-mass effects for domain-wall fermions",
-     journal   = "JHEP",
-     volume    = "12",
-     year      = "2003",
-     pages     = "038",
-     eprint    = "hep-lat/0305009",
-     SLACcitation  = "%%CITATION = HEP-LAT 0305009;%%"
-}
-@Article{Jansen:2003nt,
-     author    = "Jansen, K.",
-     title     = "Actions for dynamical fermion simulations: Are we ready to
-                  go?",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "129",
-     year      = "2004",
-     pages     = "3-16",
-     eprint    = "hep-lat/0311039",
-     SLACcitation  = "%%CITATION = HEP-LAT 0311039;%%"
-}
-@Article{Jansen:2005cg,
-     author    = "Jansen, K. and others",
- collaboration = "\xlf",
-     title     = "Flavour breaking effects of {Wilson} twisted mass fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B624",
-     year      = "2005",
-     pages     = "334-341",
-     eprint    = "hep-lat/0507032",
-     SLACcitation  = "%%CITATION = HEP-LAT 0507032;%%"
-}
-@Unpublished{Jansen:2005chi,
-  author = 	 {Jansen, K. and others},
-collaborations = {\xlf},
-  title = 	 {},
-  note = 	 {in preparation},
-  OPTkey = 	 {},
-  OPTmonth = 	 {},
-  year = 	 {2005},
-  OPTannote = 	 {}
-}
-@Article{Jansen:2005gf,
-     author    = "Jansen, K. and Papinutto, M. and Shindler, A. and Urbach,
-                  C. and Wetzorke, I.",
- collaboration = "\xlf",
-     title     = "Light quarks with twisted mass fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B619",
-     year      = "2005",
-     pages     = "184-191",
-     eprint    = "hep-lat/0503031",
-     SLACcitation  = "%%CITATION = HEP-LAT 0503031;%%"
-}
-@Article{Jansen:2005kk,
-     author    = "Jansen, K. and Papinutto, M. and Shindler, A. and Urbach,
-                  C. and Wetzorke, I.",
- collaboration = "\xlf",
-     title     = "Quenched scaling of {Wilson} twisted mass fermions",
-     journal   = "JHEP",
-     volume    = "09",
-     year      = "2005",
-     pages     = "071",
-     eprint    = "hep-lat/0507010",
-     SLACcitation  = "%%CITATION = HEP-LAT 0507010;%%"
-}
-@Article{Jansen:2005yp,
-     author    = "Jansen, Karl and Shindler, Andrea and Urbach, Carsten and
-                  Wenger, Urs",
-     title     = "{HMC} algorithm with multiple time scale integration and mass
-                  preconditioning",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "118",
-     eprint    = "hep-lat/0510064",
-     SLACcitation  = "%%CITATION = HEP-LAT 0510064;%%"
-}
-@Article{Jansen:2006ks,
-     author    = "Jansen, Karl",
-     title     = "Status report on ILDG activities",
-     year      = "2006",
-     eprint    = "hep-lat/0609012",
-     SLACcitation  = "%%CITATION = HEP-LAT 0609012;%%"
-}
-@Article{Jansen:2006rf,
-     author    = "Jansen, Karl and Urbach, Carsten",
- collaboration = "ETM",
-     title     = "First results with two light flavours of quarks with
-                  maximally twisted mass",
-     year      = "2006",
-     eprint    = "hep-lat/0610015",
-     SLACcitation  = "%%CITATION = HEP-LAT 0610015;%%"
-}
-@Article{Jansen:2008wv,
-     author    = "Jansen, K. and Michael, C. and Urbach, C.",
- collaboration = "ETM",
-     title     = "The eta' meson from lattice {QCD}",
-     year      = "2008",
-     eprint    = "0804.3871",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0804.3871;%%"
-}
-@Article{Jansen:2008zz,
-     author    = "Jansen, K. and Michael, C. and Urbach, C.",
-     title     = "{The eta-prime meson from lattice QCD}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C58",
-     year      = "2008",
-     pages     = "261-269",
-     doi       = "10.1140/epjc/s10052-008-0764-6",
-     SLACcitation  = "%%CITATION = EPHJA,C58,261;%%"
-}
-@Unpublished{Jegerlehner:1996pm,
-     author    = "Jegerlehner, Beat",
-     title     = "Krylov space solvers for shifted linear systems",
-     year      = "1996",
-     eprint    = "hep-lat/9612014",
-     note      = "unpublished",
-     SLACcitation  = "%%CITATION = HEP-LAT 9612014;%%"
-}
-@Article{Jegerlehner:1997rn,
-     author    = "Jegerlehner, B.",
-     title     = "Multiple mass solvers",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "63",
-     year      = "1998",
-     pages     = "958-960",
-     eprint    = "hep-lat/9708029",
-     SLACcitation  = "%%CITATION = HEP-LAT 9708029;%%"
-}
-@Article{Jegerlehner:2003qp,
-     author    = "Jegerlehner, F.",
-     title     = "Theoretical precision in estimates of the hadronic
-                  contributions to  (g-2)mu and alpha(QED)(M(Z))",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "126",
-     year      = "2004",
-     pages     = "325-334",
-     eprint    = "hep-ph/0310234",
-     SLACcitation  = "%%CITATION = HEP-PH 0310234;%%"
-}
-@Article{Jenkins:1990jv,
-     author    = "Jenkins, Elizabeth Ellen and Manohar, Aneesh V.",
-     title     = "Baryon chiral perturbation theory using a heavy fermion
-                  Lagrangian",
-     journal   = "Phys. Lett.",
-     volume    = "B255",
-     year      = "1991",
-     pages     = "558-562",
-     SLACcitation  = "%%CITATION = PHLTA,B255,558;%%"
-}
-@Article{Kaiser:1998ds,
-     author    = "Kaiser, Roland and Leutwyler, H.",
-     title     = "{Pseudoscalar decay constants at large N(c)}",
-     year      = "1998",
-     eprint    = "hep-ph/9806336",
-     SLACcitation  = "%%CITATION = HEP-PH/9806336;%%"
+@article{Furman:1994ky,
+	author = "Furman, V. and Shamir, Y.",
+	eprint = "hep-lat/9405004",
+	journal = "Nucl. Phys.",
+	pages = "54--78",
+	slaccitation = "%\%CITATION = HEP-LAT 9405004;\%\%",
+	title = "{Axial symmetries in lattice QCD with Kaplan fermions}",
+	volume = "B439",
+	year = "1995"
 }
 
-@Article{Kalkreuter:1995mm,
-     author    = "Kalkreuter, Thomas and Simma, Hubert",
-     title     = "An Accelerated conjugate gradient algorithm to compute low
-                  lying eigenvalues: A Study for the Dirac operator in SU(2)
-                  lattice QCD",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "93",
-     year      = "1996",
-     pages     = "33-47",
-     eprint    = "hep-lat/9507023",
-     SLACcitation  = "%%CITATION = HEP-LAT 9507023;%%"
-}
-@Article{Kalkreuter:1996mm,
-     author    = "Kalkreuter, T. and Simma, H.",
-     title     = "An Accelerated conjugate gradient algorithm to compute low
-                  lying eigenvalues: A Study for the Dirac operator in SU(2)
-                  lattice {QCD}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "93",
-     year      = "1996",
-     pages     = "33-47",
-     eprint    = "hep-lat/9507023",
-     SLACcitation  = "%%CITATION = HEP-LAT 9507023;%%"
-}
-@Article{Kamleh:2005wg,
-     author    = "Kamleh, W. and Peardon, M. J.",
- collaboration = "TrinLat",
-     title     = "{Polynomial filtering for HMC in lattice QCD}",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "106",
-     SLACcitation  = "%%CITATION = POSCI,LAT2005,106;%%"
-}
-@Article{Kaplan:1992bt,
-     author    = "Kaplan, D. B.",
-     title     = "A Method for simulating chiral fermions on the lattice",
-     journal   = "Phys. Lett.",
-     volume    = "B288",
-     year      = "1992",
-     pages     = "342-347",
-     eprint    = "hep-lat/9206013",
-     SLACcitation  = "%%CITATION = HEP-LAT 9206013;%%"
-}
-@Article{Karsten:1980wd,
-     author    = "Karsten, L. H. and Smit, J.",
-     title     = "Lattice fermions: species doubling, chiral invariance, and
-                  the triangle anomaly",
-     journal   = "Nucl. Phys.",
-     volume    = "B183",
-     year      = "1981",
-     pages     = "103",
-     SLACcitation  = "%%CITATION = NUPHA,B183,103;%%"
-}
-@Article{Kennedy:1990bv,
-     author    = "Kennedy, A. D. and Pendleton, B.",
-     title     = "Acceptances and autocorrelations in hybrid Monte Carlo",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "20",
-     year      = "1991",
-     pages     = "118-121",
-     SLACcitation  = "%%CITATION = NUPHZ,20,118;%%"
-}
-@Article{Knechtli:1998gf,
-     author    = "Knechtli, F. and Sommer, R.",
- collaboration = "ALPHA",
-     title     = "String breaking in SU(2) gauge theory with scalar matter
-                  fields",
-     journal   = "Phys. Lett.",
-     volume    = "B440",
-     year      = "1998",
-     pages     = "345-352",
-     eprint    = "hep-lat/9807022",
-     SLACcitation  = "%%CITATION = HEP-LAT 9807022;%%"
-}
-@Article{Knechtli:2000df,
-     author    = "Knechtli, F. and Sommer, R.",
- collaboration = "ALPHA",
-     title     = "String breaking as a mixing phenomenon in the SU(2) Higgs
-                  model",
-     journal   = "Nucl. Phys.",
-     volume    = "B590",
-     year      = "2000",
-     pages     = "309-328",
-     eprint    = "hep-lat/0005021",
-     SLACcitation  = "%%CITATION = HEP-LAT 0005021;%%"
-}
-@Article{Lacock:1994qx,
-     author    = "Lacock, P. and McKerrell, A. and Michael, C. and Stopher,
-                            I. M. and Stephenson, P. W.",
-     collaboration = "UKQCD",
-     title     = "Efficient hadronic operators in lattice gauge theory",
-     journal   = "Phys. Rev.",
-     volume    = "D51",
-     year      = "1995",
-     pages     = "6403-6410",
-     eprint    = "hep-lat/9412079",
-     SLACcitation  = "%%CITATION = HEP-LAT 9412079;%%"
-}
-@Article{Lepage:1992xa,
-     author    = "Lepage, G. Peter and Mackenzie, Paul B.",
-     title     = "On the viability of lattice perturbation theory",
-     journal   = "Phys. Rev.",
-     volume    = "D48",
-     year      = "1993",
-     pages     = "2250-2264",
-     eprint    = "hep-lat/9209022",
-     SLACcitation  = "%%CITATION = HEP-LAT 9209022;%%"
-}
-@Article{Lepage:2001ym,
-     author    = "Lepage, G. P. and others",
-     title     = "{Constrained curve fitting}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "12-20",
-     eprint    = "hep-lat/0110175",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/S0920-5632(01)01638-3",
-     SLACcitation  = "%%CITATION = HEP-LAT/0110175;%%"
-}
-@Article{Lesk:2002gd,
-     author    = "Lesk, V. I. and others",
- collaboration = "CP-PACS",
-     title     = "Flavor singlet meson mass in the continuum limit in two-
-                  flavor lattice QCD",
-     journal   = "Phys. Rev.",
-     volume    = "D67",
-     year      = "2003",
-     pages     = "074503",
-     eprint    = "hep-lat/0211040",
-     SLACcitation  = "%%CITATION = HEP-LAT/0211040;%%"
-}
-@Article{Leutwyler:1997yr,
-     author    = "Leutwyler, H.",
-     title     = "{On the 1/N-expansion in chiral perturbation theory}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "64",
-     year      = "1998",
-     pages     = "223-231",
-     eprint    = "hep-ph/9709408",
-     SLACcitation  = "%%CITATION = HEP-PH/9709408;%%"
-}
-@Article{Leutwyler:2006qq,
-     author    = "Leutwyler, H.",
-     title     = "pi pi scattering",
-     year      = "2006",
-     eprint    = "hep-ph/0612112",
-     SLACcitation  = "%%CITATION = HEP-PH 0612112;%%"
-}
-@Article{Liu:1997fs,
-     author    = "Liu, C. and Jaster, A. and Jansen, K.",
-     title     = "Liapunov exponents and the reversibility of molecular
-                  dynamics  algorithms",
-     journal   = "Nucl. Phys.",
-     volume    = "B524",
-     year      = "1998",
-     pages     = "603-617",
-     eprint    = "hep-lat/9708017",
-     SLACcitation  = "%%CITATION = HEP-LAT 9708017;%%"
-}
-@Article{Luscher:1985dn,
-     author    = "L{\"u}scher, M.",
-     title     = "{Volume Dependence of the Energy Spectrum in Massive
-                  Quantum Field Theories. 1. Stable Particle States}",
-     journal   = "Commun. Math. Phys.",
-     volume    = "104",
-     year      = "1986",
-     pages     = "177",
-     doi       = "10.1007/BF01211589",
-     SLACcitation  = "%%CITATION = CMPHA,104,177;%%"
-}
-@Article{Luscher:1990ck,
-     author    = "L{\"u}scher, M. and Wolff, U.",
-     title     = "How to calculate the elastic scattering matrix in two-
-                  dimensional quantum field theories by numerical
-                  simulation",
-     journal   = "Nucl. Phys.",
-     volume    = "B339",
-     year      = "1990",
-     pages     = "222-252",
-     SLACcitation  = "%%CITATION = NUPHA,B339,222;%%"
-}
-@Article{Luscher:1993dy,
-     author    = "L{\"u}scher, Martin",
-     title     = "{A Portable high quality random number generator for
-                  lattice field theory simulations}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = 79,
-     year      = 1994,
-     pages     = "100-110",
-     eprint    = "hep-lat/9309020",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/0010-4655(94)90232-1",
-     SLACcitation  = "%%CITATION = HEP-LAT/9309020;%%"
-}
-@Article{Luscher:1993xx,
-     author    = "L{\"u}scher, Martin",
-     title     = "A New approach to the problem of dynamical quarks in
-                  numerical simulations of lattice {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B418",
-     year      = "1994",
-     pages     = "637-648",
-     eprint    = "hep-lat/9311007",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/0550-3213(94)90533-9",
-     SLACcitation  = "%%CITATION = HEP-LAT/9311007;%%"
-}
-@Article{Luscher:1993xx,
-     author    = "L{\"u}scher, M.",
-     title     = "A New approach to the problem of dynamical quarks in
-                  numerical simulations of lattice {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B418",
-     year      = "1994",
-     pages     = "637-648",
-     eprint    = "hep-lat/9311007",
-     SLACcitation  = "%%CITATION = HEP-LAT 9311007;%%"
-}
-@Article{Luscher:1996sc,
-     author    = "L{\"u}scher, M. and Sint, S. and Sommer, R. and
-                  Weisz, P.",
-     title     = "Chiral symmetry and {O(a)} improvement in lattice {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B478",
-     year      = "1996",
-     pages     = "365-400",
-     eprint    = "hep-lat/9605038",
-     SLACcitation  = "%%CITATION = HEP-LAT 9605038;%%"
-}
-@Article{Luscher:1996ug,
-     author    = "L{\"u}scher, M. and Sint, S. and Sommer, R. and
-                  Weisz, P. and Wolff, U.",
-     title     = "Non-perturbative {O(a)} improvement of lattice {QCD}",
-     journal   = "Nucl. Phys.",
-     volume    = "B491",
-     year      = "1997",
-     pages     = "323-343",
-     eprint    = "hep-lat/9609035",
-     SLACcitation  = "%%CITATION = HEP-LAT 9609035;%%"
-}
-@Article{Luscher:1998pq,
-     author    = "L{\"u}scher, M.",
-     title     = "Exact chiral symmetry on the lattice and the {Ginsparg}-
-                  {Wilson} relation",
-     journal   = "Phys. Lett.",
-     volume    = "B428",
-     year      = "1998",
-     pages     = "342-345",
-     eprint    = "hep-lat/9802011",
-     SLACcitation  = "%%CITATION = HEP-LAT 9802011;%%"
-}
-@Article{Luscher:2001tx,
-     author    = "L{\"u}scher, Martin",
-     title     = "{Lattice QCD on PCs?}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "21-28",
-     eprint    = "hep-lat/0110007",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/S0920-5632(01)01639-5",
-     SLACcitation  = "%%CITATION = HEP-LAT/0110007;%%"
-}
-@Article{Luscher:2003qa,
-     author    = "L{\"u}scher, M.",
-     title     = "Solution of the {D}irac equation in lattice {QCD} using a
-                  domain  decomposition method",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "156",
-     year      = "2004",
-     pages     = "209-220",
-     eprint    = "hep-lat/0310048",
-     SLACcitation  = "%%CITATION = HEP-LAT 0310048;%%"
-}
-@Article{Luscher:2004rx,
-     author    = "L{\"u}scher, M.",
-     title     = "Schwarz-preconditioned {HMC} algorithm for two-flavour
-                  lattice {QCD}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "165",
-     year      = "2005",
-     pages     = "199",
-     eprint    = "hep-lat/0409106",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409106;%%"
+@article{Garden:1999fg,
+	author = "Garden, J. and Heitger, J. and Sommer, R. and H., Wittig",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/9906013",
+	journal = "Nucl. Phys.",
+	pages = "237--256",
+	slaccitation = "%\%CITATION = HEP-LAT 9906013;\%\%",
+	title = "{Precision computation of the strange quark's mass in quenched {QCD}}",
+	volume = "B571",
+	year = "2000"
 }
 
-@Article{Luscher:2005mv,
-     author    = "L{\"u}scher, Martin",
-     title     = "Lattice {QCD} with light {W}ilson quarks",
-     journal   = "\href{http://pos.sissa.it/archive/conferences/020/008/LAT2005_002.pdf}{PoS(LAT2005)002}", 
-     year      = "2005",
-     eprint    = "hep-lat/0509152",
-     howpublished="Talk presented at International Symposium on Lattice Field Theory (Lattice 2005)",
-     SLACcitation  = "%%CITATION = HEP-LAT 0509152;%%"
-}
-@Article{Luscher:2007es,
-     author    = "L{\"u}scher, Martin",
-     title     = "{Deflation acceleration of lattice {QCD} simulations}",
-     journal   = "JHEP",
-     volume    = "12",
-     year      = "2007",
-     pages     = "011",
-     eprint    = "0710.5417",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     doi       = "10.1088/1126-6708/2007/12/011",
-     SLACcitation  = "%%CITATION = 0710.5417;%%"
-}
-@Article{Luscher:ranluxweb,
-     author    = "L{\"u}scher, M.",
-     title     = "Ranlux random number generator",
-     eprint    = "http://luscher.web.cern.ch/luscher/ranlux/"
-}
-@Article{Luscher:sse,
-     author    = "L{\"u}scher, M.",
-     title     = "Lattice QCD parallel benchmark programs",
-     eprint    = "http://luscher.web.cern.ch/luscher/QCDpbm/"
-}
-@Article{Madras:1988ei,
-     author    = "Madras, N. and Sokal, A. D.",
-     title     = "The Pivot algorithm: a highly efficient Monte Carlo method
-                  for selfavoiding walk",
-     journal   = "J. Statist. Phys.",
-     volume    = "50",
-     year      = "1988",
-     pages     = "109-186",
-     SLACcitation  = "%%CITATION = JSTPB,50,109;%%"
-}
-@Article{Martinelli:1982mw,
-     author    = "Martinelli, G. and Zhang, Yi-Cheng",
-     title     = "THE CONNECTION BETWEEN LOCAL OPERATORS ON THE LATTICE AND
-                  IN THE CONTINUUM AND ITS RELATION TO MESON DECAY
-                  CONSTANTS",
-     journal   = "Phys. Lett.",
-     volume    = "B123",
-     year      = "1983",
-     pages     = "433",
-     SLACcitation  = "%%CITATION = PHLTA,B123,433;%%"
-}
-@Article{Martinelli:1994ty,
-     author    = "Martinelli, G. and Pittori, C. and Sachrajda, Christopher
-                  T. and Testa, M. and Vladikas, A.",
-     title     = "{A General method for nonperturbative renormalization of
-                  lattice operators}",
-     journal   = "Nucl. Phys.",
-     volume    = "B445",
-     year      = "1995",
-     pages     = "81-108",
-     eprint    = "hep-lat/9411010",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/0550-3213(95)00126-D",
-     SLACcitation  = "%%CITATION = HEP-LAT/9411010;%%"
-}
-@Article{McNeile:2000hf,
-     author    = "McNeile, C. and Michael, C.",
-     collaboration = "UKQCD",
-     title     = "The eta and eta' mesons in {QCD}",
-     journal   = "Phys. Lett.",
-     volume    = "B491",
-     year      = "2000",
-     pages     = "123-129",
-     eprint    = "hep-lat/0006020",
-     SLACcitation  = "%%CITATION = HEP-LAT 0006020;%%"
-}
-@Article{McNeile:2000xx,
-     author    = "McNeile, Craig and Michael, Chris",
-     collaboration = "UKQCD",
-     title     = "Mixing of scalar glueballs and flavour-singlet scalar
-                  mesons",
-     journal   = "Phys. Rev.",
-     volume    = "D63",
-     year      = "2001",
-     pages     = "114503",
-     eprint    = "hep-lat/0010019",
-     SLACcitation  = "%%CITATION = HEP-LAT0010019;%%"
-}
-@Article{McNeile:2001cr,
-     author    = "McNeile, C. and Michael, C. and Sharkey, K. J.",
- collaboration = "UKQCD",
-     title     = "The flavor singlet mesons in {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D65",
-     year      = "2002",
-     pages     = "014508",
-     eprint    = "hep-lat/0107003",
-     SLACcitation  = "%%CITATION = HEP-LAT 0107003;%%"
-}
-@Article{McNeile:2002fh,
-     author    = "McNeile, C. and Michael, C.",
- collaboration = "UKQCD",
-     title     = "Hadronic decay of a vector meson from the lattice",
-     journal   = "Phys. Lett.",
-     volume    = "B556",
-     year      = "2003",
-     pages     = "177-184",
-     eprint    = "hep-lat/0212020",
-     SLACcitation  = "%%CITATION = HEP-LAT 0212020;%%"
-}
-@Article{McNeile:2006bz,
-     author    = "McNeile, C. and Michael, C.",
-     collaboration = "UKQCD",
-     title     = "Decay width of light quark hybrid meson from the lattice",
-     journal   = "Phys. Rev.",
-     volume    = "D73",
-     year      = "2006",
-     pages     = "074506",
-     eprint    = "hep-lat/0603007",
-     SLACcitation  = "%%CITATION = HEP-LAT 0603007;%%"
-}
-@Article{Meyer:2006ty,
-     author    = "Meyer, Harvey B. and others",
-     title     = "{Exploring the HMC trajectory-length dependence of
-                  autocorrelation times in lattice QCD}",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "176",
-     year      = "2007",
-     pages     = "91-97",
-     eprint    = "hep-lat/0606004",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/j.cpc.2006.08.002",
-     SLACcitation  = "%%CITATION = HEP-LAT/0606004;%%"
-}
-@Article{Michael:1982gb,
-     author    = "Michael, C. and Teasdale, I.",
-     title     = "EXTRACTING GLUEBALL MASSES FROM LATTICE QCD",
-     journal   = "Nucl. Phys.",
-     volume    = "B215",
-     year      = "1983",
-     pages     = "433",
-     SLACcitation  = "%%CITATION = NUPHA,B215,433;%%"
-}
-@Article{Michael:1989mf,
-     author    = "Michael, C.",
-     title     = "Particle decay in lattice gauge theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B327",
-     year      = "1989",
-     pages     = "515",
-     SLACcitation  = "%%CITATION = NUPHA,B327,515;%%"
-}
-@Article{Michael:1991nc,
-     author    = "Michael, C.",
-     title     = "Hadronic forces from the lattice",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "26",
-     year      = "1992",
-     pages     = "417-419",
-     SLACcitation  = "%%CITATION = NUPHZ,26,417;%%"
-}
-@Article{Michael:1993yj,
-     author    = "Michael, Christopher",
-     title     = "{Fitting correlated data}",
-     journal   = "Phys. Rev.",
-     volume    = "D49",
-     year      = "1994",
-     pages     = "2616-2619",
-     eprint    = "hep-lat/9310026",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.49.2616",
-     SLACcitation  = "%%CITATION = HEP-LAT/9310026;%%"
-}
-@Article{Michael:1994sz,
-     author    = "Michael, Christopher and McKerrell, A.",
-     title     = "{Fitting correlated hadron mass spectrum data}",
-     journal   = "Phys. Rev.",
-     volume    = "D51",
-     year      = "1995",
-     pages     = "3745-3750",
-     eprint    = "hep-lat/9412087",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.51.3745",
-     SLACcitation  = "%%CITATION = HEP-LAT/9412087;%%"
-}
-@Article{Michael:2007vn,
-     author    = "Michael, C. and Urbach, C.",
- collaboration = "ETM",
-     title     = "Neutral mesons and disconnected diagrams in Twisted Mass
-                  QCD",
-     journal   = "",
-     volume    = "",
-     pages     = "",
-     year      = "2007",
-     eprint    = "0709.4564",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = ARXIV:0709.4564;%%"
-}
-@Book{Montvay:1994cy,
-     author    = "Montvay, I. and M{\"u}nster, G.",
-     title     = "Quantum fields on a lattice",
-     publisher = "Cambridge University Press",
-     year      = "1994",
-     series    = "Cambridge Monographs on Mathematical Physics",
-}
-@Article{Montvay:1995ea,
-     author    = "Montvay, I.",
-     title     = "An Algorithm for Gluinos on the Lattice",
-     journal   = "Nucl. Phys.",
-     volume    = "B466",
-     year      = "1996",
-     pages     = "259-284",
-     eprint    = "hep-lat/9510042",
-     SLACcitation  = "%%CITATION = HEP-LAT 9510042;%%"
-}
-@Article{Montvay:2005tj,
-     author    = "Montvay, I. and Scholz, E.",
-     title     = "Updating algorithms with multi-step stochastic correction",
-     journal   = "Phys. Lett.",
-     volume    = "B623",
-     year      = "2005",
-     pages     = "73-79",
-     eprint    = "hep-lat/0506006",
-     SLACcitation  = "%%CITATION = HEP-LAT 0506006;%%"
-}
-@Article{Morgan:2002a,
-  author       = "Morgan, R. B.",
-  title        = "GMRES with Deated Restarting",
-  journal      = "SIAM J. Sci. Comput.",
-  volume       = "24",
-  year         = "2002",
-  pages        = "20"
-}
-@Article{Morningstar:2003gk,
-     author    = "Morningstar, Colin and Peardon, Mike J.",
-     title     = "{Analytic smearing of SU(3) link variables in lattice
-                  QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D69",
-     year      = "2004",
-     pages     = "054501",
-     eprint    = "hep-lat/0311018",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.69.054501",
-     SLACcitation  = "%%CITATION = HEP-LAT/0311018;%%"
-}
-@Article{Munster:2004am,
-     author    = "M{\"u}nster, G.",
-     title     = "On the phase structure of twisted mass lattice {QCD}",
-     journal   = "JHEP",
-     volume    = "09",
-     year      = "2004",
-     pages     = "035",
-     eprint    = "hep-lat/0407006",
-     SLACcitation  = "%%CITATION = HEP-LAT 0407006;%%"
-}
-@Article{Munster:2004wt,
-     author    = "M{\"u}nster, Gernot and Schmidt, Christian and Scholz, Enno E.
-                  ",
-     title     = "Chiral perturbation theory for twisted mass {QCD}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "140",
-     year      = "2005",
-     pages     = "320-322",
-     eprint    = "hep-lat/0409066",
-     SLACcitation  = "%%CITATION = HEP-LAT 0409066;%%"
-}   
-@Article{Nagai:2005mi,
-     author    = "Nagai, Kei-ichi and Jansen, Karl",
-     title     = "Two-dimensional lattice Gross-Neveu model with Wilson
-                  twisted mass  fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B633",
-     year      = "2006",
-     pages     = "325-330",
-     eprint    = "hep-lat/0510076",
-     SLACcitation  = "%%CITATION = HEP-LAT 0510076;%%"
-}
-@Unpublished{Nagai:priv,
-  author = 	 {Nagai, K},
-  title = 	 {Two-dimensional Gross-Neveu model with {Wilson}
-                  twisted mass fermions},
-  note = 	 {private communication},
-  OPTkey = 	 {},
-  OPTmonth = 	 {},
-  OPTyear = 	 {},
-  OPTannote = 	 {}
-}
-@Article{Necco:2001xg,
-     author    = "Necco, S. and Sommer, R.",
-     title     = "The {N(f)} = 0 heavy quark potential from short to
-                  intermediate  distances",
-     journal   = "Nucl. Phys.",
-     volume    = "B622",
-     year      = "2002",
-     pages     = "328-346",
-     eprint    = "hep-lat/0108008",
-     SLACcitation  = "%%CITATION = HEP-LAT 0108008;%%"
-}
-@Article{Necco:2003vh,
-     author    = "Necco, Silvia",
-     journal   = "Nucl. Phys.",
-     volume    = "B683",
-     year      = "2004",
-     pages     = "137-167",
-     eprint    = "hep-lat/0309017",
-     SLACcitation  = "%%CITATION = HEP-LAT 0309017;%%"
-}
-@Article{Neff:2001zr,
-     author    = "Neff, H. and Eicker, N. and Lippert, T. and Negele, J. W.
-                  and Schilling, K.",
-     title     = "On the low fermionic eigenmode dominance in {QCD} on the
-                  lattice",
-     journal   = "Phys. Rev.",
-     volume    = "D64",
-     year      = "2001",
-     pages     = "114509",
-     eprint    = "hep-lat/0106016",
-     SLACcitation  = "%%CITATION = HEP-LAT/0106016;%%"
-}
-@Article{Neuberger:1997fp,
-     author    = "Neuberger, H.",
-     title     = "Exactly massless quarks on the lattice",
-     journal   = "Phys. Lett.",
-     volume    = "B417",
-     year      = "1998",
-     pages     = "141-144",
-     eprint    = "hep-lat/9707022",
-     SLACcitation  = "%%CITATION = HEP-LAT 9707022;%%"
-}
-@Article{Neuberger:1998wv,
-     author    = "Neuberger, H.",
-     title     = "More about exactly massless quarks on the lattice",
-     journal   = "Phys. Lett.",
-     volume    = "B427",
-     year      = "1998",
-     pages     = "353-355",
-     eprint    = "hep-lat/9801031",
-     SLACcitation  = "%%CITATION = HEP-LAT 9801031;%%"
-}
-@Article{Niedermayer:1998bi,
-     author    = "Niedermayer, F.",
-     title     = "Exact chiral symmetry, topological charge and related
-                  topics",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "73",
-     year      = "1999",
-     pages     = "105-119",
-     eprint    = "hep-lat/9810026",
-     SLACcitation  = "%%CITATION = HEP-LAT 9810026;%%"
-}
-@Article{Nielsen:1980rz,
-     author    = "Nielsen, H. B. and Ninomiya, M.",
-     title     = "Absence of neutrinos on a lattice. 1. proof by homotopy
-                  theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B185",
-     year      = "1981",
-     pages     = "20",
-     SLACcitation  = "%%CITATION = NUPHA,B185,20;%%"
-}
-@Article{Nielsen:1981hk,
-     author    = "Nielsen, H. B. and Ninomiya, M.",
-     title     = "No go theorem for regularizing chiral fermions",
-     journal   = "Phys. Lett.",
-     volume    = "B105",
-     year      = "1981",
-     pages     = "219",
-     SLACcitation  = "%%CITATION = PHLTA,B105,219;%%"
-}
-@Article{Nielsen:1981xu,
-     author    = "Nielsen, H. B. and Ninomiya, M.",
-     title     = "Absence of neutrinos on a lattice. 2. intuitive topological
-                  proof",
-     journal   = "Nucl. Phys.",
-     volume    = "B193",
-     year      = "1981",
-     pages     = "173",
-     SLACcitation  = "%%CITATION = NUPHA,B193,173;%%"
-}
-@Article{Noaki:1998zc,
-     author    = "Noaki, J. and Izubuchi, T. and Ukawa, A.",
-     title     = "Two-dimensional Gross-Neveu model with {Wilson} fermion
-                  action at finite temperature and density",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "73",
-     year      = "1999",
-     pages     = "483-485",
-     eprint    = "hep-lat/9809071",
-     SLACcitation  = "%%CITATION = HEP-LAT 9809071;%%"
-}
-@Article{Orginos:2001xa,
-     author    = "Orginos, K.",
- collaboration = "RBC",
-     title     = "Chiral properties of domain wall fermions with improved
-                  gauge actions",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "721-723",
-     eprint    = "hep-lat/0110074",
-     SLACcitation  = "%%CITATION = HEP-LAT 0110074;%%"
-}
-@Article{Orth:2005kq,
-     author    = "Orth, B. and Lippert, T. and Schilling, K.",
-     title     = "Finite-size effects in lattice {QCD} with dynamical {Wilson}
-                  fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D72",
-     year      = "2005",
-     pages     = "014503",
-     eprint    = "hep-lat/0503016",
-     SLACcitation  = "%%CITATION = HEP-LAT 0503016;%%"
-}
-@Article{Osterwalder:1973dx,
-     author    = "Osterwalder, K. and Schrader, R.",
-     title     = "Axioms for euclidean Green's functions",
-     journal   = "Commun. Math. Phys.",
-     volume    = "31",
-     year      = "1973",
-     pages     = "83-112",
-     SLACcitation  = "%%CITATION = CMPHA,31,83;%%"
-}
-@Article{Osterwalder:1975tc,
-     author    = "Osterwalder, K. and Schrader, R.",
-     title     = "Axioms for euclidean Green's functions. 2",
-     journal   = "Commun. Math. Phys.",
-     volume    = "42",
-     year      = "1975",
-     pages     = "281",
-     SLACcitation  = "%%CITATION = CMPHA,42,281;%%"
-}
-@Article{Osterwalder:1977pc,
-     author    = "Osterwalder, K. and Seiler, E.",
-     title     = "Gauge field theories on the lattice",
-     journal   = "Ann. Phys.",
-     volume    = "110",
-     year      = "1978",
-     pages     = "440",
-     SLACcitation  = "%%CITATION = APNYA,110,440;%%"
-}
-@Article{PDBook,
-     author = "Eidelman, S. and others",
-     title = "{Review of Particle Physics}",
-     journal = "{Physics Letters B}",
-     year = "2004",
-     volume = "592",
-     pages = {1+},
-     url = {http://pdg.lbl.gov}
-}
-@Article{Peardon:2002wb,
-     author    = "Peardon, M. J. and Sexton, J.",
- collaboration = "TrinLat",
-     title     = "Multiple molecular dynamics time-scales in hybrid Monte
-                  Carlo fermion simulations",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "119",
-     year      = "2003",
-     pages     = "985-987",
-     eprint    = "hep-lat/0209037",
-     SLACcitation  = "%%CITATION = HEP-LAT 0209037;%%"
-}
-@Book{Peskin:1995ev,
-  author = 	 {Peskin, M. E. and Schroeder, D. V.},
-  title = 	 {An Introduction to quantum field theory},
-  publisher = 	 {Westview Press},
-  year = 	 {1995},
-  OPTkey = 	 {},
-  OPTvolume = 	 {},
-  OPTnumber = 	 {},
-  OPTseries = 	 {Advanced Book Program},
-  OPTaddress = 	 {Boulder, Colorado},
-  OPTedition = 	 {},
-  OPTmonth = 	 {},
-  OPTnote = 	 {},
-  OPTannote = 	 {}
-}
-@Article{Politzer:1973fx,
-     author    = "Politzer, H. D.",
-     title     = "Reliable perturbative results for strong interactions?",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "30",
-     year      = "1973",
-     pages     = "1346-1349",
-     SLACcitation  = "%%CITATION = PRLTA,30,1346;%%"
-}
-@Article{Politzer:1974fr,
-     author    = "Politzer, H. D.",
-     title     = "Asymptotic freedom: an approach to strong interactions",
-     journal   = "Phys. Rept.",
-     volume    = "14",
-     year      = "1974",
-     pages     = "129-180",
-     SLACcitation  = "%%CITATION = PRPLC,14,129;%%"
-}
-@Manual{R:2005,
-    title = {R: A language and environment for statistical computing},
-    author = {{R Development Core Team}},
-    organization = {R Foundation for Statistical Computing},
-    address = {Vienna, Austria},
-    year = {2005},
-    note = {{ISBN} 3-900051-07-0},
-    url = {http://www.R-project.org},
+@article{Garron:2003cb,
+	author = "Garron, N. and Giusti, L. and Hoelbling, C. and Lellouch, L. and Rebbi, C.",
+	eprint = "hep-ph/0306295",
+	journal = "Phys. Rev. Lett.",
+	pages = "042001",
+	slaccitation = "%\%CITATION = HEP-PH 0306295;\%\%",
+	title = "{B(K) from quenched {QCD} with exact chiral symmetry}",
+	volume = "92",
+	year = "2004"
 }
 
-@Book{Rothe:1992wy,
-     author    = "Rothe, H.J.",
-     title     = "Lattice gauge theories",
-     publisher = "World Scientific, Singapore",
-     year      = "1992",
-     pages     = "528",
-     edition   = "",
-}
-@Article{Rupak:2002sm,
-     author    = "Rupak, G. and Shoresh, N.",
-     title     = "Chiral perturbation theory for the {Wilson} lattice action",
-     journal   = "Phys. Rev.",
-     volume    = "D66",
-     year      = "2002",
-     pages     = "054503",
-     eprint    = "hep-lat/0201019",
-     SLACcitation  = "%%CITATION = HEP-LAT 0201019;%%"
+@article{Gasser:1982ap,
+	author = "Gasser, J. and Leutwyler, H.",
+	journal = "Phys. Rept.",
+	pages = "77--169",
+	slaccitation = "%\%CITATION = PRPLC,87,77;\%\%",
+	title = "{Quark masses}",
+	volume = "87",
+	year = "1982"
 }
 
-@Article{Saad:1993a,
-  author  = "Saad, Y.",
-  title   = "A flexible inner-outer preconditioned GMRES altorithm",
-  journal = "SIAM J. Sci. Comput.",
-  volume  = "14 (2)",
-  year    = "1993",
-  page    = "461-469"  
-}
-@Article{Sachrajda:2004mi,
-     author    = "Sachrajda, C. T. and Villadoro, G.",
-     title     = "{Twisted boundary conditions in lattice simulations}",
-     journal   = "Phys. Lett.",
-     volume    = "B609",
-     year      = "2005",
-     pages     = "73-85",
-     eprint    = "hep-lat/0411033",
-     archivePrefix = "arXiv",
-     doi       = "10.1016/j.physletb.2005.01.033",
-     SLACcitation  = "%%CITATION = HEP-LAT/0411033;%%"
-}
-@Article{Scorzato:2004da,
-     author    = "Scorzato, L.",
-     title     = "Pion mass splitting and phase structure in twisted mass
-                  {QCD}",
-     journal   = "Eur. Phys. J.",
-     volume    = "C37",
-     year      = "2004",
-     pages     = "445-455",
-     eprint    = "hep-lat/0407023",
-     SLACcitation  = "%%CITATION = HEP-LAT 0407023;%%"
-}
-@Article{Scorzato:2005rb,
-     author    = "Scorzato, L. and others",
-     title     = "N(f) = 2 lattice {QCD} and chiral perturbation theory",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "153",
-     year      = "2006",
-     pages     = "283-290",
-     eprint    = "hep-lat/0511036",
-     SLACcitation  = "%%CITATION = HEP-LAT 0511036;%%"
+@article{Gasser:1983yg,
+	author = "Gasser, J. and Leutwyler, H.",
+	journal = "Ann. Phys.",
+	pages = "142",
+	slaccitation = "%\%CITATION = APNYA,158,142;\%\%",
+	title = "{Chiral perturbation theory to one loop}",
+	volume = "158",
+	year = "1984"
 }
 
-@Article{Sexton:1992nu,
-     author    = "Sexton, J. C. and Weingarten, D. H.",
-     title     = "Hamiltonian evolution for the hybrid monte carlo
-                  algorithm",
-     journal   = "Nucl. Phys.",
-     volume    = "B380",
-     year      = "1992",
-     pages     = "665-678",
-     SLACcitation  = "%%CITATION = NUPHA,B380,665;%%"
+@article{Gasser:1985gg,
+	author = "Gasser, J. and Leutwyler, H.",
+	journal = "Nucl. Phys.",
+	pages = "465",
+	slaccitation = "%\%CITATION = NUPHA,B250,465;\%\%",
+	title = "{Chiral perturbation theory: expansions in the mass of the strange quark}",
+	volume = "B250",
+	year = "1985"
 }
 
-@Article{Sharpe:1998xm,
-     author    = "Sharpe, S. R. and Singleton, R., Jr.",
-     title     = "Spontaneous flavor and parity breaking with {Wilson}
-                  fermions",
-     journal   = "Phys. Rev.",
-     volume    = "D58",
-     year      = "1998",
-     pages     = "074501",
-     eprint    = "hep-lat/9804028",
-     SLACcitation  = "%%CITATION = HEP-LAT 9804028;%%"
+@article{Gasser:1986vb,
+	author = "Gasser, J. and Leutwyler, H.",
+	journal = "Phys. Lett.",
+	pages = "83",
+	slaccitation = "%\%CITATION = PHLTA,B184,83;\%\%",
+	title = "{LIGHT QUARKS AT LOW TEMPERATURES}",
+	volume = "B184",
+	year = "1987"
 }
 
-@Article{Sharpe:2004ny,
-     author    = "Sharpe, S. R. and Wu, Jackson M. S.",
-     title     = "Twisted mass chiral perturbation theory at next-to-leading
-                  order",
-     journal   = "Phys. Rev.",
-     volume    = "D71",
-     year      = "2005",
-     pages     = "074501",
-     eprint    = "hep-lat/0411021",
-     SLACcitation  = "%%CITATION = HEP-LAT 0411021;%%"
+@article{Gattringer:2003qx,
+	author = "Gattringer, C. and others",
+	collaboration = "BGR",
+	eprint = "hep-lat/0307013",
+	journal = "Nucl. Phys.",
+	pages = "3--51",
+	slaccitation = "%\%CITATION = HEP-LAT 0307013;\%\%",
+	title = "{Quenched spectroscopy with fixed-point and chirally improved fermions}",
+	volume = "B677",
+	year = "2004"
 }
-@Article{Sharpe:2004ps,
-     author    = "Sharpe, S. R. and Wu, J. M. S.",
-     title     = "The phase diagram of twisted mass lattice {QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "094029",
-     eprint    = "hep-lat/0407025",
-     SLACcitation  = "%%CITATION = HEP-LAT 0407025;%%"
+
+@article{Gell-Mann:1964nj,
+	author = "Gell-Mann, M.",
+	journal = "Phys. Lett.",
+	pages = "214--215",
+	slaccitation = "%\%CITATION = PHLTA,8,214;\%\%",
+	title = "{A Schematic model of baryons and mesons}",
+	volume = "8",
+	year = "1964"
 }
-@Article{Sharpe:2005rq,
-     author    = "Sharpe, Stephen R.",
-     title     = "Observations on discretization errors in twisted-mass
-                  lattice QCD",
-     journal   = "Phys. Rev.",
-     volume    = "D72",
-     year      = "2005",
-     pages     = "074510",
-     eprint    = "hep-lat/0509009",
-     SLACcitation  = "%%CITATION = HEP-LAT 0509009;%%"
+
+@article{Gell-Mann:1968rz,
+	author = "Gell-Mann, M. and Oakes, R. J. and Renner, B.",
+	journal = "Phys. Rev.",
+	pages = "2195--2199",
+	slaccitation = "%\%CITATION = PHRVA,175,2195;\%\%",
+	title = "{Behavior of current divergences under SU(3) x SU(3)}",
+	volume = "175",
+	year = "1968"
 }
-@Article{Sheikholeslami:1985ij,
-     author    = "Sheikholeslami, B. and Wohlert, R.",
-     title     = "Improved continuum limit lattice action for qcd with {Wilson}
-                  fermions",
-     journal   = "Nucl. Phys.",
-     volume    = "B259",
-     year      = "1985",
-     pages     = "572",
-     SLACcitation  = "%%CITATION = NUPHA,B259,572;%%"
+
+@phdthesis{Geus:2002,
+	author = "Geus, R.",
+	optaddress = "",
+	optannote = "",
+	optkey = "DISS. ETH NO. 14734",
+	optmonth = "",
+	optnote = "",
+	opttype = "",
+	school = "Swiss Federal Institute Of Technology Z{\"u}rich",
+	title = "{The Jacobi-Davidson algorithm for solving large sparse symmetric eigenvalue problems with application to the design of accelerator cavities}",
+	year = "2002"
 }
-@Article{Shindler:2005vj,
-     author    = "Shindler, Andrea",
-     title     = "Twisted mass lattice {QCD}: Recent developments and results",
-     journal   = "PoS",
-     volume    = "LAT2005",
-     year      = "2006",
-     pages     = "014",
-     eprint    = "hep-lat/0511002",
-     SLACcitation  = "%%CITATION = HEP-LAT 0511002;%%"
+
+@article{Gimenez:1998ue,
+	author = "Gimenez, V. and Giusti, L. and Rapuano, F. and Talevi, M.",
+	eprint = "hep-lat/9806006",
+	journal = "Nucl. Phys.",
+	pages = "429--445",
+	slaccitation = "%\%CITATION = HEP-LAT 9806006;\%\%",
+	title = "{Non-perturbative renormalization of quark bilinears}",
+	volume = "B531",
+	year = "1998"
 }
-@Article{Shindler:2006tm,
-     author    = "Shindler, A.",
- collaboration = "ETM",
-     title     = "Lattice QCD with light twisted quarks: First results",
-     year      = "2006",
-     eprint    = "hep-ph/0611264",
-     SLACcitation  = "%%CITATION = HEP-PH 0611264;%%"
+
+@article{Gimenez:2005nt,
+	author = "Gimenez, V. and Lubicz, V. and Mescia, F. and Porretti, V. and Reyes, J.",
+	eprint = "hep-lat/0503001",
+	journal = "Eur. Phys. J.",
+	pages = "535--544",
+	slaccitation = "%\%CITATION = HEP-LAT/0503001;\%\%",
+	title = "{Operator product expansion and quark condensate from lattice QCD in coordinate space}",
+	volume = "C41",
+	year = "2005"
 }
-@Article{Shindler:2007vp,
-     author    = "Shindler, A.",
-     title     = "{Twisted mass lattice QCD}",
-     journal   = "Phys. Rept.",
-     volume    = "461",
-     year      = "2008",
-     pages     = "37-110",
-     eprint    = "0707.4093",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     doi       = "10.1016/j.physrep.2008.03.001",
-     SLACcitation  = "%%CITATION = 0707.4093;%%"
+
+@article{Ginsparg:1981bj,
+	author = "Ginsparg, P. H. and {Wilson}, K. G.",
+	journal = "Phys. Rev.",
+	pages = "2649",
+	slaccitation = "%\%CITATION = PHRVA,D25,2649;\%\%",
+	title = "{A remnant of chiral symmetry on the lattice}",
+	volume = "D25",
+	year = "1982"
 }
-@Article{Sleijpen:1996aa,
-     author    = "G. L. G. Sleijpen and H. A. Van der Vorst",
-     title     = "A Jacobi-Davidson iteration method for linear 
-                  eigenvalue problems",
-     journal   = "SIAM Journal on Matrix Analysis and Applications",
-     volume    = "17",
-     year      = "1996",
-     pages     = "401-425",
+
+@article{Giusti:1998wy,
+	author = "Giusti, L. and Rapuano, F. and Talevi, M. and Vladikas, A.",
+	eprint = "hep-lat/9807014",
+	journal = "Nucl. Phys.",
+	pages = "249--277",
+	slaccitation = "%\%CITATION = HEP-LAT 9807014;\%\%",
+	title = "{The QCD chiral condensate from the lattice}",
+	volume = "B538",
+	year = "1999"
 }
-@Article{Sommer:1993ce,
-     author    = "Sommer, R.",
-     title     = "A New way to set the energy scale in lattice gauge theories
-                  and its applications to the static force and alpha-s in
-                  SU(2) Yang-Mills theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B411",
-     year      = "1994",
-     pages     = "839-854",
-     eprint    = "hep-lat/9310022",
-     SLACcitation  = "%%CITATION = HEP-LAT 9310022;%%"
+
+@article{Giusti:2001pk,
+	author = "Giusti, L. and Hoelbling, C. and Rebbi, C.",
+	eprint = "hep-lat/0108007",
+	journal = "Phys. Rev.",
+	note = "Erratum-ibid.D65:079903,2002",
+	pages = "114508",
+	slaccitation = "%\%CITATION = HEP-LAT 0108007;\%\%",
+	title = "{Light quark masses with overlap fermions in quenched {QCD}}",
+	volume = "D64",
+	year = "2001"
 }
-@Article{Sonneveld:1989cgs,
- author = {Peter Sonneveld},
- title = {CGS, a fast Lanczos-type solver for nonsymmetric linear systems},
- journal = {SIAM J. Sci. Stat. Comput.},
- volume = {10},
- number = {1},
- year = {1989},
- issn = {0196-5204},
- pages = {36--52},
- publisher = {Society for Industrial and Applied Mathematics},
- address = {Philadelphia, PA, USA},
- }
-@Article{Sternbeck:2003gy,
-     author    = "Sternbeck, A. and Ilgenfritz, E.-M. and Kerler, W.
-                  and M{\"u}ller-Preu{\ss}ker, M. and St{\"u}ben, H.",
-     title     = "The {Aoki} phase for {N(f)} = 2 {Wilson} fermions revisited",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "129",
-     year      = "2004",
-     pages     = "898-900",
-     eprint    = "hep-lat/0309059",
-     SLACcitation  = "%%CITATION = HEP-LAT 0309059;%%"
+
+@article{Giusti:2002sm,
+	author = "Giusti, L. and Hoelbling, C. and L{\"u}scher, M. and Wittig, H.",
+	eprint = "hep-lat/0212012",
+	journal = "Comput. Phys. Commun.",
+	pages = "31--51",
+	slaccitation = "%\%CITATION = HEP-LAT 0212012;\%\%",
+	title = "{Numerical techniques for lattice QCD in the epsilon- regime}",
+	volume = "153",
+	year = "2003"
 }
-@Article{Sternbeck:2005tk,
-     author    = "Sternbeck, A. and Ilgenfritz, E. -M. and Mueller-Preussker,
-                  M. and Schiller, A.",
-     title     = "{Going infrared in SU(3) Landau gauge gluodynamics}",
-     journal   = "Phys. Rev.",
-     volume    = "D72",
-     year      = "2005",
-     pages     = "014507",
-     eprint    = "hep-lat/0506007",
-     SLACcitation  = "%%CITATION = HEP-LAT/0506007;%%"
+
+@article{Giusti:2007hk,
+	author = "Giusti, Leonardo",
+	eprint = "hep-lat/0702014",
+	journal = "PoS.",
+	pages = "",
+	slaccitation = "%\%CITATION = HEP-LAT/0702014;\%\%",
+	title = "{Light dynamical fermions on the lattice: Toward the chiral regime of QCD}",
+	volume = "LAT2006",
+	year = "2007"
 }
-@Article{Symanzik:1983dc,
-     author    = "Symanzik, K.",
-     title     = "Continuum limit and improved action in lattice theories. 1.
-                  principles and phi**4 theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B226",
-     year      = "1983",
-     pages     = "187",
-     SLACcitation  = "%%CITATION = NUPHA,B226,187;%%"
+
+@article{Glassner:1996gz,
+	author = "Gl{\"a}ssner, U. and others",
+	eprint = "hep-lat/9605008",
+	slaccitation = "%\%CITATION = HEP-LAT 9605008;\%\%",
+	title = "{How to compute {G}reen's functions for entire mass trajectories within {K}rylov solvers}",
+	year = "1996"
 }
-@Conference{Symanzik:1981hc,
-     author    = "Symanzik, K.",
-     title     = "Some topics in quantum field theory",
-     booktitle = "Mathematical problems in theoretical physics",
-     journal   = "Lecture Notes in Physics",
-     volume    = "153",
-     year      = "1981",
-     pages     = "47-58",
-     editor    = "R. Schrader et al.",
-     note      = "Presented at 6th Int. Conf. on Mathematical Physics,
-                  Berlin, West Germany"
+
+@article{Gockeler:1998fn,
+	author = "G{\"o}ckeler, M. and others",
+	eprint = "hep-lat/9707021",
+	journal = "Phys. Rev.",
+	pages = "5562--5580",
+	slaccitation = "%\%CITATION = HEP-LAT 9707021;\%\%",
+	title = "{Scaling of non-perturbatively {O(a)} improved {Wilson} fermions: Hadron spectrum, quark masses and decay constants}",
+	volume = "D57",
+	year = "1998"
 }
-@Article{Symanzik:1983gh,
-     author    = "Symanzik, K.",
-     title     = "Continuum limit and improved action in lattice theories. 2.
-                  O(N) nonlinear sigma model in perturbation theory",
-     journal   = "Nucl. Phys.",
-     volume    = "B226",
-     year      = "1983",
-     pages     = "205",
-     SLACcitation  = "%%CITATION = NUPHA,B226,205;%%"
+
+@article{Gorishnii:1990vf,
+	author = "Gorishnii, S. G. and Kataev, A. L. and Larin, S. A.",
+	journal = "Phys. Lett.",
+	pages = "144--150",
+	slaccitation = "%\%CITATION = PHLTA,B259,144;\%\%",
+	title = "{The O (alpha-s**3) corrections to sigma-tot (e+ e- $\to$ hadrons) and Gamma (tau- $\to$ tau-neutrino + hadrons) in QCD}",
+	volume = "B259",
+	year = "1991"
 }
-@Article{Takaishi:1996xj,
-     author    = "Takaishi, T.",
-     title     = "Heavy quark potential and effective actions on blocked
-                  configurations",
-     journal   = "Phys. Rev.",
-     volume    = "D54",
-     year      = "1996",
-     pages     = "1050-1053",
-     SLACcitation  = "%%CITATION = PHRVA,D54,1050;%%"
+
+@article{Greenberg:1964pe,
+	author = "Greenberg, O. W.",
+	journal = "Phys. Rev. Lett.",
+	pages = "598--602",
+	slaccitation = "%\%CITATION = PRLTA,13,598;\%\%",
+	title = "{Spin and unitary spin independence in a paraquark model of baryons and mesons}",
+	volume = "13",
+	year = "1964"
 }
-@Article{Takaishi:2005tz,
-     author    = "Takaishi, Tetsuya and de Forcrand, Philippe",
-     title     = "{Testing and tuning new symplectic integrators for hybrid
-                  Monte Carlo  algorithm in lattice QCD}",
-     journal   = "Phys. Rev.",
-     volume    = "E73",
-     year      = "2006",
-     pages     = "036706",
-     eprint    = "hep-lat/0505020",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevE.73.036706",
-     SLACcitation  = "%%CITATION = HEP-LAT/0505020;%%"
+
+@article{Gregory:2007ce,
+	archiveprefix = "arXiv",
+	author = "Gregory, Eric B. and Irving, Alan and Richards, Chris M. and McNeile, Craig and Hart, Alistair",
+	eprint = "0710.1725",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0710.1725;\%\%",
+	title = "{Pseudoscalar Flavor-Singlet Physics with Staggered Fermions}",
+	year = "2007"
 }
-@Article{Takeda:2004xh,
-     author    = "Takeda, S. and others",
-     title     = "A scaling study of the step scaling function in SU(3) gauge
-                  theory with  improved gauge actions",
-     journal   = "Phys. Rev.",
-     volume    = "D70",
-     year      = "2004",
-     pages     = "074510",
-     eprint    = "hep-lat/0408010",
-     SLACcitation  = "%%CITATION = HEP-LAT 0408010;%%"
+
+@article{Gross:1973id,
+	author = "Gross, D. J. and Wilczek, F.",
+	journal = "Phys. Rev. Lett.",
+	pages = "1343--1346",
+	slaccitation = "%\%CITATION = PRLTA,30,1343;\%\%",
+	title = "{Ultraviolet behavior of non-Abelian gauge theories}",
+	volume = "30",
+	year = "1973"
 }
-@Article{Ukawa:2002pc,
-     author    = "Ukawa, A.",
- collaboration = "CP-PACS and JL{QCD}",
-     title     = "Computational cost of full {QCD} simulations experienced by
-                  {CP-PACS and JLQCD Collaborations}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "106",
-     year      = "2002",
-     pages     = "195-196",
-     SLACcitation  = "%%CITATION = NUPHZ,106,195;%%"
+
+@article{Gross:1973ju,
+	author = "Gross, D. J. and Wilczek, F.",
+	journal = "Phys. Rev.",
+	pages = "3633--3652",
+	slaccitation = "%\%CITATION = PHRVA,D8,3633;\%\%",
+	title = "{Asymptotically free gauge theories. 1}",
+	volume = "D8",
+	year = "1973"
 }
-@Article{Urbach:2005ji,
-     author    = "Urbach, C. and Jansen, K. and Shindler, A. and Wenger, U.",
-     title     = "{HMC} algorithm with multiple time scale integration and mass
-                  preconditioning",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "174",
-     year      = "2006",
-     pages     = "87-98",
-     eprint    = "hep-lat/0506011",
-     SLACcitation  = "%%CITATION = HEP-LAT 0506011;%%"
+
+@article{Gross:1974jv,
+	author = "Gross, D. J. and Neveu, A.",
+	journal = "Phys. Rev.",
+	pages = "3235",
+	slaccitation = "%\%CITATION = PHRVA,D10,3235;\%\%",
+	title = "{Dynamical symmetry breaking in asymptotically free field theories}",
+	volume = "D10",
+	year = "1974"
 }
-@Article{Urbach:2007rt,
-     author    = "Urbach, Carsten",
- collaboration = "ETM",
-     title     = "{Lattice QCD with two light Wilson quarks and maximally
-                  twisted mass}",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "022",
-     eprint    = "0710.1517",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0710.1517;%%"
+
+@article{Guagnelli:1998ud,
+	author = "Guagnelli, M. and Sommer, R. and Wittig, H.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/9806005",
+	journal = "Nucl. Phys.",
+	pages = "389--402",
+	slaccitation = "%\%CITATION = HEP-LAT 9806005;\%\%",
+	title = "{Precision computation of a low-energy reference scale in quenched lattice {QCD}}",
+	volume = "B535",
+	year = "1998"
 }
-@Article{WalkerLoud:2005bt,
-     author    = "Walker-Loud, Andre and Wu, Jackson M. S.",
-     title     = "{Nucleon and Delta masses in twisted mass chiral
-                  perturbation theory}",
-     journal   = "Phys. Rev.",
-     volume    = "D72",
-     year      = "2005",
-     pages     = "014506",
-     eprint    = "hep-lat/0504001",
-     archivePrefix = "arXiv",
-     doi       = "10.1103/PhysRevD.72.014506",
-     SLACcitation  = "%%CITATION = HEP-LAT/0504001;%%"
+
+@article{Guagnelli:2004ga,
+	author = "Guagnelli, M. and others",
+	collaboration = "Zeuthen-Rome (ZeRo)",
+	eprint = "hep-lat/0405027",
+	journal = "Eur. Phys. J.",
+	pages = "69--80",
+	slaccitation = "%\%CITATION = HEP-LAT 0405027;\%\%",
+	title = "{Non-perturbative pion matrix element of a twist-2 operator from the lattice}",
+	volume = "C40",
+	year = "2005"
 }
-@Article{Weinberg:1973un,
-     author    = "Weinberg, S.",
-     title     = "Nonabelian gauge theories of the strong interactions",
-     journal   = "Phys. Rev. Lett.",
-     volume    = "31",
-     year      = "1973",
-     pages     = "494-497",
-     SLACcitation  = "%%CITATION = PRLTA,31,494;%%"
+
+@article{Guagnelli:2004ww,
+	author = "Guagnelli, M. and others",
+	collaboration = "Zeuthen-Rome (ZeRo)",
+	eprint = "hep-lat/0403009",
+	journal = "Phys. Lett.",
+	pages = "216--221",
+	slaccitation = "%\%CITATION = HEP-LAT 0403009;\%\%",
+	title = "{Finite size effects of a pion matrix element}",
+	volume = "B597",
+	year = "2004"
 }
-@Article{Weinberg:1978kz,
-     author    = "Weinberg, S.",
-     title     = "Phenomenological Lagrangians",
-     journal   = "Physica",
-     volume    = "A96",
-     year      = "1979",
-     pages     = "327",
-     SLACcitation  = "%%CITATION = PHYSA,A96,327;%%"
+
+@article{Guagnelli:2005zc,
+	author = "Guagnelli, M. and Heitger, J. and Pena, C. and Sint, S. and Vladikas, A.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0505002",
+	journal = "JHEP",
+	pages = "088",
+	slaccitation = "%\%CITATION = HEP-LAT 0505002;\%\%",
+	title = "{Non-perturbative renormalization of left-left four-fermion operators in quenched lattice QCD}",
+	volume = "03",
+	year = "2006"
 }
-@Book{Weinberg:1995mt,
-     author    = "Weinberg, S.",
-     title     = "The Quantum theory of fields. Vol. 1: Foundations",
-     publisher = "Cambridge University Press",
-     year      = "1995",
-     pages     = "609",
+
+@article{Gupta:1988js,
+	author = "Gupta, R. and Kilcup, G. W. and Sharpe, S. R.",
+	journal = "Phys. Rev.",
+	pages = "1278",
+	slaccitation = "%\%CITATION = PHRVA,D38,1278;\%\%",
+	title = "{Tuning the hybrid monte carlo algorithm}",
+	volume = "D38",
+	year = "1988"
 }
-@Article{Weisz:1982zw,
-     author    = "Weisz, P.",
-     title     = "Continuum limit improved lattice action for pure {Yang-Mills}
-                  theory. 1",
-     journal   = "Nucl. Phys.",
-     volume    = "B212",
-     year      = "1983",
-     pages     = "1",
-     SLACcitation  = "%%CITATION = NUPHA,B212,1;%%"
+
+@article{Gupta:1989kx,
+	author = "Gupta, R. and others",
+	journal = "Phys. Rev.",
+	pages = "2072",
+	slaccitation = "%\%CITATION = PHRVA,D40,2072;\%\%",
+	title = "{{QCD} with dynamical {Wilson} fermions}",
+	volume = "D40",
+	year = "1989"
 }
-@Article{Weisz:1983bn,
-     author    = "Weisz, P. and Wohlert, R.",
-     title     = "Continuum limit improved lattice action for pure {Yang-Mills}
-                  theory. 2",
-     journal   = "Nucl. Phys.",
-     volume    = "B236",
-     year      = 1984,
-     pages     = 397,
-     SLACcitation  = "%%CITATION = NUPHA,B236,397;%%"
+
+@article{Gupta:1990ka,
+	author = "Gupta, S. and Irback, A. and Karsch, F. and Petersson, B.",
+	journal = "Phys. Lett.",
+	pages = "437--443",
+	slaccitation = "%\%CITATION = PHLTA,B242,437;\%\%",
+	title = "{The acceptance probability in the hybrid monte carlo method}",
+	volume = "B242",
+	year = "1990"
 }
-@Article{Wennekers:2005wa,
-     author    = "Wennekers, J. and Wittig, H.",
-     title     = "On the renormalized scalar density in quenched QCD",
-     year      = "2005",
-     eprint    = "hep-lat/0507026",
-     SLACcitation  = "%%CITATION = HEP-LAT 0507026;%%"
+
+@article{Gupta:1991sn,
+	author = "Gupta, R. and others",
+	journal = "Phys. Rev.",
+	pages = "3272--3292",
+	slaccitation = "%\%CITATION = PHRVA,D44,3272;\%\%",
+	title = "{{QCD} with dynamical {Wilson} fermions. 2}",
+	volume = "D44",
+	year = "1991"
 }
-@Article{Weyl:1918ib,
-     author    = "Weyl, H.",
-     title     = "Gravitation und Elektrizit{\"a}t",
-     journal   = "Sitzungsber. Preuss. Akad. Wiss. Berlin (Math. Phys. )",
-     volume    = "1918",
-     year      = "1918",
-     pages     = "465",
-     SLACcitation  = "%%CITATION = SPWPA,1918,465;%%"
+
+@unpublished{Gupta:1997nd,
+	author = "Gupta, R.",
+	eprint = "hep-lat/9807028",
+	note = "Lectures given at Les Houches Summer School in Theoretical Physics, Session 68",
+	slaccitation = "%\%CITATION = HEP-LAT 9807028;\%\%",
+	title = "{Introduction to lattice {QCD}}",
+	year = "1997"
 }
-@Article{Weyl:1929fm,
-     author    = "Weyl, H.",
-     title     = "Electron and gravitation",
-     journal   = "Z. Phys.",
-     volume    = "56",
-     year      = "1929",
-     pages     = "330-352",
-     SLACcitation  = "%%CITATION = ZEPYA,56,330;%%"
+
+@article{Han:1965pf,
+	author = "Han, M. Y. and Nambu, Yoichiro",
+	journal = "Phys. Rev.",
+	pages = "B1006--B1010",
+	slaccitation = "%\%CITATION = PHRVA,139,B1006;\%\%",
+	title = "{Three-triplet model with double SU(3) symmetry}",
+	volume = "139",
+	year = "1965"
 }
-@Article{Wilson:1974sk,
-     author    = "Wilson, K. G.",
-     title     = "Confinement of quarks",
-     journal   = "Phys. Rev.",
-     volume    = "D10",
-     year      = "1974",
-     pages     = "2445-2459",
-     SLACcitation  = "%%CITATION = PHRVA,D10,2445;%%"
+
+@article{Hasenbusch:2001ne,
+	author = "Hasenbusch, M.",
+	eprint = "hep-lat/0107019",
+	journal = "Phys. Lett.",
+	pages = "177--182",
+	slaccitation = "%\%CITATION = HEP-LAT 0107019;\%\%",
+	title = "{Speeding up the {H}ybrid-{M}onte-{C}arlo algorithm for dynamical fermions}",
+	volume = "B519",
+	year = "2001"
 }
-@Article{Wilson:1974sk,
-     author    = "Wilson, K. G.",
-     title     = "Confinement of quarks",
-     journal   = "Phys. Rev.",
-     volume    = "D10",
-     year      = "1974",
-     pages     = "2445-2459",
-     SLACcitation  = "%%CITATION = PHRVA,D10,2445;%%"
+
+@article{Hasenbusch:2002ai,
+	author = "Hasenbusch, M. and Jansen, K.",
+	eprint = "hep-lat/0211042",
+	journal = "Nucl. Phys.",
+	pages = "299--320",
+	slaccitation = "%\%CITATION = HEP-LAT 0211042;\%\%",
+	title = "{Speeding up lattice {QCD} simulations with clover-improved {Wilson} fermions}",
+	volume = "B659",
+	year = "2003"
 }
-@Article{Wilson:1975mb,
-     author    = "Wilson, K. G.",
-     title     = "The renormalization group: Critical phenomena and the kondo
-                  problem",
-     journal   = "Rev. Mod. Phys.",
-     volume    = "47",
-     year      = "1975",
-     pages     = "773",
-     SLACcitation  = "%%CITATION = RMPHA,47,773;%%"
+
+@article{Hasenbusch:2003vg,
+	archiveprefix = "arXiv",
+	author = "Hasenbusch, Martin",
+	doi = "10.1016/S0920-5632(03)02504-0",
+	eprint = "hep-lat/0310029",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "27--33",
+	slaccitation = "%\%CITATION = HEP-LAT/0310029;\%\%",
+	title = "{Full QCD algorithms towards the chiral limit}",
+	volume = "129",
+	year = "2004"
 }
-@Article{Wilson:1975mb,
-     author    = "Wilson, K. G.",
-     title     = "The renormalization group: Critical phenomena and the kondo
-                  problem",
-     journal   = "Rev. Mod. Phys.",
-     volume    = "47",
-     year      = "1975",
-     pages     = "773",
-     SLACcitation  = "%%CITATION = RMPHA,47,773;%%"
+
+@article{Hasenfratz:1998jp,
+	author = "Hasenfratz, P.",
+	eprint = "hep-lat/9802007",
+	journal = "Nucl. Phys.",
+	pages = "401--409",
+	slaccitation = "%\%CITATION = HEP-LAT 9802007;\%\%",
+	title = "{Lattice {QCD} without tuning, mixing and current renormalization}",
+	volume = "B525",
+	year = "1998"
 }
-@Article{Wolff:2003sm,
-     author    = "Wolff, U.",
- collaboration = "ALPHA",
-     title     = "Monte Carlo errors with less errors",
-     journal   = "Comput. Phys. Commun.",
-     volume    = "156",
-     year      = "2004",
-     pages     = "143-153",
-     eprint    = "hep-lat/0306017",
-     SLACcitation  = "%%CITATION = HEP-LAT 0306017;%%"
+
+@article{Hasenfratz:1998ri,
+	author = "Hasenfratz, P. and Laliena, V. and Niedermayer, F.",
+	eprint = "hep-lat/9801021",
+	journal = "Phys. Lett.",
+	pages = "125--131",
+	slaccitation = "%\%CITATION = HEP-LAT 9801021;\%\%",
+	title = "{The index theorem in {QCD} with a finite cut-off}",
+	volume = "B427",
+	year = "1998"
 }
-@Article{Yang:1954ek,
-     author    = "Yang, C.-N. and Mills, R. L.",
-     title     = "Conservation of isotopic spin and isotopic gauge
-                  invariance",
-     journal   = "Phys. Rev.",
-     volume    = "96",
-     year      = "1954",
-     pages     = "191-195",
-     SLACcitation  = "%%CITATION = PHRVA,96,191;%%"
+
+@article{Hasenfratz:2001hp,
+	author = "Hasenfratz, A. and Knechtli, F.",
+	eprint = "hep-lat/0103029",
+	journal = "Phys. Rev.",
+	pages = "034504",
+	slaccitation = "%\%CITATION = HEP-LAT 0103029;\%\%",
+	title = "{Flavor symmetry and the static potential with hypercubic blocking}",
+	volume = "D64",
+	year = "2001"
 }
-@Article{Yoshie:2008aw,
-     author    = "Yoshie, Tomoteru",
-     title     = "{Making use of the International Lattice Data Grid}",
-     journal   = "PoS",
-     volume    = "LATTICE2008",
-     year      = "2008",
-     pages     = "019",
-     eprint    = "0812.0849",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0812.0849;%%"
+
+@article{Hasenfratz:2001tw,
+	author = "Hasenfratz, A. and Hoffmann, R. and Knechtli, F.",
+	eprint = "hep-lat/0110168",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "418--420",
+	slaccitation = "%\%CITATION = HEP-LAT 0110168;\%\%",
+	title = "{The static potential with hypercubic blocking}",
+	volume = "106",
+	year = "2002"
 }
-@Article{Zweig:1964jf,
-     author    = "Zweig, G.",
-     title     = "An SU(3) model for strong interaction symmetry and its
-                  breaking. 2",
-     note     = "CERN-TH-412"
+
+@article{Hashimoto:2008xg,
+	archiveprefix = "arXiv",
+	author = "Hashimoto, Koichi and Izubuchi, Taku",
+	eprint = "0803.0186",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0803.0186;\%\%",
+	title = "{eta' meson from two flavor dynamical domain wall fermions}",
+	year = "2008"
 }
-@Article{cln:web,
-  author = 	 {},
-  eprint =       {http://www.ginac.de/CLN/}
+
+@article{Heitger:2000ay,
+	author = "Heitger, J. and Sommer, R. and Wittig, H.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0006026",
+	journal = "Nucl. Phys.",
+	note = "and references therein",
+	pages = "377--399",
+	slaccitation = "%\%CITATION = HEP-LAT 0006026;\%\%",
+	title = "{Effective chiral Lagrangians and lattice {{QCD}}}",
+	volume = "B588",
+	year = "2000"
 }
-@Article{deForcrand:1995bs,
-     author    = "de Forcrand, P.",
-     title     = "Progress on lattice {QCD} algorithms",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "47",
-     year      = "1996",
-     pages     = "228-235",
-     eprint    = "hep-lat/9509082",
-     SLACcitation  = "%%CITATION = HEP-LAT 9509082;%%"
+
+@article{Hernandez:1998et,
+	author = "Hernandez, P. and Jansen, K. and L{\"u}scher, M.",
+	eprint = "hep-lat/9808010",
+	journal = "Nucl. Phys.",
+	pages = "363--378",
+	slaccitation = "%\%CITATION = HEP-LAT 9808010;\%\%",
+	title = "{Locality properties of Neuberger's lattice Dirac operator}",
+	volume = "B552",
+	year = "1999"
 }
-@Article{deForcrand:1996bx,
-     author    = "de Forcrand, P. and others",
- collaboration = "{QCD}-TARO",
-     title     = "Search for effective lattice action of pure {QCD}",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "53",
-     year      = "1997",
-     pages     = "938-941",
-     eprint    = "hep-lat/9608094",
-     SLACcitation  = "%%CITATION = HEP-LAT 9608094;%%"
+
+@article{Hernandez:2000sb,
+	author = "Hernandez, P. and Jansen, K. and Lellouch, L.",
+	eprint = "hep-lat/0001008",
+	slaccitation = "%\%CITATION = HEP-LAT 0001008;\%\%",
+	title = "{A numerical treatment of Neuberger's lattice Dirac operator}",
+	year = "2000"
 }
-@Article{deForcrand:1996ck,
-     author    = "de Forcrand, P. and Takaishi, T.",
-     title     = "Fast fermion Monte Carlo",
-     journal   = "Nucl. Phys. Proc. Suppl.",
-     volume    = "53",
-     year      = "1997",
-     pages     = "968-970",
-     eprint    = "hep-lat/9608093",
-     SLACcitation  = "%%CITATION = HEP-LAT 9608093;%%"
+
+@article{Hernandez:2001hq,
+	author = "Hernandez, P. and Jansen, K. and Lellouch, L. and Wittig, H.",
+	eprint = "hep-lat/0110199",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "766--771",
+	slaccitation = "%\%CITATION = HEP-LAT 0110199;\%\%",
+	title = "{Scalar condensate and light quark masses from overlap fermions}",
+	volume = "106",
+	year = "2002"
 }
-@Article{etmc:asqr,
-     author    = "Frezzotti, R. et al.",
-     title     = "{O(a^2) cutoff effects in Wilson fermion simulations}",
-     journal   = "PoS",
-     volume    = "LAT2007",
-     year      = "2007",
-     pages     = "277",
-     eprint    = "0710.2492",
-     archivePrefix = "arXiv",
-     primaryClass  =  "hep-lat",
-     SLACcitation  = "%%CITATION = 0710.2492;%%"
+
+@article{Hernandez:2001yn,
+	author = "Hernandez, P. and Jansen, K. and Lellouch, L. and Wittig, H.",
+	eprint = "hep-lat/0106011",
+	journal = "JHEP",
+	pages = "018",
+	slaccitation = "%\%CITATION = HEP-LAT 0106011;\%\%",
+	title = "{Non-perturbative renormalization of the quark condensate in {Ginsparg}-{Wilson} regularizations}",
+	volume = "07",
+	year = "2001"
 }
-@Article{ildg:web,
-  eprint = 	 {http://cssm.sasr.edu.au/ildg/},
-  author =	 {}
+
+@article{Horsley:2004mx,
+	author = "Horsley, R. and Perlt, H. and Rakow, P. E. L. and Schierholz, G. and Schiller, A.",
+	collaboration = "QCDSF",
+	eprint = "hep-lat/0404007",
+	journal = "Nucl. Phys.",
+	pages = "3--35",
+	slaccitation = "%\%CITATION = HEP-LAT 0404007;\%\%",
+	title = "{One-loop renormalisation of quark bilinears for overlap fermions with improved gauge actions}",
+	volume = "B693",
+	year = "2004"
 }
-@Book{kleinert:1,
-     author    = "Kleinert, H.",
-     title     = "Path integrals in quantum mechanics, statistics and polymer ph
-ysics",
-     publisher = "World Scientific, Singapore",
-     year      = "1995",
-     edition   = "2nd Edition",
+
+@article{Ilgenfritz:2003gw,
+	author = "Ilgenfritz, E.-M. and Kerler, W. and M{\"u}ller-Preu{\ss}ker, M. and Sternbeck, A. and St{\"u}ben, H.",
+	eprint = "hep-lat/0309057",
+	journal = "Phys. Rev.",
+	pages = "074511",
+	slaccitation = "%\%CITATION = HEP-LAT 0309057;\%\%",
+	title = "{A numerical reinvestigation of the {Aoki} phase with {N(f)} = 2 {Wilson} fermions at zero temperature}",
+	volume = "D69",
+	year = "2004"
 }
-@Article{lapack:web,
-  author = 	 {},
-  eprint =       {http://www.netlib.org/lapack/}
+
+@article{Ilgenfritz:2006tz,
+	author = "Ilgenfritz, E. -M. and others",
+	eprint = "hep-lat/0610112",
+	slaccitation = "%\%CITATION = HEP-LAT 0610112;\%\%",
+	title = "{Twisted mass QCD thermodynamics: First results on apeNEXT}",
+	year = "2006"
 }
-@Article{lime:web,
-  author = 	 {USQCD},
-  title = 	 {c-lime library},
-  eprint =       {http://usqcd.jlab.org/usqcd-docs/c-lime/}
+
+@article{Iwasaki:1983ck,
+	author = "Iwasaki, Y.",
+	note = "UTHEP-118",
+	title = "{Renormalization group analysis of lattice theories and improved lattice action. 2. four-dimensional nonabelian SU(N) gauge model}"
 }
-@Article{hmc:web,
-  author = 	 {},
-  title = 	 {tmLQCD},
-  eprint =       {http://www.carsten-urbach.eu/}
+
+@article{Iwasaki:1985we,
+	author = "Iwasaki, Y.",
+	journal = "Nucl. Phys.",
+	pages = "141--156",
+	slaccitation = "%\%CITATION = NUPHA,B258,141;\%\%",
+	title = "{Renormalization group analysis of lattice theories and improved lattice action: two-dimensional nonlinear O(N) sigma model}",
+	volume = "B258",
+	year = "1985"
 }
-@Book{meister:1999,
-  author = 	 {Meister, Andreas},
-  title = 	 {Numerik linearer Gleichungssysteme},
-  publisher = 	 {vieweg},
-  year = 	 {1999},
-  OPTkey = 	 {},
-  OPTvolume = 	 {},
-  OPTnumber = 	 {},
-  OPTseries = 	 {},
-  OPTaddress = 	 {},
-  OPTedition = 	 {},
-  OPTmonth = 	 {},
-  OPTnote = 	 {},
-  OPTannote = 	 {}
+
+@article{Iwasaki:1992hn,
+	author = "Iwasaki, Y. and Kanaya, K. and Sakai, S. and Yoshie, T.",
+	eprint = "hep-lat/9211035",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "327--330",
+	slaccitation = "%\%CITATION = HEP-LAT 9211035;\%\%",
+	title = "{Quark confinement in multi - flavor quantum chromodynamics}",
+	volume = "30",
+	year = "1993"
 }
-@Manual{minuit,
-  title = 	 {MINUIT home page},
-  note= {\\seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/home.html}
+
+@article{Izubuchi:1998hy,
+	author = "Izubuchi, T. and Noaki, J. and Ukawa, A.",
+	eprint = "hep-lat/9805019",
+	journal = "Phys. Rev.",
+	pages = "114507",
+	slaccitation = "%\%CITATION = HEP-LAT 9805019;\%\%",
+	title = "{Two-dimensional lattice Gross-Neveu model with {Wilson} fermion action at finite temperature and chemical potential}",
+	volume = "D58",
+	year = "1998"
 }
-@Article{mpi:web,
-  author =       {},
-  title  =       {The message passing interface standard},
-  eprint =       {http://www-unix.mcs.anl.gov/mpi/}
+
+@article{Jacobs:1983ph,
+	author = "Jacobs, L.",
+	journal = "Phys. Rev. Lett.",
+	pages = "172",
+	slaccitation = "%\%CITATION = PRLTA,51,172;\%\%",
+	title = "{Undoubling chirally symmetric lattice fermions}",
+	volume = "51",
+	year = "1983"
 }
-@PhdThesis{orth:2004phd,
-  author = 	 {Orth, B.},
-  title = 	 {Finite size effects in lattice {QCD}
-                  with dynamical {Wilson} fermions},
-  school = 	 {Bergische Universit{\"a}t Wuppertal},
-  year = 	 {2004},
-  OPTkey = 	 {},
-  OPTtype = 	 {},
-  OPTaddress = 	 {},
-  OPTmonth = 	 {},
-  OPTnote = 	 {},
-  OPTannote = 	 {}
+
+@article{Jagels:1994a,
+	author = "Jagels, C. F. and Reichel, L.",
+	journal = "Numer. Linear Algebra Appl.",
+	pages = "555--570",
+	title = "{fast minimal residual algorithm for shifted unitary matrices}",
+	volume = "1(6)",
+	year = "1994"
 }
-@PhdThesis{pleiter:phd,
-  author = 	 {Pleiter, D.},
-  title = 	 {XXX},
-  school = 	 {Freie {U}niversität {B}erlin},
-  year = 	 {2001}
+
+@article{Jagels:1994aa,
+	author = "Jagels, C. F. and Reichel, L.",
+	journal = "Numerical Linear Algebra with Aplications",
+	pages = "555--570",
+	title = "{A Fast Minimal Residual Algorithm for Shifted Unitary Matrices}",
+	volume = "1(6)",
+	year = "1994"
 }
+
+@article{Jansen:1994ym,
+	author = "Jansen, K.",
+	eprint = "hep-lat/9410018",
+	journal = "Phys. Rept.",
+	pages = "1--54",
+	slaccitation = "%\%CITATION = HEP-LAT 9410018;\%\%",
+	title = "{Domain wall fermions and chiral gauge theories}",
+	volume = "273",
+	year = "1996"
+}
+
+@article{Jansen:1995ck,
+	author = "Jansen, Karl and others",
+	eprint = "hep-lat/9512009",
+	journal = "Phys. Lett.",
+	pages = "275--282",
+	slaccitation = "%\%CITATION = HEP-LAT 9512009;\%\%",
+	title = "{Non-perturbative renormalization of lattice QCD at all scales}",
+	volume = "B372",
+	year = "1996"
+}
+
+@article{Jansen:1996cq,
+	author = "Jansen, K. and Liu, C.",
+	eprint = "hep-lat/9607057",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "974--976",
+	slaccitation = "%\%CITATION = HEP-LAT 9607057;\%\%",
+	title = "{Study of Liapunov exponents and the reversibility of molecular dynamics algorithms}",
+	volume = "53",
+	year = "1997"
+}
+
+@article{Jansen:1996xp,
+	author = "Jansen, K.",
+	eprint = "hep-lat/9607051",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "127--133",
+	slaccitation = "%\%CITATION = HEP-LAT 9607051;\%\%",
+	title = "{Recent developments in fermion simulation algorithms}",
+	volume = "53",
+	year = "1997"
+}
+
+@article{Jansen:1997yt,
+	author = "Jansen, K. and Liu, C.",
+	eprint = "hep-lat/9603008",
+	journal = "Comput. Phys. Commun.",
+	pages = "221--234",
+	slaccitation = "%\%CITATION = HEP-LAT 9603008;\%\%",
+	title = "{Implementation of Symanzik's improvement program for simulations of dynamical {Wilson} fermions in lattice {QCD}}",
+	volume = "99",
+	year = "1997"
+}
+
+@article{Jansen:1998mx,
+	author = "Jansen, K. and Sommer, R.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/9803017",
+	journal = "Nucl. Phys.",
+	pages = "185--203",
+	slaccitation = "%\%CITATION = HEP-LAT 9803017;\%\%",
+	title = "{O(alpha) improvement of lattice {QCD} with two flavors of {Wilson} quarks}",
+	volume = "B530",
+	year = "1998"
+}
+
+@article{Jansen:2003ir,
+	author = "Jansen, K. and Shindler, A. and Urbach, C. and Wetzorke, I.",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0312013",
+	journal = "Phys. Lett.",
+	pages = "432--438",
+	slaccitation = "%\%CITATION = HEP-LAT 0312013;\%\%",
+	title = "{Scaling test for {Wilson} twisted mass {QCD}}",
+	volume = "B586",
+	year = "2004"
+}
+
+@article{Jansen:2003jq,
+	author = "Jansen, K. and Nagai, K.-I.",
+	eprint = "hep-lat/0305009",
+	journal = "JHEP",
+	pages = "038",
+	slaccitation = "%\%CITATION = HEP-LAT 0305009;\%\%",
+	title = "{Reducing residual-mass effects for domain-wall fermions}",
+	volume = "12",
+	year = "2003"
+}
+
+@article{Jansen:2003nt,
+	author = "Jansen, K.",
+	eprint = "hep-lat/0311039",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "3--16",
+	slaccitation = "%\%CITATION = HEP-LAT 0311039;\%\%",
+	title = "{Actions for dynamical fermion simulations: Are we ready to go?}",
+	volume = "129",
+	year = "2004"
+}
+
+@article{Jansen:2005cg,
+	author = "Jansen, K. and others",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0507032",
+	journal = "Phys. Lett.",
+	pages = "334--341",
+	slaccitation = "%\%CITATION = HEP-LAT 0507032;\%\%",
+	title = "{Flavour breaking effects of {Wilson} twisted mass fermions}",
+	volume = "B624",
+	year = "2005"
+}
+
+@unpublished{Jansen:2005chi,
+	author = "Jansen, K. and others",
+	collaborations = "\xlf",
+	note = "in preparation",
+	optannote = "",
+	optkey = "",
+	optmonth = "",
+	title = "{}",
+	year = "2005"
+}
+
+@article{Jansen:2005gf,
+	author = "Jansen, K. and Papinutto, M. and Shindler, A. and Urbach, C. and Wetzorke, I.",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0503031",
+	journal = "Phys. Lett.",
+	pages = "184--191",
+	slaccitation = "%\%CITATION = HEP-LAT 0503031;\%\%",
+	title = "{Light quarks with twisted mass fermions}",
+	volume = "B619",
+	year = "2005"
+}
+
+@article{Jansen:2005kk,
+	author = "Jansen, K. and Papinutto, M. and Shindler, A. and Urbach, C. and Wetzorke, I.",
+	collaboration = "\xlf",
+	eprint = "hep-lat/0507010",
+	journal = "JHEP",
+	pages = "071",
+	slaccitation = "%\%CITATION = HEP-LAT 0507010;\%\%",
+	title = "{Quenched scaling of {Wilson} twisted mass fermions}",
+	volume = "09",
+	year = "2005"
+}
+
+@article{Jansen:2005yp,
+	author = "Jansen, Karl and Shindler, Andrea and Urbach, Carsten and Wenger, Urs",
+	eprint = "hep-lat/0510064",
+	journal = "PoS",
+	pages = "118",
+	slaccitation = "%\%CITATION = HEP-LAT 0510064;\%\%",
+	title = "{{HMC} algorithm with multiple time scale integration and mass preconditioning}",
+	volume = "LAT2005",
+	year = "2006"
+}
+
+@article{Jansen:2006ks,
+	author = "Jansen, Karl",
+	eprint = "hep-lat/0609012",
+	slaccitation = "%\%CITATION = HEP-LAT 0609012;\%\%",
+	title = "{Status report on ILDG activities}",
+	year = "2006"
+}
+
+@article{Jansen:2006rf,
+	author = "Jansen, Karl and Urbach, Carsten",
+	collaboration = "ETM",
+	eprint = "hep-lat/0610015",
+	slaccitation = "%\%CITATION = HEP-LAT 0610015;\%\%",
+	title = "{First results with two light flavours of quarks with maximally twisted mass}",
+	year = "2006"
+}
+
+@article{Jansen:2008wv,
+	archiveprefix = "arXiv",
+	author = "Jansen, K. and Michael, C. and Urbach, C.",
+	collaboration = "ETM",
+	eprint = "0804.3871",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0804.3871;\%\%",
+	title = "{The eta' meson from lattice {QCD}}",
+	year = "2008"
+}
+
+@article{Jansen:2008zz,
+	author = "Jansen, K. and Michael, C. and Urbach, C.",
+	doi = "10.1140/epjc/s10052-008-0764-6",
+	journal = "Eur. Phys. J.",
+	pages = "261--269",
+	slaccitation = "%\%CITATION = EPHJA,C58,261;\%\%",
+	title = "{The eta-prime meson from lattice QCD}",
+	volume = "C58",
+	year = "2008"
+}
+
+@unpublished{Jegerlehner:1996pm,
+	author = "Jegerlehner, Beat",
+	eprint = "hep-lat/9612014",
+	note = "unpublished",
+	slaccitation = "%\%CITATION = HEP-LAT 9612014;\%\%",
+	title = "{Krylov space solvers for shifted linear systems}",
+	year = "1996"
+}
+
+@article{Jegerlehner:1997rn,
+	author = "Jegerlehner, B.",
+	eprint = "hep-lat/9708029",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "958--960",
+	slaccitation = "%\%CITATION = HEP-LAT 9708029;\%\%",
+	title = "{Multiple mass solvers}",
+	volume = "63",
+	year = "1998"
+}
+
+@article{Jegerlehner:2003qp,
+	author = "Jegerlehner, F.",
+	eprint = "hep-ph/0310234",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "325--334",
+	slaccitation = "%\%CITATION = HEP-PH 0310234;\%\%",
+	title = "{Theoretical precision in estimates of the hadronic contributions to (g-2)mu and alpha(QED)(M(Z))}",
+	volume = "126",
+	year = "2004"
+}
+
+@article{Jenkins:1990jv,
+	author = "Jenkins, Elizabeth Ellen and Manohar, Aneesh V.",
+	journal = "Phys. Lett.",
+	pages = "558--562",
+	slaccitation = "%\%CITATION = PHLTA,B255,558;\%\%",
+	title = "{Baryon chiral perturbation theory using a heavy fermion Lagrangian}",
+	volume = "B255",
+	year = "1991"
+}
+
+@article{Kaiser:1998ds,
+	author = "Kaiser, Roland and Leutwyler, H.",
+	eprint = "hep-ph/9806336",
+	slaccitation = "%\%CITATION = HEP-PH/9806336;\%\%",
+	title = "{Pseudoscalar decay constants at large N(c)}",
+	year = "1998"
+}
+
+@article{Kalkreuter:1995mm,
+	author = "Kalkreuter, Thomas and Simma, Hubert",
+	eprint = "hep-lat/9507023",
+	journal = "Comput. Phys. Commun.",
+	pages = "33--47",
+	slaccitation = "%\%CITATION = HEP-LAT 9507023;\%\%",
+	title = "{An Accelerated conjugate gradient algorithm to compute low lying eigenvalues: A Study for the Dirac operator in SU(2) lattice QCD}",
+	volume = "93",
+	year = "1996"
+}
+
+@article{Kalkreuter:1996mm,
+	author = "Kalkreuter, T. and Simma, H.",
+	eprint = "hep-lat/9507023",
+	journal = "Comput. Phys. Commun.",
+	pages = "33--47",
+	slaccitation = "%\%CITATION = HEP-LAT 9507023;\%\%",
+	title = "{An Accelerated conjugate gradient algorithm to compute low lying eigenvalues: A Study for the Dirac operator in SU(2) lattice {QCD}}",
+	volume = "93",
+	year = "1996"
+}
+
+@article{Kamleh:2005wg,
+	author = "Kamleh, W. and Peardon, M. J.",
+	collaboration = "TrinLat",
+	journal = "PoS",
+	pages = "106",
+	slaccitation = "%\%CITATION = POSCI,LAT2005,106;\%\%",
+	title = "{Polynomial filtering for HMC in lattice QCD}",
+	volume = "LAT2005",
+	year = "2006"
+}
+
+@article{Kaplan:1992bt,
+	author = "Kaplan, D. B.",
+	eprint = "hep-lat/9206013",
+	journal = "Phys. Lett.",
+	pages = "342--347",
+	slaccitation = "%\%CITATION = HEP-LAT 9206013;\%\%",
+	title = "{A Method for simulating chiral fermions on the lattice}",
+	volume = "B288",
+	year = "1992"
+}
+
+@article{Karsten:1980wd,
+	author = "Karsten, L. H. and Smit, J.",
+	journal = "Nucl. Phys.",
+	pages = "103",
+	slaccitation = "%\%CITATION = NUPHA,B183,103;\%\%",
+	title = "{Lattice fermions: species doubling, chiral invariance, and the triangle anomaly}",
+	volume = "B183",
+	year = "1981"
+}
+
+@article{Kennedy:1990bv,
+	author = "Kennedy, A. D. and Pendleton, B.",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "118--121",
+	slaccitation = "%\%CITATION = NUPHZ,20,118;\%\%",
+	title = "{Acceptances and autocorrelations in hybrid Monte Carlo}",
+	volume = "20",
+	year = "1991"
+}
+
+@article{Knechtli:1998gf,
+	author = "Knechtli, F. and Sommer, R.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/9807022",
+	journal = "Phys. Lett.",
+	pages = "345--352",
+	slaccitation = "%\%CITATION = HEP-LAT 9807022;\%\%",
+	title = "{String breaking in SU(2) gauge theory with scalar matter fields}",
+	volume = "B440",
+	year = "1998"
+}
+
+@article{Knechtli:2000df,
+	author = "Knechtli, F. and Sommer, R.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0005021",
+	journal = "Nucl. Phys.",
+	pages = "309--328",
+	slaccitation = "%\%CITATION = HEP-LAT 0005021;\%\%",
+	title = "{String breaking as a mixing phenomenon in the SU(2) Higgs model}",
+	volume = "B590",
+	year = "2000"
+}
+
+@article{Lacock:1994qx,
+	author = "Lacock, P. and McKerrell, A. and Michael, C. and Stopher, I. M. and Stephenson, P. W.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/9412079",
+	journal = "Phys. Rev.",
+	pages = "6403--6410",
+	slaccitation = "%\%CITATION = HEP-LAT 9412079;\%\%",
+	title = "{Efficient hadronic operators in lattice gauge theory}",
+	volume = "D51",
+	year = "1995"
+}
+
+@article{Lepage:1992xa,
+	author = "Lepage, G. Peter and Mackenzie, Paul B.",
+	eprint = "hep-lat/9209022",
+	journal = "Phys. Rev.",
+	pages = "2250--2264",
+	slaccitation = "%\%CITATION = HEP-LAT 9209022;\%\%",
+	title = "{On the viability of lattice perturbation theory}",
+	volume = "D48",
+	year = "1993"
+}
+
+@article{Lepage:2001ym,
+	archiveprefix = "arXiv",
+	author = "Lepage, G. P. and others",
+	doi = "10.1016/S0920-5632(01)01638-3",
+	eprint = "hep-lat/0110175",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "12--20",
+	slaccitation = "%\%CITATION = HEP-LAT/0110175;\%\%",
+	title = "{Constrained curve fitting}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Lesk:2002gd,
+	author = "Lesk, V. I. and others",
+	collaboration = "CP-PACS",
+	eprint = "hep-lat/0211040",
+	journal = "Phys. Rev.",
+	pages = "074503",
+	slaccitation = "%\%CITATION = HEP-LAT/0211040;\%\%",
+	title = "{Flavor singlet meson mass in the continuum limit in two- flavor lattice QCD}",
+	volume = "D67",
+	year = "2003"
+}
+
+@article{Leutwyler:1997yr,
+	author = "Leutwyler, H.",
+	eprint = "hep-ph/9709408",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "223--231",
+	slaccitation = "%\%CITATION = HEP-PH/9709408;\%\%",
+	title = "{On the 1/N-expansion in chiral perturbation theory}",
+	volume = "64",
+	year = "1998"
+}
+
+@article{Leutwyler:2006qq,
+	author = "Leutwyler, H.",
+	eprint = "hep-ph/0612112",
+	slaccitation = "%\%CITATION = HEP-PH 0612112;\%\%",
+	title = "{pi pi scattering}",
+	year = "2006"
+}
+
+@article{Liu:1997fs,
+	author = "Liu, C. and Jaster, A. and Jansen, K.",
+	eprint = "hep-lat/9708017",
+	journal = "Nucl. Phys.",
+	pages = "603--617",
+	slaccitation = "%\%CITATION = HEP-LAT 9708017;\%\%",
+	title = "{Liapunov exponents and the reversibility of molecular dynamics algorithms}",
+	volume = "B524",
+	year = "1998"
+}
+
+@article{Luscher:1985dn,
+	author = "L{\"u}scher, M.",
+	doi = "10.1007/BF01211589",
+	journal = "Commun. Math. Phys.",
+	pages = "177",
+	slaccitation = "%\%CITATION = CMPHA,104,177;\%\%",
+	title = "{Volume Dependence of the Energy Spectrum in Massive Quantum Field Theories. 1. Stable Particle States}",
+	volume = "104",
+	year = "1986"
+}
+
+@article{Luscher:1990ck,
+	author = "L{\"u}scher, M. and Wolff, U.",
+	journal = "Nucl. Phys.",
+	pages = "222--252",
+	slaccitation = "%\%CITATION = NUPHA,B339,222;\%\%",
+	title = "{How to calculate the elastic scattering matrix in two- dimensional quantum field theories by numerical simulation}",
+	volume = "B339",
+	year = "1990"
+}
+
+@article{Luscher:1993dy,
+	archiveprefix = "arXiv",
+	author = "L{\"u}scher, Martin",
+	doi = "10.1016/0010-4655(94)90232-1",
+	eprint = "hep-lat/9309020",
+	journal = "Comput. Phys. Commun.",
+	pages = "100--110",
+	slaccitation = "%\%CITATION = HEP-LAT/9309020;\%\%",
+	title = "{A Portable high quality random number generator for lattice field theory simulations}",
+	volume = 79,
+	year = 1994
+}
+
+@article{Luscher:1993xx,
+	archiveprefix = "arXiv",
+	author = "L{\"u}scher, Martin",
+	doi = "10.1016/0550-3213(94)90533-9",
+	eprint = "hep-lat/9311007",
+	journal = "Nucl. Phys.",
+	pages = "637--648",
+	slaccitation = "%\%CITATION = HEP-LAT/9311007;\%\%",
+	title = "{A New approach to the problem of dynamical quarks in numerical simulations of lattice {QCD}}",
+	volume = "B418",
+	year = "1994"
+}
+
+@article{Luscher:1993xx,
+	author = "L{\"u}scher, M.",
+	eprint = "hep-lat/9311007",
+	journal = "Nucl. Phys.",
+	pages = "637--648",
+	slaccitation = "%\%CITATION = HEP-LAT 9311007;\%\%",
+	title = "{A New approach to the problem of dynamical quarks in numerical simulations of lattice {QCD}}",
+	volume = "B418",
+	year = "1994"
+}
+
+@article{Luscher:1996sc,
+	author = "L{\"u}scher, M. and Sint, S. and Sommer, R. and Weisz, P.",
+	eprint = "hep-lat/9605038",
+	journal = "Nucl. Phys.",
+	pages = "365--400",
+	slaccitation = "%\%CITATION = HEP-LAT 9605038;\%\%",
+	title = "{Chiral symmetry and {O(a)} improvement in lattice {QCD}}",
+	volume = "B478",
+	year = "1996"
+}
+
+@article{Luscher:1996ug,
+	author = "L{\"u}scher, M. and Sint, S. and Sommer, R. and Weisz, P. and Wolff, U.",
+	eprint = "hep-lat/9609035",
+	journal = "Nucl. Phys.",
+	pages = "323--343",
+	slaccitation = "%\%CITATION = HEP-LAT 9609035;\%\%",
+	title = "{Non-perturbative {O(a)} improvement of lattice {QCD}}",
+	volume = "B491",
+	year = "1997"
+}
+
+@article{Luscher:1998pq,
+	author = "L{\"u}scher, M.",
+	eprint = "hep-lat/9802011",
+	journal = "Phys. Lett.",
+	pages = "342--345",
+	slaccitation = "%\%CITATION = HEP-LAT 9802011;\%\%",
+	title = "{Exact chiral symmetry on the lattice and the {Ginsparg}- {Wilson} relation}",
+	volume = "B428",
+	year = "1998"
+}
+
+@article{Luscher:2001tx,
+	archiveprefix = "arXiv",
+	author = "L{\"u}scher, Martin",
+	doi = "10.1016/S0920-5632(01)01639-5",
+	eprint = "hep-lat/0110007",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "21--28",
+	slaccitation = "%\%CITATION = HEP-LAT/0110007;\%\%",
+	title = "{Lattice QCD on PCs?}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Luscher:2003qa,
+	author = "L{\"u}scher, M.",
+	eprint = "hep-lat/0310048",
+	journal = "Comput. Phys. Commun.",
+	pages = "209--220",
+	slaccitation = "%\%CITATION = HEP-LAT 0310048;\%\%",
+	title = "{Solution of the {D}irac equation in lattice {QCD} using a domain decomposition method}",
+	volume = "156",
+	year = "2004"
+}
+
+@article{Luscher:2004rx,
+	author = "L{\"u}scher, M.",
+	eprint = "hep-lat/0409106",
+	journal = "Comput. Phys. Commun.",
+	pages = "199",
+	slaccitation = "%\%CITATION = HEP-LAT 0409106;\%\%",
+	title = "{Schwarz-preconditioned {HMC} algorithm for two-flavour lattice {QCD}}",
+	volume = "165",
+	year = "2005"
+}
+
+@article{Luscher:2005mv,
+	author = "L{\"u}scher, Martin",
+	eprint = "hep-lat/0509152",
+	howpublished = "Talk presented at International Symposium on Lattice Field Theory (Lattice 2005)",
+	journal = "\href{http://pos.sissa.it/archive/conferences/020/008/LAT2005\_002.pdf}{PoS(LAT2005)002}",
+	slaccitation = "%\%CITATION = HEP-LAT 0509152;\%\%",
+	title = "{Lattice {QCD} with light {W}ilson quarks}",
+	year = "2005"
+}
+
+@article{Luscher:2007es,
+	archiveprefix = "arXiv",
+	author = "L{\"u}scher, Martin",
+	doi = "10.1088/1126-6708/2007/12/011",
+	eprint = "0710.5417",
+	journal = "JHEP",
+	pages = "011",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.5417;\%\%",
+	title = "{Deflation acceleration of lattice {QCD} simulations}",
+	volume = "12",
+	year = "2007"
+}
+
+@article{Luscher:ranluxweb,
+	author = "L{\"u}scher, M.",
+	eprint = "http://luscher.web.cern.ch/luscher/ranlux/",
+	title = "{Ranlux random number generator}"
+}
+
+@article{Luscher:sse,
+	author = "L{\"u}scher, M.",
+	eprint = "http://luscher.web.cern.ch/luscher/QCDpbm/",
+	title = "{Lattice QCD parallel benchmark programs}"
+}
+
+@article{Madras:1988ei,
+	author = "Madras, N. and Sokal, A. D.",
+	journal = "J. Statist. Phys.",
+	pages = "109--186",
+	slaccitation = "%\%CITATION = JSTPB,50,109;\%\%",
+	title = "{The Pivot algorithm: a highly efficient Monte Carlo method for selfavoiding walk}",
+	volume = "50",
+	year = "1988"
+}
+
+@article{Martinelli:1982mw,
+	author = "Martinelli, G. and Zhang, Yi-Cheng",
+	journal = "Phys. Lett.",
+	pages = "433",
+	slaccitation = "%\%CITATION = PHLTA,B123,433;\%\%",
+	title = "{THE CONNECTION BETWEEN LOCAL OPERATORS ON THE LATTICE AND IN THE CONTINUUM AND ITS RELATION TO MESON DECAY CONSTANTS}",
+	volume = "B123",
+	year = "1983"
+}
+
+@article{Martinelli:1994ty,
+	archiveprefix = "arXiv",
+	author = "Martinelli, G. and Pittori, C. and Sachrajda, Christopher T. and Testa, M. and Vladikas, A.",
+	doi = "10.1016/0550-3213(95)00126-D",
+	eprint = "hep-lat/9411010",
+	journal = "Nucl. Phys.",
+	pages = "81--108",
+	slaccitation = "%\%CITATION = HEP-LAT/9411010;\%\%",
+	title = "{A General method for nonperturbative renormalization of lattice operators}",
+	volume = "B445",
+	year = "1995"
+}
+
+@article{McNeile:2000hf,
+	author = "McNeile, C. and Michael, C.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0006020",
+	journal = "Phys. Lett.",
+	pages = "123--129",
+	slaccitation = "%\%CITATION = HEP-LAT 0006020;\%\%",
+	title = "{The eta and eta' mesons in {QCD}}",
+	volume = "B491",
+	year = "2000"
+}
+
+@article{McNeile:2000xx,
+	author = "McNeile, Craig and Michael, Chris",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0010019",
+	journal = "Phys. Rev.",
+	pages = "114503",
+	slaccitation = "%\%CITATION = HEP-LAT0010019;\%\%",
+	title = "{Mixing of scalar glueballs and flavour-singlet scalar mesons}",
+	volume = "D63",
+	year = "2001"
+}
+
+@article{McNeile:2001cr,
+	author = "McNeile, C. and Michael, C. and Sharkey, K. J.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0107003",
+	journal = "Phys. Rev.",
+	pages = "014508",
+	slaccitation = "%\%CITATION = HEP-LAT 0107003;\%\%",
+	title = "{The flavor singlet mesons in {QCD}}",
+	volume = "D65",
+	year = "2002"
+}
+
+@article{McNeile:2002fh,
+	author = "McNeile, C. and Michael, C.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0212020",
+	journal = "Phys. Lett.",
+	pages = "177--184",
+	slaccitation = "%\%CITATION = HEP-LAT 0212020;\%\%",
+	title = "{Hadronic decay of a vector meson from the lattice}",
+	volume = "B556",
+	year = "2003"
+}
+
+@article{McNeile:2006bz,
+	author = "McNeile, C. and Michael, C.",
+	collaboration = "UKQCD",
+	eprint = "hep-lat/0603007",
+	journal = "Phys. Rev.",
+	pages = "074506",
+	slaccitation = "%\%CITATION = HEP-LAT 0603007;\%\%",
+	title = "{Decay width of light quark hybrid meson from the lattice}",
+	volume = "D73",
+	year = "2006"
+}
+
+@article{Meyer:2006ty,
+	archiveprefix = "arXiv",
+	author = "Meyer, Harvey B. and others",
+	doi = "10.1016/j.cpc.2006.08.002",
+	eprint = "hep-lat/0606004",
+	journal = "Comput. Phys. Commun.",
+	pages = "91--97",
+	slaccitation = "%\%CITATION = HEP-LAT/0606004;\%\%",
+	title = "{Exploring the HMC trajectory-length dependence of autocorrelation times in lattice QCD}",
+	volume = "176",
+	year = "2007"
+}
+
+@article{Michael:1982gb,
+	author = "Michael, C. and Teasdale, I.",
+	journal = "Nucl. Phys.",
+	pages = "433",
+	slaccitation = "%\%CITATION = NUPHA,B215,433;\%\%",
+	title = "{EXTRACTING GLUEBALL MASSES FROM LATTICE QCD}",
+	volume = "B215",
+	year = "1983"
+}
+
+@article{Michael:1989mf,
+	author = "Michael, C.",
+	journal = "Nucl. Phys.",
+	pages = "515",
+	slaccitation = "%\%CITATION = NUPHA,B327,515;\%\%",
+	title = "{Particle decay in lattice gauge theory}",
+	volume = "B327",
+	year = "1989"
+}
+
+@article{Michael:1991nc,
+	author = "Michael, C.",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "417--419",
+	slaccitation = "%\%CITATION = NUPHZ,26,417;\%\%",
+	title = "{Hadronic forces from the lattice}",
+	volume = "26",
+	year = "1992"
+}
+
+@article{Michael:1993yj,
+	archiveprefix = "arXiv",
+	author = "Michael, Christopher",
+	doi = "10.1103/PhysRevD.49.2616",
+	eprint = "hep-lat/9310026",
+	journal = "Phys. Rev.",
+	pages = "2616--2619",
+	slaccitation = "%\%CITATION = HEP-LAT/9310026;\%\%",
+	title = "{Fitting correlated data}",
+	volume = "D49",
+	year = "1994"
+}
+
+@article{Michael:1994sz,
+	archiveprefix = "arXiv",
+	author = "Michael, Christopher and McKerrell, A.",
+	doi = "10.1103/PhysRevD.51.3745",
+	eprint = "hep-lat/9412087",
+	journal = "Phys. Rev.",
+	pages = "3745--3750",
+	slaccitation = "%\%CITATION = HEP-LAT/9412087;\%\%",
+	title = "{Fitting correlated hadron mass spectrum data}",
+	volume = "D51",
+	year = "1995"
+}
+
+@article{Michael:2007vn,
+	archiveprefix = "arXiv",
+	author = "Michael, C. and Urbach, C.",
+	collaboration = "ETM",
+	eprint = "0709.4564",
+	journal = "",
+	pages = "",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = ARXIV:0709.4564;\%\%",
+	title = "{Neutral mesons and disconnected diagrams in Twisted Mass QCD}",
+	volume = "",
+	year = "2007"
+}
+
+@book{Montvay:1994cy,
+	author = "Montvay, I. and M{\"u}nster, G.",
+	publisher = "Cambridge University Press",
+	series = "{Cambridge Monographs on Mathematical Physics}",
+	title = "{Quantum fields on a lattice}",
+	year = "1994"
+}
+
+@article{Montvay:1995ea,
+	author = "Montvay, I.",
+	eprint = "hep-lat/9510042",
+	journal = "Nucl. Phys.",
+	pages = "259--284",
+	slaccitation = "%\%CITATION = HEP-LAT 9510042;\%\%",
+	title = "{An Algorithm for Gluinos on the Lattice}",
+	volume = "B466",
+	year = "1996"
+}
+
+@article{Montvay:2005tj,
+	author = "Montvay, I. and Scholz, E.",
+	eprint = "hep-lat/0506006",
+	journal = "Phys. Lett.",
+	pages = "73--79",
+	slaccitation = "%\%CITATION = HEP-LAT 0506006;\%\%",
+	title = "{Updating algorithms with multi-step stochastic correction}",
+	volume = "B623",
+	year = "2005"
+}
+
+@article{Morgan:2002a,
+	author = "Morgan, R. B.",
+	journal = "SIAM J. Sci. Comput.",
+	pages = "20",
+	title = "{GMRES with Deated Restarting}",
+	volume = "24",
+	year = "2002"
+}
+
+@article{Morningstar:2003gk,
+	archiveprefix = "arXiv",
+	author = "Morningstar, Colin and Peardon, Mike J.",
+	doi = "10.1103/PhysRevD.69.054501",
+	eprint = "hep-lat/0311018",
+	journal = "Phys. Rev.",
+	pages = "054501",
+	slaccitation = "%\%CITATION = HEP-LAT/0311018;\%\%",
+	title = "{Analytic smearing of SU(3) link variables in lattice QCD}",
+	volume = "D69",
+	year = "2004"
+}
+
+@article{Munster:2004am,
+	author = "M{\"u}nster, G.",
+	eprint = "hep-lat/0407006",
+	journal = "JHEP",
+	pages = "035",
+	slaccitation = "%\%CITATION = HEP-LAT 0407006;\%\%",
+	title = "{On the phase structure of twisted mass lattice {QCD}}",
+	volume = "09",
+	year = "2004"
+}
+
+@article{Munster:2004wt,
+	author = "M{\"u}nster, Gernot and Schmidt, Christian and Scholz, Enno E.",
+	eprint = "hep-lat/0409066",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "320--322",
+	slaccitation = "%\%CITATION = HEP-LAT 0409066;\%\%",
+	title = "{Chiral perturbation theory for twisted mass {QCD}}",
+	volume = "140",
+	year = "2005"
+}
+
+@article{Nagai:2005mi,
+	author = "Nagai, Kei-ichi and Jansen, Karl",
+	eprint = "hep-lat/0510076",
+	journal = "Phys. Lett.",
+	pages = "325--330",
+	slaccitation = "%\%CITATION = HEP-LAT 0510076;\%\%",
+	title = "{Two-dimensional lattice Gross-Neveu model with Wilson twisted mass fermions}",
+	volume = "B633",
+	year = "2006"
+}
+
+@unpublished{Nagai:priv,
+	author = "Nagai, K",
+	note = "private communication",
+	optannote = "",
+	optkey = "",
+	optmonth = "",
+	optyear = "",
+	title = "{Two-dimensional Gross-Neveu model with {Wilson} twisted mass fermions}"
+}
+
+@article{Necco:2001xg,
+	author = "Necco, S. and Sommer, R.",
+	eprint = "hep-lat/0108008",
+	journal = "Nucl. Phys.",
+	pages = "328--346",
+	slaccitation = "%\%CITATION = HEP-LAT 0108008;\%\%",
+	title = "{The {N(f)} = 0 heavy quark potential from short to intermediate distances}",
+	volume = "B622",
+	year = "2002"
+}
+
+@article{Necco:2003vh,
+	author = "Necco, Silvia",
+	eprint = "hep-lat/0309017",
+	journal = "Nucl. Phys.",
+	pages = "137--167",
+	slaccitation = "%\%CITATION = HEP-LAT 0309017;\%\%",
+	volume = "B683",
+	year = "2004"
+}
+
+@article{Neff:2001zr,
+	author = "Neff, H. and Eicker, N. and Lippert, T. and Negele, J. W. and Schilling, K.",
+	eprint = "hep-lat/0106016",
+	journal = "Phys. Rev.",
+	pages = "114509",
+	slaccitation = "%\%CITATION = HEP-LAT/0106016;\%\%",
+	title = "{On the low fermionic eigenmode dominance in {QCD} on the lattice}",
+	volume = "D64",
+	year = "2001"
+}
+
+@article{Neuberger:1997fp,
+	author = "Neuberger, H.",
+	eprint = "hep-lat/9707022",
+	journal = "Phys. Lett.",
+	pages = "141--144",
+	slaccitation = "%\%CITATION = HEP-LAT 9707022;\%\%",
+	title = "{Exactly massless quarks on the lattice}",
+	volume = "B417",
+	year = "1998"
+}
+
+@article{Neuberger:1998wv,
+	author = "Neuberger, H.",
+	eprint = "hep-lat/9801031",
+	journal = "Phys. Lett.",
+	pages = "353--355",
+	slaccitation = "%\%CITATION = HEP-LAT 9801031;\%\%",
+	title = "{More about exactly massless quarks on the lattice}",
+	volume = "B427",
+	year = "1998"
+}
+
+@article{Niedermayer:1998bi,
+	author = "Niedermayer, F.",
+	eprint = "hep-lat/9810026",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "105--119",
+	slaccitation = "%\%CITATION = HEP-LAT 9810026;\%\%",
+	title = "{Exact chiral symmetry, topological charge and related topics}",
+	volume = "73",
+	year = "1999"
+}
+
+@article{Nielsen:1980rz,
+	author = "Nielsen, H. B. and Ninomiya, M.",
+	journal = "Nucl. Phys.",
+	pages = "20",
+	slaccitation = "%\%CITATION = NUPHA,B185,20;\%\%",
+	title = "{Absence of neutrinos on a lattice. 1. proof by homotopy theory}",
+	volume = "B185",
+	year = "1981"
+}
+
+@article{Nielsen:1981hk,
+	author = "Nielsen, H. B. and Ninomiya, M.",
+	journal = "Phys. Lett.",
+	pages = "219",
+	slaccitation = "%\%CITATION = PHLTA,B105,219;\%\%",
+	title = "{No go theorem for regularizing chiral fermions}",
+	volume = "B105",
+	year = "1981"
+}
+
+@article{Nielsen:1981xu,
+	author = "Nielsen, H. B. and Ninomiya, M.",
+	journal = "Nucl. Phys.",
+	pages = "173",
+	slaccitation = "%\%CITATION = NUPHA,B193,173;\%\%",
+	title = "{Absence of neutrinos on a lattice. 2. intuitive topological proof}",
+	volume = "B193",
+	year = "1981"
+}
+
+@article{Noaki:1998zc,
+	author = "Noaki, J. and Izubuchi, T. and Ukawa, A.",
+	eprint = "hep-lat/9809071",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "483--485",
+	slaccitation = "%\%CITATION = HEP-LAT 9809071;\%\%",
+	title = "{Two-dimensional Gross-Neveu model with {Wilson} fermion action at finite temperature and density}",
+	volume = "73",
+	year = "1999"
+}
+
+@article{Orginos:2001xa,
+	author = "Orginos, K.",
+	collaboration = "RBC",
+	eprint = "hep-lat/0110074",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "721--723",
+	slaccitation = "%\%CITATION = HEP-LAT 0110074;\%\%",
+	title = "{Chiral properties of domain wall fermions with improved gauge actions}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Orth:2005kq,
+	author = "Orth, B. and Lippert, T. and Schilling, K.",
+	eprint = "hep-lat/0503016",
+	journal = "Phys. Rev.",
+	pages = "014503",
+	slaccitation = "%\%CITATION = HEP-LAT 0503016;\%\%",
+	title = "{Finite-size effects in lattice {QCD} with dynamical {Wilson} fermions}",
+	volume = "D72",
+	year = "2005"
+}
+
+@article{Osterwalder:1973dx,
+	author = "Osterwalder, K. and Schrader, R.",
+	journal = "Commun. Math. Phys.",
+	pages = "83--112",
+	slaccitation = "%\%CITATION = CMPHA,31,83;\%\%",
+	title = "{Axioms for euclidean Green's functions}",
+	volume = "31",
+	year = "1973"
+}
+
+@article{Osterwalder:1975tc,
+	author = "Osterwalder, K. and Schrader, R.",
+	journal = "Commun. Math. Phys.",
+	pages = "281",
+	slaccitation = "%\%CITATION = CMPHA,42,281;\%\%",
+	title = "{Axioms for euclidean Green's functions. 2}",
+	volume = "42",
+	year = "1975"
+}
+
+@article{Osterwalder:1977pc,
+	author = "Osterwalder, K. and Seiler, E.",
+	journal = "Ann. Phys.",
+	pages = "440",
+	slaccitation = "%\%CITATION = APNYA,110,440;\%\%",
+	title = "{Gauge field theories on the lattice}",
+	volume = "110",
+	year = "1978"
+}
+
+@article{PDBook,
+	author = "Eidelman, S. and others",
+	journal = "{Physics Letters B}",
+	pages = "1+",
+	title = "{Review of Particle Physics}",
+	url = "http://pdg.lbl.gov",
+	volume = "592",
+	year = "2004"
+}
+
+@article{Peardon:2002wb,
+	author = "Peardon, M. J. and Sexton, J.",
+	collaboration = "TrinLat",
+	eprint = "hep-lat/0209037",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "985--987",
+	slaccitation = "%\%CITATION = HEP-LAT 0209037;\%\%",
+	title = "{Multiple molecular dynamics time-scales in hybrid Monte Carlo fermion simulations}",
+	volume = "119",
+	year = "2003"
+}
+
+@book{Peskin:1995ev,
+	author = "Peskin, M. E. and Schroeder, D. V.",
+	optaddress = "Boulder, Colorado",
+	optannote = "",
+	optedition = "",
+	optkey = "",
+	optmonth = "",
+	optnote = "",
+	optnumber = "",
+	optseries = "Advanced Book Program",
+	optvolume = "",
+	publisher = "Westview Press",
+	title = "{An Introduction to quantum field theory}",
+	year = "1995"
+}
+
+@article{Politzer:1973fx,
+	author = "Politzer, H. D.",
+	journal = "Phys. Rev. Lett.",
+	pages = "1346--1349",
+	slaccitation = "%\%CITATION = PRLTA,30,1346;\%\%",
+	title = "{Reliable perturbative results for strong interactions?}",
+	volume = "30",
+	year = "1973"
+}
+
+@article{Politzer:1974fr,
+	author = "Politzer, H. D.",
+	journal = "Phys. Rept.",
+	pages = "129--180",
+	slaccitation = "%\%CITATION = PRPLC,14,129;\%\%",
+	title = "{Asymptotic freedom: an approach to strong interactions}",
+	volume = "14",
+	year = "1974"
+}
+
+@manual{R:2005,
+	address = "Vienna, Austria",
+	author = "{R Development Core Team}",
+	note = "{ISBN} 3-900051-07-0",
+	organization = "R Foundation for Statistical Computing",
+	title = "{R: A language and environment for statistical computing}",
+	url = "http://www.R-project.org",
+	year = "2005"
+}
+
+@book{Rothe:1992wy,
+	author = "Rothe, H.J.",
+	edition = "",
+	pages = "528",
+	publisher = "World Scientific, Singapore",
+	title = "{Lattice gauge theories}",
+	year = "1992"
+}
+
+@article{Rupak:2002sm,
+	author = "Rupak, G. and Shoresh, N.",
+	eprint = "hep-lat/0201019",
+	journal = "Phys. Rev.",
+	pages = "054503",
+	slaccitation = "%\%CITATION = HEP-LAT 0201019;\%\%",
+	title = "{Chiral perturbation theory for the {Wilson} lattice action}",
+	volume = "D66",
+	year = "2002"
+}
+
+@article{Saad:1993a,
+	author = "Saad, Y.",
+	journal = "SIAM J. Sci. Comput.",
+	page = "461-469",
+	title = "{A flexible inner-outer preconditioned GMRES altorithm}",
+	volume = "14 (2)",
+	year = "1993"
+}
+
+@article{Sachrajda:2004mi,
+	archiveprefix = "arXiv",
+	author = "Sachrajda, C. T. and Villadoro, G.",
+	doi = "10.1016/j.physletb.2005.01.033",
+	eprint = "hep-lat/0411033",
+	journal = "Phys. Lett.",
+	pages = "73--85",
+	slaccitation = "%\%CITATION = HEP-LAT/0411033;\%\%",
+	title = "{Twisted boundary conditions in lattice simulations}",
+	volume = "B609",
+	year = "2005"
+}
+
+@article{Scorzato:2004da,
+	author = "Scorzato, L.",
+	eprint = "hep-lat/0407023",
+	journal = "Eur. Phys. J.",
+	pages = "445--455",
+	slaccitation = "%\%CITATION = HEP-LAT 0407023;\%\%",
+	title = "{Pion mass splitting and phase structure in twisted mass {QCD}}",
+	volume = "C37",
+	year = "2004"
+}
+
+@article{Scorzato:2005rb,
+	author = "Scorzato, L. and others",
+	eprint = "hep-lat/0511036",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "283--290",
+	slaccitation = "%\%CITATION = HEP-LAT 0511036;\%\%",
+	title = "{N(f) = 2 lattice {QCD} and chiral perturbation theory}",
+	volume = "153",
+	year = "2006"
+}
+
+@article{Sexton:1992nu,
+	author = "Sexton, J. C. and Weingarten, D. H.",
+	journal = "Nucl. Phys.",
+	pages = "665--678",
+	slaccitation = "%\%CITATION = NUPHA,B380,665;\%\%",
+	title = "{Hamiltonian evolution for the hybrid monte carlo algorithm}",
+	volume = "B380",
+	year = "1992"
+}
+
+@article{Sharpe:1998xm,
+	author = "Sharpe, S. R. and Singleton, R. Jr.",
+	eprint = "hep-lat/9804028",
+	journal = "Phys. Rev.",
+	pages = "074501",
+	slaccitation = "%\%CITATION = HEP-LAT 9804028;\%\%",
+	title = "{Spontaneous flavor and parity breaking with {Wilson} fermions}",
+	volume = "D58",
+	year = "1998"
+}
+
+@article{Sharpe:2004ny,
+	author = "Sharpe, S. R. and Wu, Jackson M. S.",
+	eprint = "hep-lat/0411021",
+	journal = "Phys. Rev.",
+	pages = "074501",
+	slaccitation = "%\%CITATION = HEP-LAT 0411021;\%\%",
+	title = "{Twisted mass chiral perturbation theory at next-to-leading order}",
+	volume = "D71",
+	year = "2005"
+}
+
+@article{Sharpe:2004ps,
+	author = "Sharpe, S. R. and Wu, J. M. S.",
+	eprint = "hep-lat/0407025",
+	journal = "Phys. Rev.",
+	pages = "094029",
+	slaccitation = "%\%CITATION = HEP-LAT 0407025;\%\%",
+	title = "{The phase diagram of twisted mass lattice {QCD}}",
+	volume = "D70",
+	year = "2004"
+}
+
+@article{Sharpe:2005rq,
+	author = "Sharpe, Stephen R.",
+	eprint = "hep-lat/0509009",
+	journal = "Phys. Rev.",
+	pages = "074510",
+	slaccitation = "%\%CITATION = HEP-LAT 0509009;\%\%",
+	title = "{Observations on discretization errors in twisted-mass lattice QCD}",
+	volume = "D72",
+	year = "2005"
+}
+
+@article{Sheikholeslami:1985ij,
+	author = "Sheikholeslami, B. and Wohlert, R.",
+	journal = "Nucl. Phys.",
+	pages = "572",
+	slaccitation = "%\%CITATION = NUPHA,B259,572;\%\%",
+	title = "{Improved continuum limit lattice action for qcd with {Wilson} fermions}",
+	volume = "B259",
+	year = "1985"
+}
+
+@article{Shindler:2005vj,
+	author = "Shindler, Andrea",
+	eprint = "hep-lat/0511002",
+	journal = "PoS",
+	pages = "014",
+	slaccitation = "%\%CITATION = HEP-LAT 0511002;\%\%",
+	title = "{Twisted mass lattice {QCD}: Recent developments and results}",
+	volume = "LAT2005",
+	year = "2006"
+}
+
+@article{Shindler:2006tm,
+	author = "Shindler, A.",
+	collaboration = "ETM",
+	eprint = "hep-ph/0611264",
+	slaccitation = "%\%CITATION = HEP-PH 0611264;\%\%",
+	title = "{Lattice QCD with light twisted quarks: First results}",
+	year = "2006"
+}
+
+@article{Shindler:2007vp,
+	archiveprefix = "arXiv",
+	author = "Shindler, A.",
+	doi = "10.1016/j.physrep.2008.03.001",
+	eprint = "0707.4093",
+	journal = "Phys. Rept.",
+	pages = "37--110",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0707.4093;\%\%",
+	title = "{Twisted mass lattice QCD}",
+	volume = "461",
+	year = "2008"
+}
+
+@article{Sleijpen:1996aa,
+	author = "Sleijpen, G. L. G. and der Vorst, H. A. Van",
+	journal = "SIAM Journal on Matrix Analysis and Applications",
+	pages = "401--425",
+	title = "{A Jacobi-Davidson iteration method for linear eigenvalue problems}",
+	volume = "17",
+	year = "1996"
+}
+
+@article{Sommer:1993ce,
+	author = "Sommer, R.",
+	eprint = "hep-lat/9310022",
+	journal = "Nucl. Phys.",
+	pages = "839--854",
+	slaccitation = "%\%CITATION = HEP-LAT 9310022;\%\%",
+	title = "{A New way to set the energy scale in lattice gauge theories and its applications to the static force and alpha-s in SU(2) Yang-Mills theory}",
+	volume = "B411",
+	year = "1994"
+}
+
+@article{Sonneveld:1989cgs,
+	address = "Philadelphia, PA, USA",
+	author = "Sonneveld, Peter",
+	issn = "0196-5204",
+	journal = "SIAM J. Sci. Stat. Comput.",
+	number = "1",
+	pages = "36--52",
+	publisher = "Society for Industrial and Applied Mathematics",
+	title = "{CGS, a fast Lanczos-type solver for nonsymmetric linear systems}",
+	volume = "10",
+	year = "1989"
+}
+
+@article{Sternbeck:2003gy,
+	author = "Sternbeck, A. and Ilgenfritz, E.-M. and Kerler, W. and M{\"u}ller-Preu{\ss}ker, M. and St{\"u}ben, H.",
+	eprint = "hep-lat/0309059",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "898--900",
+	slaccitation = "%\%CITATION = HEP-LAT 0309059;\%\%",
+	title = "{The {Aoki} phase for {N(f)} = 2 {Wilson} fermions revisited}",
+	volume = "129",
+	year = "2004"
+}
+
+@article{Sternbeck:2005tk,
+	author = "Sternbeck, A. and Ilgenfritz, E. -M. and Mueller-Preussker, M. and Schiller, A.",
+	eprint = "hep-lat/0506007",
+	journal = "Phys. Rev.",
+	pages = "014507",
+	slaccitation = "%\%CITATION = HEP-LAT/0506007;\%\%",
+	title = "{Going infrared in SU(3) Landau gauge gluodynamics}",
+	volume = "D72",
+	year = "2005"
+}
+
+@article{Symanzik:1983dc,
+	author = "Symanzik, K.",
+	journal = "Nucl. Phys.",
+	pages = "187",
+	slaccitation = "%\%CITATION = NUPHA,B226,187;\%\%",
+	title = "{Continuum limit and improved action in lattice theories. 1. principles and phi**4 theory}",
+	volume = "B226",
+	year = "1983"
+}
+
+@conference{Symanzik:1981hc,
+	author = "Symanzik, K.",
+	booktitle = "{Mathematical problems in theoretical physics}",
+	editor = "et al., R. Schrader",
+	journal = "Lecture Notes in Physics",
+	note = "Presented at 6th Int. Conf. on Mathematical Physics, Berlin, West Germany",
+	pages = "47--58",
+	title = "{Some topics in quantum field theory}",
+	volume = "153",
+	year = "1981"
+}
+
+@article{Symanzik:1983gh,
+	author = "Symanzik, K.",
+	journal = "Nucl. Phys.",
+	pages = "205",
+	slaccitation = "%\%CITATION = NUPHA,B226,205;\%\%",
+	title = "{Continuum limit and improved action in lattice theories. 2. O(N) nonlinear sigma model in perturbation theory}",
+	volume = "B226",
+	year = "1983"
+}
+
+@article{Takaishi:1996xj,
+	author = "Takaishi, T.",
+	journal = "Phys. Rev.",
+	pages = "1050--1053",
+	slaccitation = "%\%CITATION = PHRVA,D54,1050;\%\%",
+	title = "{Heavy quark potential and effective actions on blocked configurations}",
+	volume = "D54",
+	year = "1996"
+}
+
+@article{Takaishi:2005tz,
+	archiveprefix = "arXiv",
+	author = "Takaishi, Tetsuya and de Forcrand, Philippe",
+	doi = "10.1103/PhysRevE.73.036706",
+	eprint = "hep-lat/0505020",
+	journal = "Phys. Rev.",
+	pages = "036706",
+	slaccitation = "%\%CITATION = HEP-LAT/0505020;\%\%",
+	title = "{Testing and tuning new symplectic integrators for hybrid Monte Carlo algorithm in lattice QCD}",
+	volume = "E73",
+	year = "2006"
+}
+
+@article{Takeda:2004xh,
+	author = "Takeda, S. and others",
+	eprint = "hep-lat/0408010",
+	journal = "Phys. Rev.",
+	pages = "074510",
+	slaccitation = "%\%CITATION = HEP-LAT 0408010;\%\%",
+	title = "{A scaling study of the step scaling function in SU(3) gauge theory with improved gauge actions}",
+	volume = "D70",
+	year = "2004"
+}
+
+@article{Ukawa:2002pc,
+	author = "Ukawa, A.",
+	collaboration = "CP-PACS and JL{QCD}",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "195--196",
+	slaccitation = "%\%CITATION = NUPHZ,106,195;\%\%",
+	title = "{Computational cost of full {QCD} simulations experienced by {CP-PACS and JLQCD Collaborations}}",
+	volume = "106",
+	year = "2002"
+}
+
+@article{Urbach:2005ji,
+	author = "Urbach, C. and Jansen, K. and Shindler, A. and Wenger, U.",
+	eprint = "hep-lat/0506011",
+	journal = "Comput. Phys. Commun.",
+	pages = "87--98",
+	slaccitation = "%\%CITATION = HEP-LAT 0506011;\%\%",
+	title = "{{HMC} algorithm with multiple time scale integration and mass preconditioning}",
+	volume = "174",
+	year = "2006"
+}
+
+@article{Urbach:2007rt,
+	archiveprefix = "arXiv",
+	author = "Urbach, Carsten",
+	collaboration = "ETM",
+	eprint = "0710.1517",
+	journal = "PoS",
+	pages = "022",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.1517;\%\%",
+	title = "{Lattice QCD with two light Wilson quarks and maximally twisted mass}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{WalkerLoud:2005bt,
+	archiveprefix = "arXiv",
+	author = "Walker-Loud, Andre and Wu, Jackson M. S.",
+	doi = "10.1103/PhysRevD.72.014506",
+	eprint = "hep-lat/0504001",
+	journal = "Phys. Rev.",
+	pages = "014506",
+	slaccitation = "%\%CITATION = HEP-LAT/0504001;\%\%",
+	title = "{Nucleon and Delta masses in twisted mass chiral perturbation theory}",
+	volume = "D72",
+	year = "2005"
+}
+
+@article{Weinberg:1973un,
+	author = "Weinberg, S.",
+	journal = "Phys. Rev. Lett.",
+	pages = "494--497",
+	slaccitation = "%\%CITATION = PRLTA,31,494;\%\%",
+	title = "{Nonabelian gauge theories of the strong interactions}",
+	volume = "31",
+	year = "1973"
+}
+
+@article{Weinberg:1978kz,
+	author = "Weinberg, S.",
+	journal = "Physica",
+	pages = "327",
+	slaccitation = "%\%CITATION = PHYSA,A96,327;\%\%",
+	title = "{Phenomenological Lagrangians}",
+	volume = "A96",
+	year = "1979"
+}
+
+@book{Weinberg:1995mt,
+	author = "Weinberg, S.",
+	pages = "609",
+	publisher = "Cambridge University Press",
+	title = "{The Quantum theory of fields. Vol. 1: Foundations}",
+	year = "1995"
+}
+
+@article{Weisz:1982zw,
+	author = "Weisz, P.",
+	journal = "Nucl. Phys.",
+	pages = "1",
+	slaccitation = "%\%CITATION = NUPHA,B212,1;\%\%",
+	title = "{Continuum limit improved lattice action for pure {Yang-Mills} theory. 1}",
+	volume = "B212",
+	year = "1983"
+}
+
+@article{Weisz:1983bn,
+	author = "Weisz, P. and Wohlert, R.",
+	journal = "Nucl. Phys.",
+	pages = 397,
+	slaccitation = "%\%CITATION = NUPHA,B236,397;\%\%",
+	title = "{Continuum limit improved lattice action for pure {Yang-Mills} theory. 2}",
+	volume = "B236",
+	year = 1984
+}
+
+@article{Wennekers:2005wa,
+	author = "Wennekers, J. and Wittig, H.",
+	eprint = "hep-lat/0507026",
+	slaccitation = "%\%CITATION = HEP-LAT 0507026;\%\%",
+	title = "{On the renormalized scalar density in quenched QCD}",
+	year = "2005"
+}
+
+@article{Weyl:1918ib,
+	author = "Weyl, H.",
+	journal = "Sitzungsber. Preuss. Akad. Wiss. Berlin (Math. Phys. )",
+	pages = "465",
+	slaccitation = "%\%CITATION = SPWPA,1918,465;\%\%",
+	title = "{Gravitation und Elektrizit{\"a}t}",
+	volume = "1918",
+	year = "1918"
+}
+
+@article{Weyl:1929fm,
+	author = "Weyl, H.",
+	journal = "Z. Phys.",
+	pages = "330--352",
+	slaccitation = "%\%CITATION = ZEPYA,56,330;\%\%",
+	title = "{Electron and gravitation}",
+	volume = "56",
+	year = "1929"
+}
+
+@article{Wilson:1974sk,
+	author = "Wilson, K. G.",
+	journal = "Phys. Rev.",
+	pages = "2445--2459",
+	slaccitation = "%\%CITATION = PHRVA,D10,2445;\%\%",
+	title = "{Confinement of quarks}",
+	volume = "D10",
+	year = "1974"
+}
+
+@article{Wilson:1974sk,
+	author = "Wilson, K. G.",
+	journal = "Phys. Rev.",
+	pages = "2445--2459",
+	slaccitation = "%\%CITATION = PHRVA,D10,2445;\%\%",
+	title = "{Confinement of quarks}",
+	volume = "D10",
+	year = "1974"
+}
+
+@article{Wilson:1975mb,
+	author = "Wilson, K. G.",
+	journal = "Rev. Mod. Phys.",
+	pages = "773",
+	slaccitation = "%\%CITATION = RMPHA,47,773;\%\%",
+	title = "{The renormalization group: Critical phenomena and the kondo problem}",
+	volume = "47",
+	year = "1975"
+}
+
+@article{Wilson:1975mb,
+	author = "Wilson, K. G.",
+	journal = "Rev. Mod. Phys.",
+	pages = "773",
+	slaccitation = "%\%CITATION = RMPHA,47,773;\%\%",
+	title = "{The renormalization group: Critical phenomena and the kondo problem}",
+	volume = "47",
+	year = "1975"
+}
+
+@article{Wolff:2003sm,
+	author = "Wolff, U.",
+	collaboration = "ALPHA",
+	eprint = "hep-lat/0306017",
+	journal = "Comput. Phys. Commun.",
+	pages = "143--153",
+	slaccitation = "%\%CITATION = HEP-LAT 0306017;\%\%",
+	title = "{Monte Carlo errors with less errors}",
+	volume = "156",
+	year = "2004"
+}
+
+@article{Yang:1954ek,
+	author = "Yang, C.-N. and Mills, R. L.",
+	journal = "Phys. Rev.",
+	pages = "191--195",
+	slaccitation = "%\%CITATION = PHRVA,96,191;\%\%",
+	title = "{Conservation of isotopic spin and isotopic gauge invariance}",
+	volume = "96",
+	year = "1954"
+}
+
+@article{Yoshie:2008aw,
+	archiveprefix = "arXiv",
+	author = "Yoshie, Tomoteru",
+	eprint = "0812.0849",
+	journal = "PoS",
+	pages = "019",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0812.0849;\%\%",
+	title = "{Making use of the International Lattice Data Grid}",
+	volume = "LATTICE2008",
+	year = "2008"
+}
+
+@article{Zweig:1964jf,
+	author = "Zweig, G.",
+	note = "CERN-TH-412",
+	title = "{An SU(3) model for strong interaction symmetry and its breaking. 2}"
+}
+
+@article{cln:web,
+	eprint = "http://www.ginac.de/CLN/"
+}
+
+@article{deForcrand:1995bs,
+	author = "de Forcrand, P.",
+	eprint = "hep-lat/9509082",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "228--235",
+	slaccitation = "%\%CITATION = HEP-LAT 9509082;\%\%",
+	title = "{Progress on lattice {QCD} algorithms}",
+	volume = "47",
+	year = "1996"
+}
+
+@article{deForcrand:1996bx,
+	author = "de Forcrand, P. and others",
+	collaboration = "{QCD}-TARO",
+	eprint = "hep-lat/9608094",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "938--941",
+	slaccitation = "%\%CITATION = HEP-LAT 9608094;\%\%",
+	title = "{Search for effective lattice action of pure {QCD}}",
+	volume = "53",
+	year = "1997"
+}
+
+@article{deForcrand:1996ck,
+	author = "de Forcrand, P. and Takaishi, T.",
+	eprint = "hep-lat/9608093",
+	journal = "Nucl. Phys. Proc. Suppl.",
+	pages = "968--970",
+	slaccitation = "%\%CITATION = HEP-LAT 9608093;\%\%",
+	title = "{Fast fermion Monte Carlo}",
+	volume = "53",
+	year = "1997"
+}
+
+@article{etmc:asqr,
+	archiveprefix = "arXiv",
+	author = "Frezzotti, R. et al.",
+	eprint = "0710.2492",
+	journal = "PoS",
+	pages = "277",
+	primaryclass = "hep-lat",
+	slaccitation = "%\%CITATION = 0710.2492;\%\%",
+	title = "{O(a^2) cutoff effects in Wilson fermion simulations}",
+	volume = "LAT2007",
+	year = "2007"
+}
+
+@article{ildg:web,
+	eprint = "http://cssm.sasr.edu.au/ildg/"
+}
+
+@book{kleinert:1,
+	author = "Kleinert, H.",
+	edition = "2nd Edition",
+	publisher = "World Scientific, Singapore",
+	title = "{Path integrals in quantum mechanics, statistics and polymer ph ysics}",
+	year = "1995"
+}
+
+@article{lapack:web,
+	eprint = "http://www.netlib.org/lapack/"
+}
+
+@article{lime:web,
+	author = "USQCD",
+	eprint = "http://usqcd.jlab.org/usqcd-docs/c-lime/",
+	title = "{c-lime library}"
+}
+
+@article{hmc:web,
+	eprint = "http://www.carsten-urbach.eu/",
+	title = "{tmLQCD}"
+}
+
+@book{meister:1999,
+	author = "Meister, Andreas",
+	optaddress = "",
+	optannote = "",
+	optedition = "",
+	optkey = "",
+	optmonth = "",
+	optnote = "",
+	optnumber = "",
+	optseries = "",
+	optvolume = "",
+	publisher = "vieweg",
+	title = "{Numerik linearer Gleichungssysteme}",
+	year = "1999"
+}
+
+@manual{minuit,
+	note = "\\seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/home.html",
+	title = "{MINUIT home page}"
+}
+
+@article{mpi:web,
+	eprint = "http://www-unix.mcs.anl.gov/mpi/",
+	title = "{The message passing interface standard}"
+}
+
+@phdthesis{orth:2004phd,
+	author = "Orth, B.",
+	optaddress = "",
+	optannote = "",
+	optkey = "",
+	optmonth = "",
+	optnote = "",
+	opttype = "",
+	school = "Bergische Universit{\"a}t Wuppertal",
+	title = "{Finite size effects in lattice {QCD} with dynamical {Wilson} fermions}",
+	year = "2004"
+}
+
+@phdthesis{pleiter:phd,
+	author = "Pleiter, D.",
+	school = "Freie {U}niversitï¿½t {B}erlin",
+	title = "{XXX}",
+	year = "2001"
+}
+
 @book{press:1992,
-	address = {Cambridge, UK},
-	author = {Press, William   and Teukolsky, Saul   and Vetterling, William   and Flannery, Brian  },
-	citeulike-article-id = {767703},
-	edition = {2nd},
-	keywords = {bibtex-import},
-	posted-at = {2006-07-21 00:26:35},
-	priority = {0},
-	publisher = {Cambridge University Press},
-	title = {Numerical Recipes in C},
-	year = {1992}
-}
-@Manual{root,
-  title = 	 {The ROOT system home page},
-  note = {root.cern.ch/}
+	address = "Cambridge, UK",
+	author = "Press, William and Teukolsky, Saul and Vetterling, William and Flannery, Brian",
+	citeulike-article-id = "767703",
+	edition = "2nd",
+	keywords = "bibtex-import",
+	posted-at = "2006-07-21 00:26:35",
+	priority = "0",
+	publisher = "Cambridge University Press",
+	title = "{Numerical Recipes in C}",
+	year = "1992"
 }
 
-@Book{saad:2003a,
-     author    = "Y. Saad",
-     title     = "Iterative Methods for sparse linear systems",
-     publisher = "SIAM",
-     year      = "2003",
-     edition   = "2nd",
+@manual{root,
+	note = "root.cern.ch/",
+	title = "{The ROOT system home page}"
 }
 
-@Article{scidac,
-  author = 	 {},
-  eprint =       {http://www.scidac.gov/}
+@book{saad:2003a,
+	author = "Saad, Y.",
+	edition = "2nd",
+	publisher = "SIAM",
+	title = "{Iterative Methods for sparse linear systems}",
+	year = "2003"
 }
-@MastersThesis{urbach:2002aa,
-  author = 	 {Urbach, C.},
-  title = 	 {Untersuchung der {R}eversibilit{\"a}tsverletzung im {H}ybrid
-                  {M}onte {C}arlo {A}lgorithmus},
-  school = 	 {Freie Universit{\"a}t Berlin, Fachbereich Physik},
-  year = 	 {2002}
+
+@article{scidac,
+	eprint = "http://www.scidac.gov/"
 }
+
+@mastersthesis{urbach:2002aa,
+	author = "Urbach, C.",
+	school = "Freie Universit{\"a}t Berlin, Fachbereich Physik",
+	title = "{Untersuchung der {R}eversibilit{\"a}tsverletzung im {H}ybrid {M}onte {C}arlo {A}lgorithmus}",
+	year = "2002"
+}
+
+@inbook{Joo2013,
+	abstract = "Lattice Quantum Chromodynamics (LQCD) is currently the only known model independent, non perturbative computational method for calculations in the theory of the strong interactions, and is of importance in studies of nuclear and high energy physics. LQCD codes use large fractions of supercomputing cycles worldwide and are often amongst the first to be ported to new high performance computing architectures. The recently released Intel Xeon Phi architecture from Intel Corporation features parallelism at the level of many x86-based cores, multiple threads per core, and vector processing units. In this contribution, we describe our experiences with optimizing a key LQCD kernel for the Xeon Phi architecture. On a single node, using single precision, our Dslash kernel sustains a performance of up to 320 GFLOPS, while our Conjugate Gradients solver sustains up to 237 GFLOPS. Furthermore we demonstrate a fully 'native' multi-node LQCD implementation running entirely on KNC nodes with minimum involvement of the host CPU. Our multi-node implementation of the solver has been strong scaled to 3.9 TFLOPS on 32 KNCs.",
+	address = "Berlin, Heidelberg",
+	author = "Jo{\'o}, B{\'a}lint and Kalamkar, Dhiraj D. and Vaidyanathan, Karthikeyan and Smelyanskiy, Mikhail and Pamnany, Kiran and Lee, Victor W. and Dubey, Pradeep and Watson, William",
+	booktitle = "{Supercomputing: 28th International Supercomputing Conference, ISC 2013, Leipzig, Germany, June 16-20, 2013. Proceedings}",
+	doi = "10.1007/978-3-642-38750-0_4",
+	editor = "Kunkel, Julian Martin and Ludwig, Thomas and Meuer, Hans Werner",
+	isbn = "978-3-642-38750-0",
+	pages = "40--54",
+	publisher = "Springer Berlin Heidelberg",
+	title = "{Lattice QCD on IntelÂ® Xeon PhiTM Coprocessors}",
+	url = "https://doi.org/10.1007/978-3-642-38750-0_4",
+	year = "2013"
+}
+

--- a/doc/cgmms.tex
+++ b/doc/cgmms.tex
@@ -68,9 +68,11 @@ For details about the rational approximation in tmLQCD, see Section~\ref{subsec:
 
 Note that it passes the shifts as expected by tmLQCD's \texttt{cg\_mms\_tm}, which means that they need to be squared.
 For the QPhiX normalisation, the QPhiX solver interface also divides them by $4\kappa^2$.
-The shifts are taken as is and not shifted by $\sigma_0$
+The shifts are taken as is and not shifted by $\sigma_0$.
 
 \subsubsection{Two flavour Wilson twisted mass (clover) fermions in the rational approximation}
+
+\textbf{QPhiX interface:} For the HMC with non-degenerate twisted mass (clover) doublets (\texttt{NDRAT} and \texttt{NDCLOVERRAT} monomials, exactly the same approach is used.
 
 %%% Local Variables: 
 %%% mode: latex

--- a/doc/cgmms.tex
+++ b/doc/cgmms.tex
@@ -1,0 +1,78 @@
+\subsection{CGMMS}
+
+The multi-shift CG implementation in tmLQCD is referred to as \emph{CGMMS} since it was originally developped to solve a multi-system of equations of the form
+\begin{equation}
+  ( A + \mathbb{I}\mu_k^2 ) = b \, ,
+\end{equation}
+where $A$ can be $\Qp\Qm$ or $\Mp\Mm$ and the squared shifts $\mu_i^2$ can be naturally interpreted as different twisted quark masses (in the case of $\Mp\Mm$, appropriate factors of $\gamma^5$ must be inserted as required).
+\begin{equation}
+  \begin{split}
+  ( \Mw + i \mu \gamma^5 )( \Mw^\dagger - i \mu \gamma^5 ) & = b \\
+  ( \Mw \Mw^\dagger + \cancel{i\mu\gamma^5 \Mw^\dagger - i \mu \Mw \gamma^5} + \mu^2 ) & = b \\
+  ( \Mw \Mw^\dagger + \mu^2 ) & = b \, ,
+  \end{split}
+\end{equation}
+where in the last line $\gamma_5$-hermiticity of $\Mw$ was used.
+With the clover term, $T$, in the operator, the calculation goes through in the same way, with the result
+\begin{equation}
+  \begin{split}
+    & ( \Mw \Mw^\dagger + \Mw T + T \Mw^\dagger + \cancel{i\mu\gamma^5 \Mw^\dagger - i \mu \Mw \gamma^5} + i\mu\gamma_5 T - i\mu T \gamma_5 + T^2 + \mu^2 ) = b \\
+    & ( \Msw \Msw^\dagger + \mu^2 ) = b \, ,
+  \end{split}
+\end{equation}
+where $\Msw = \Mw + T$.
+
+The algorithm is listed below in Algorithm \ref{alg:cgm} (see also Ref.~\cite{Chiarappa:2006hz}
+and references therein), with the identification $\sigma_k = \mu_k^2$.
+Note that in line 6 below, $\alpha_{n-1}(1+\sigma_k\alpha_n)$ is correct, in contrast to Ref.~\cite{Chiarappa:2006hz}.
+
+\begin{algorithm}
+  \caption{CGMMS algorithm}
+  \label{alg:cgm}
+  \begin{algorithmic}[1]
+    \vspace{.2cm}
+    \STATE $n=0, x_0^k = 0, r_0 = p_0 = p_0^k = b, k_\mathrm{max},
+    \delta, \epsilon$
+    \STATE  $\biggl.\biggr.\alpha_{-1} = \zeta_{-1}^k = \zeta_0^k = 1, \beta_0^k = \beta_0 = 0$
+    \REPEAT
+    \STATE $\alpha_n = (r_n, r_n) / (p_n, A p_n)$
+    \FOR{$k = 1$ to $k_\mathrm{max}$}
+    \STATE $\biggl.\biggr.\zeta_{n+1}^k = (\zeta^k_n  \alpha_{n-1}) / 
+      (\alpha_n \beta_n(1 - \zeta_n^k / \zeta^k_{n-1}) + \alpha_{n-1}
+      (1+\sigma_k\alpha_n))$
+    \STATE $\alpha^k_n = (\alpha_n \zeta_{n+1}^k)/ \zeta_n^k$
+    \STATE $\biggl.\biggr.x_{n+1}^k = x_n^k + \alpha_n^k p_n^k$
+    \IF{$\|\alpha^{k_\mathrm{max}} p^{k_\mathrm{max}}\| < \delta$}
+    \STATE $k_\mathrm{max} = k_\mathrm{max} -1$
+    \ENDIF
+    \ENDFOR
+    \STATE $x_{n+1} = x_n + \alpha_n p_n$
+    \STATE $\biggl.\biggr.r_{n+1} = r_n - \alpha_n Ap_n$
+    \STATE $\beta_{n+1} = (r_{n+1}, r_{n+1}) / (r_n, r_n)$
+    \STATE $\beta_{n+1}^k = \frac{\beta_{n+1} \zeta_{n+1}^k \alpha_n^k}{\zeta_{n}^k\alpha_n}$
+    \STATE $\biggl.\biggr.p_{n+1}^k = \zeta_{n+1}^k r_{n+1} + \beta_{n+1}^k p_n^k$
+    \STATE $n=n+1$
+    \UNTIL{$\|r_n\|<\epsilon$}
+  \end{algorithmic}
+\end{algorithm}
+
+The implementations in \texttt{solver/cg\_mms\_tm.c} and \texttt{solver/cg\_mms\_tm\_nd.c} use a slightly different approach in that the lowest shift is included in the operator $A$, such that the higher shifts are $\sigma_k-\sigma_0\, \forall k > 0$.
+
+It should be noted that $\sqrt{\sigma_k}$ are passed to \texttt{cg\_mms\_tm} and the solver internally squares these and shifts them by $\sigma_0$.
+
+\subsubsection{Single flavour Wilson (clover) fermions in the rational approximation}
+
+For details about the rational approximation in tmLQCD, see Section~\ref{subsec:rationalhmc}.
+
+\textbf{QPhiX interface:} For the HMC with a single flavour of Wilson (clover) fermions (\texttt{RAT} or \texttt{CLOVERRAT} monomials), the function \texttt{solve\_mshift\_oneflavour} of \texttt{solver/monomial\_solve.c} provides a wrapper for tmLQCD or external multi-shift solvers.
+
+Note that it passes the shifts as expected by tmLQCD's \texttt{cg\_mms\_tm}, which means that they need to be squared.
+For the QPhiX normalisation, the QPhiX solver interface also divides them by $4\kappa^2$.
+The shifts are taken as is and not shifted by $\sigma_0$
+
+\subsubsection{Two flavour Wilson twisted mass (clover) fermions in the rational approximation}
+
+%%% Local Variables: 
+%%% mode: latex
+%%% TeX-master: "main"
+%%% End: 

--- a/doc/command.tex
+++ b/doc/command.tex
@@ -46,6 +46,11 @@
 \newcommand{\Qpm}{Q_{\pm}}
 \newcommand{\Qp}{Q_{+}}
 \newcommand{\Qm}{Q_{-}}
+\newcommand{\Mp}{M_{+}}
+\newcommand{\Mm}{M_{-}}
+\newcommand{\Dw}{D_\mathrm{w}}
+\newcommand{\Mw}{M_\mathrm{w}}
+\newcommand{\Msw}{M_\mathrm{sw}}
 \newcommand{\Wp}{W_{+}}
 \newcommand{\Wm}{W_{-}}
 \newcommand{\Qnd}{Q_{\textrm{ND}}}

--- a/doc/main.tex
+++ b/doc/main.tex
@@ -17,6 +17,7 @@
 \usepackage{algorithm}
 \usepackage{algorithmic}
 \usepackage{fancyvrb}
+\usepackage{cancel}
 
 \makeatletter
 \newcommand\footnoteref[1]{\protected@xdef\@thefnmark{\ref{#1}}\@footnotemark}
@@ -97,6 +98,9 @@
 
   \section{Deflation}
   \myinput{deflation}
+  
+  \section{Solvers}
+  \myinput{solvers}
 \end{appendix}
 
 

--- a/doc/main.tex
+++ b/doc/main.tex
@@ -18,6 +18,10 @@
 \usepackage{algorithmic}
 \usepackage{fancyvrb}
 \usepackage{cancel}
+\usepackage{framed}
+
+\usepackage[a4paper, total={16cm, 25cm}]{geometry}
+\usepackage{fancyvrb}
 
 \makeatletter
 \newcommand\footnoteref[1]{\protected@xdef\@thefnmark{\ref{#1}}\@footnotemark}
@@ -79,6 +83,7 @@
 \section{Interfaces to external QCD libraries}
 \myinput{quda.tex}
 \myinput{DDalphaAMG.tex}
+\myinput{qphix.tex}
 
 \clearpage
 \bibliographystyle{h-physrev5}

--- a/doc/qphix.tex
+++ b/doc/qphix.tex
@@ -1,0 +1,189 @@
+%author: Bartosz Kostrzewa <bartosz_kostrzewa@fastmail.com>
+%date: 10/2017
+
+\subsection{QPhiX: Optimised kernels and solvers for Intel Processors}\label{subsec:qphix}
+
+
+The QPhiX \cite{Joo2013} interface provides a library of MPI- and OpenMP-parallel linear operators and solvers for Wilson-type lattice fermions as well as a code-generator for the kernels employed by these operators.
+QPhiX has been extended to include all the operators relevant for tmLQCD, including the non-degenerate operator with and without the clover term.
+
+\subsubsection{Installation}
+If not already installed, you have to install QPhiX first. At the time of writing, the version with support for all twisted mass operators is in branch 
+\begin{itemize}
+  \item{\texttt{tm\_functor\_merge\_two-flav-mshift\_backport} of \\ \url{https://github.com/kostrzewa/qphix},}
+\end{itemize}
+which is due to be merged into the 
+\begin{itemize}
+\item{\texttt{devel} branch of \url{https://github.com/JeffersonLab/qphix}.}
+\end{itemize}
+
+It depends on QMP (\url{https://github.com/usqcd-software/qmp}), which is built and installed through the usual \texttt{configure, make, make install} mechanism.
+
+QPhiX is built using CMake and requires the availability of python 3, as well as the jinja2 library (\url{https://jinja.pocoo.org}).
+The latter can easily be installed via the pip package installer:
+\begin{framed}
+\begin{Verbatim}
+pip install --user jinja  
+\end{Verbatim}
+\end{framed}
+
+\textbf{QPhiX AVX2 Compilation}: 
+In order to compile QPhiX using GCC on an AVX2 machine, CMake is called in this way:
+\begin{framed}
+\begin{Verbatim}[fontsize=\small]
+CXX=mpicxx \
+CXXFLAGS="-mavx2 -mtune=core-avx2 -march=core-avx2 -std=c++11 -O3 -fopenmp" \
+cmake -Disa=avx2  \
+      -DQMP_DIR=${QMP_INSTALL_DIR} \
+      -Dparallel_arch=parscalar \
+      -Dhost_cxx=g++ \
+      -Dhost_cxxflags="-std=c++11 -O3" \
+      -Dtwisted_mass=TRUE \
+      -Dtm_clover=TRUE \
+      -Dclover=TRUE \
+      -Dtesting=FALSE  \
+      -DCMAKE_INSTALL_PREFIX=${QPHIX_INSTALL_DIR} ${QPHIX_SRC_DIR}
+\end{Verbatim}
+\end{framed}
+where \texttt{QMP\_INSTALL\_DIR}, \texttt{QPHIX\_INSTALL\_DIR} and \texttt{QPHIX\_SRC\_DIR} should be replaced with the QMP installation directory, the target installation directory for QPhiX and the QPhiX source directory respectively.
+
+In the command above:
+\begin{itemize}
+  \item{{\texttt{-Dtesting=FALSE} disables the building of all tests, which would additionally require QDP++ to be available}
+  \item{\texttt{-Dhost\_cxx} and \texttt{-Dhost\_cxxflags} define the compiler used for building the code generator executables. This can be any compiler and \texttt{g++} works just fine for this purpose.+}
+\end{itemize}
+
+\textbf{QPhiX AVX512 Compilation}: 
+On a KNL-based machine like Marconi A2 instead, the Intel compiler and Intel MPI library should be used instead:
+\begin{framed}
+\begin{Verbatim}
+CXX=mpiicpc \
+CXXFLAGS="-xMIC-AVX512 -std=c++11 -O3 -qopenmp" \
+CFLAGS="-xMIC-AVX512 -O3 -std=c99 -qopenmp" \
+cmake -Disa=avx512  \
+      -DQMP_DIR==${QMP_INSTALL_DIR} \
+      -Dparallel_arch=parscalar \
+      -Dhost_cxx=g++ \
+      -Dhost_cxxflags="-std=c++11 -O3" \
+      -Dtwisted_mass=TRUE \
+      -Dtm_clover=TRUE \
+      -Dclover=TRUE \
+      -Dtesting=FALSE  \
+      -DCMAKE_INSTALL_PREFIX=${QPHIX_INSTALL_DIR} ${QPHIX_SRC_DIR}
+\end{Verbatim}
+\end{framed}
+
+\textbf{tmLQCD AVX512 Compilation}: Once QPhiX is built and installed, tmLQCD can be configured as follows on a KNL AVX512 machine, for example:
+\begin{framed}
+\begin{Verbatim}[fontsize=\small]
+$ cd ${TMLQCD_SRC_DIR}
+$ autoconf
+$ cd ${TMLQCD_BUILD_DIR}
+$ ${TMLQCD_SRC_DIR}/configure \
+  --host=x86_64-linux-gnu \
+  --with-limedir=${LIME_INSTALL_DIR} \
+  --with-lemondir=${LEMON_INSTALL_DIR} \
+  --with-mpidimension=4 --enable-omp --enable-mpi \
+  --disable-sse2 --disable-sse3 \
+  --with-lapack="-Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a
+                 ${MKLROOT}/lib/intel64/libmkl_core.a
+                 ${MKLROOT}/lib/intel64/libmkl_intel_thread.a
+                 -Wl,--end-group -lpthread -lm -ldl" \
+  --disable-halfspinor --enable-gaugecopy \
+  --enable-alignment=64 \
+  --enable-qphix-soalen=4 \
+  --with-qphixdir=${QPHIX_INSTALL_DIR} \
+  --with-qmpdir=${QMP_INSTALL_DIR} \
+  CC=mpiicc CXX=mpiicpc F77=ifort \
+  CFLAGS="-O3 -std=c99 -qopenmp -xMIC-AVX512 -fma -debug full" \
+  CXXFLAGS="-O3 -std=c++11 -qopenmp -xMIC-AVX512 -fma -g -debug full" \
+  LDFLAGS="-qopenmp"
+\end{Verbatim}
+\end{framed}
+\textbf{IMPORTANT:} On AVX512 machines, for some reason, the half-spinor tmLQCD operators do not work (likely an issue with MPI and alignment).
+As a result, \texttt{--disable-halfspinor} is passed when building on these architectures.
+
+\texttt{--enable-qphix-soalen=4} sets the QPhiX \emph{structure of array} (SoA) length, which defines the size of the innermost direction in the blocked data-structures in QPhiX.
+\emph{Half} the \emph{local} lattice extent in $X$ direction, $L_x/2$, has to be divisible by this number.
+Setting this equal to the double-precision SIMD length on a given architecture means that a full double-precision SIMD vector can be loaded in a single instruction, while values below the SIMD vector length will result in multiple load and store instructions, while all computation are always carried out on full vectors.
+
+For now, the same SoA length is used for all supported arithmetic precisions as this facilitates thinking about possible parallelisation strategies.
+
+On AVX512 machines, a setting this to $8$ would be optimal, but at the time of writing QPhiX issue \#$98$\footnote{\url{https://github.com/JeffersonLab/qphix/issues/98}} prevents this, as it seems that the mixed-precision solver diverges when this is done.
+At the cost of a mild performance hit, it is recomended that $4$ be used until the issue has been resolved.
+
+The QPhiX interface can be combined with DD$\alpha$AMG without problems, but buildign together with the QUDA interface is only possible using GCC or clang, since QUDA is not compatible with the Intel compiler.
+On the QPhiX side, this will result in a potentially significant reduction of performance.
+
+\subsubsection{Usage}
+
+\noindent\textbf{QPhiX global parameters}: The blocking and threading parameters for QPhiX are passed by adding the following section to the tmLQCD input file:
+\begin{framed}
+\begin{Verbatim}
+BeginExternalInverter QPHIX
+  # physical cores per MPI task
+  NCores = 34
+  # block sizes (see qphix papers for details)
+  By = 8
+  Bz = 8
+  MinCt = 1
+  # (hyper-)thread geometry
+  # ompnumthreads = NCores * Sy * Sz
+  # hyperthreads should be specified here
+  Sy = 1
+  Sz = 2
+  # paddings in XY and XYZ blocks
+  PadXY = 1
+  PadXYZ = 0
+EndExternalInverter    
+\end{Verbatim}
+\end{framed}
+
+\begin{itemize}
+  \item{\texttt{NCores}: number of physical cores per MPI task. On KNL, it might even make sense to specify twice the number of physical cores since each core contains two vector processing units (VPUs). Another possiblity would be to specify the number of tiles per MPI tasks and consider cores and VPUs throuh \texttt{Sz} and \texttt{Sy} below. The only case that has been tested for performance is to set this equal to the number of physical cores per MPI task.}
+  \item{\texttt{By, Bz}: the QPhiX data structures are organised into blocks which can be efficiently loaded into CPU caches. \texttt{By} and \texttt{Bz} define the size of these blocks in the $Y$ and $Z$ lattice dimensions. The local lattice extent in the given dimension should be divisible by the respective block extent. Generally, $4$ or $8$ are good values and the larger of the two may be preferable.}
+  \item{\texttt{MinCt}: number of cores given an individual time-slice to process. This is useful for dual-socket systems when running with a single MPI task per node. In this case, this should be set to $2$ which will allow the kernels to run in a NUMA-friendly fashion. The local $T$ dimension must be divisible by this number. On KNL, this should be set to $1$.}
+  \item{\texttt{Sy, Sz}: thread blocking parameters. When multiple threads share resources (this is the case for cores and hyperthreads on KNL, for example), these parameters make it possible to consider this in the volume-traversal loops implemented in QPhiX. On KNL, the only setting which has been tested for performance is to set this equal to $2$, given that \texttt{NCores} has been set to the number of physical cores. \texttt{Sz} then splits the local $Z$ direction among two hyperthreads.}
+  \item{\texttt{PadXY(Z)}: Adds padding to the QPhiX data structures which may result in higer overall performance. Only value tested on KNL is \texttt{PadXY=1} and \texttt{PadXYZ=0}.}
+\end{itemize}
+
+\noindent\textbf{IMPORTANT}: The global setting \texttt{OmpNumThreads} should be set to \texttt{NCores * Sy * Sz}, otherwise the QPhiX interface will abort execution.
+
+\noindent\textbf{QPhiX operator / monomial parameters}: QPhiX solvers are available in operators for inversions and monomials for performing HMC with the same parameters.
+For a clover determinant, using QPhiX solvers instead of tmLQCD-native ones would be achieved as follows:
+\begin{framed}
+\begin{Verbatim}
+BeginMonomial CLOVERDET
+  Timescale = 1
+  kappa = 0.1394267
+  2KappaMu = 0.00069713350
+  CSW = 1.69
+  rho = 0.238419657
+  MaxSolverIterations = 5000
+  AcceptancePrecision =  1.e-21
+  ForcePrecision = 1.e-16
+  Name = cloverdetlight
+  Solver = mixedcg
+  UseExternalInverter = qphix
+  UseCompression = 12
+  UseSloppyPrecision = single
+EndMonomial  
+\end{Verbatim}
+\end{framed}
+\begin{itemize}
+  \item{\texttt{Solver}: specify the solver type (see below for the solvers supported by the QPhiX interface).} 
+  \item{\texttt{UseExternalInverter}: the external inverter \texttt{qphix} should be used for this monomial.}
+  \item{\texttt{UseCompression}: gauge compression should be used (\texttt{12}). This improves performance by increasing the flop/byte ratio. Twisted boundary conditions are fully supported in all directions.}
+  \item{\texttt{UseSloppyPrecision}: for a solver using just a single arithmetic precision (like basic \texttt{cg} or \texttt{bicgstab}), this sets the arithmetic precision employed. For a mixed-precision solver such as \texttt{mixedcg}, this sets the arithmetic precision of the inner solver.}
+\end{itemize}
+
+\noindent\textbf{Supported solvers}: The QPhiX interface provides support for the solvers:
+\begin{itemize}
+\item{\texttt{cg}}
+\item{\texttt{mixedcg}}
+\item{\texttt{bicgstab}}
+\item{\texttt{mixedbicgstab}}
+\item{\texttt{cgmms} (single-flavour rational \emph{monomials} only)}
+\item{\texttt{cgmmsnd} (two-flavour non-degenerate \emph{monomials} only}
+\end{itemize}
+Note that as usual, \texttt{bicgstab} and \texttt{mixedbicgstab} do not converge for twisted mass fermions at maximal twist.

--- a/doc/quda.tex
+++ b/doc/quda.tex
@@ -1,7 +1,7 @@
 %author: Mario Schroeck <mario.schroeck@roma3.infn.it>
 %date: 04/2015
 
-\subsection{QUDA: A library for QCD on GPUs}
+\subsection{QUDA: A library for QCD on GPUs}\label{subsec:quda}
 
 
 The QUDA \cite{Clark:2009wm, Babich:2011np, Strelchenko:2013vaa} interface is complementary to tmLQCD's own CUDA kernels for computations on the GPU by Florian Burger.
@@ -69,7 +69,7 @@ Note that a {\ttfamily C++} compiler is required for linking against the QUDA li
 
 
 \subsubsection{Usage}
-Any main program that reads and handles the operator declaration from an input file can easily be set up to use the QUDA inverter by setting the {\ttfamily UseQudaInverter} flag to {\ttfamily yes}. For example, in the input file for the {\ttfamily invert} executable, add the flag to the operator declaration as
+Any main program that reads and handles the operator declaration from an input file can easily be set up to use the QUDA inverter by setting the {\ttfamily UseExternalInverter} flag to {\ttfamily quda}. For example, in the input file for the {\ttfamily invert} executable, add the flag to the operator declaration as
 \begin{verbatim}
 BeginOperator TMWILSON
   2kappaMu = 0.05
@@ -78,7 +78,7 @@ BeginOperator TMWILSON
   Solver = CG
   SolverPrecision = 1e-14
   MaxSolverIterations = 1000
-  UseQudaInverter = yes
+  UseExternalInverter = quda
 EndOperator
 \end{verbatim}
 and the operator of interest will be inverted using QUDA. The initialization of QUDA is done automatically within the operator initialization,  the QUDA library should be finalized by a call to {\ttfamily \_endQuda()} just before finalizing MPI. When you use the QUDA interface for work that is being published, don't forget to cite \cite{Clark:2009wm, Babich:2011np, Strelchenko:2013vaa}.

--- a/doc/rational.tex
+++ b/doc/rational.tex
@@ -1,4 +1,4 @@
-\subsection{Rational HMC}
+\subsection{Rational HMC} \label{subsec:rationalhmc}
 
 For the heavy doublet one may alternatively use a rational
 approximation 
@@ -164,39 +164,6 @@ which can be done in different ways:
 \item the third is to use a more precise rational approximation for
   the heatbath and acceptance steps.
 \end{itemize}
-
-\subsubsection{CGMMS Solver}
-
-\begin{algorithm}
-  \caption{CGMMS algorithm}
-  \label{alg:cgm}
-  \begin{algorithmic}[1]
-    \vspace{.2cm}
-    \STATE $n=0, x_0^k = 0, r_0 = p_0 = p_0^k = b, k_\mathrm{max},
-    \delta, \epsilon$
-    \STATE  $\biggl.\biggr.\alpha_{-1} = \zeta_{-1}^k = \zeta_0^k = 1, \beta_0^k = \beta_0 = 0$
-    \REPEAT
-    \STATE $\alpha_n = (r_n, r_n) / (p_n, A p_n)$
-    \FOR{$k = 1$ to $k_\mathrm{max}$}
-    \STATE $\biggl.\biggr.\zeta_{n+1}^k = (\zeta^k_n  \alpha_{n-1}) / 
-      (\alpha_n \beta_n(1 - \zeta_n^k / \zeta^k_{n-1}) + \alpha_{n-1}
-      (1-\sigma_k\alpha_n))$
-    \STATE $\alpha^k_n = (\alpha_n \zeta_{n+1}^k)/ \zeta_n^k$
-    \STATE $\biggl.\biggr.x_{n+1}^k = x_n^k + \alpha_n^k p_n^k$
-    \IF{$\|\alpha^{k_\mathrm{max}} p^{k_\mathrm{max}}\| < \delta$}
-    \STATE $k_\mathrm{max} = k_\mathrm{max} -1$
-    \ENDIF
-    \ENDFOR
-    \STATE $x_{n+1} = x_n + \alpha_n p_n$
-    \STATE $\biggl.\biggr.r_{n+1} = r_n - \alpha_n Ap_n$
-    \STATE $\beta_{n+1} = (r_{n+1}, r_{n+1}) / (r_n, r_n)$
-    \STATE $\beta_{n+1}^k = \frac{\beta_{n+1} \zeta_{n+1}^k \alpha_n^k}{\zeta_{n}^k\alpha_n}$
-    \STATE $\biggl.\biggr.p_{n+1}^k = \zeta_{n+1}^k r_{n+1} + \beta_{n+1}^k p_n^k$
-    \STATE $n=n+1$
-    \UNTIL{$\|r_n\|<\epsilon$}
-  \end{algorithmic}
-\end{algorithm}
-
 
 For evaluating the rational approximation $\mathcal{R}$ applied to a
 spinor field $\psi$ a multi-mass or multi-shift solver (see

--- a/doc/solvers.tex
+++ b/doc/solvers.tex
@@ -1,0 +1,4 @@
+In this section, we give details of some of the solvers which are implemented in tmLQCD.
+In particular, we clarify some of the conventions used and how these map over to the external library interfaces.
+
+\myinput{cgmms}

--- a/global.h
+++ b/global.h
@@ -280,26 +280,5 @@ EXTERN int ** g_idn3d;
 
 void fatal_error(char const *error, char const *function);
 
-/* enumeration type for the sloppy prec. of the inverter */
-typedef enum SloppyPrecision_s {
-  SLOPPY_DOUBLE = 0,
-  SLOPPY_SINGLE,
-  SLOPPY_HALF
-} SloppyPrecision;
-
-/* enumeration type for the compression of the inverter */
-typedef enum CompressionType_s {
-  NO_COMPRESSION = 18,
-  COMPRESSION_12 = 12,
-  COMPRESSION_8  = 8
-} CompressionType;
-
-/* enumeration type for the external inverter */
-typedef enum ExternalInverter_s {
-  NO_EXT_INV = 0,
-  QUDA_INVERTER,
-  QPHIX_INVERTER
-} ExternalInverter;
-
 #endif
 

--- a/invert_clover_eo.c
+++ b/invert_clover_eo.c
@@ -111,12 +111,12 @@ int invert_clover_eo(spinor * const Even_new, spinor * const Odd_new,
 #ifdef TM_USE_QPHIX
     if( inverter==QPHIX_INVERTER ) {
       // QPhiX inverts M(mu)M(mu)^dag or M(mu), no gamma_5 multiplication required
-      iter = invert_eo_qphix(NULL, Odd_new, NULL, g_spinor_field[DUM_DERI],
-                            precision, max_iter,
-                            solver_flag, rel_prec,
-                            solver_params,
-                            sloppy,
-                            compression, Qsq);
+      iter = invert_eo_qphix_oneflavour(Odd_new, g_spinor_field[DUM_DERI],
+                                        precision, max_iter,
+                                        solver_flag, rel_prec,
+                                        solver_params,
+                                        sloppy,
+                                        compression);
       // for solver_params.solution_type == TM_SOLUTION_M (the default)
       // QPhiX applies M(mu)^dag internally for normal equation solves, no call to tmLQCD operaor required
     } else

--- a/invert_clover_eo.c
+++ b/invert_clover_eo.c
@@ -66,7 +66,7 @@ int invert_clover_eo(spinor * const Even_new, spinor * const Odd_new,
                      const int solver_flag, const int rel_prec, const int even_odd_flag,
 		     solver_params_t solver_params,
                      su3 *** gf, matrix_mult Qsq, matrix_mult Qm,
-                     const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression) {
+                     const ExternalInverter external_inverter, const SloppyPrecision sloppy, const CompressionType compression) {
   int iter;
 
   if(even_odd_flag) {  
@@ -75,7 +75,7 @@ int invert_clover_eo(spinor * const Even_new, spinor * const Odd_new,
     }
     
 #ifdef QUDA
-    if( inverter==QUDA_INVERTER ) {
+    if( external_inverter==QUDA_INVERTER ) {
       return invert_eo_quda(Even_new, Odd_new, Even, Odd,
                             precision, max_iter,
                             solver_flag, rel_prec,
@@ -109,10 +109,10 @@ int invert_clover_eo(spinor * const Even_new, spinor * const Odd_new,
     
     /* Here we invert the hermitean operator squared */
 #ifdef TM_USE_QPHIX
-    if( inverter==QPHIX_INVERTER ) {
+    if( external_inverter==QPHIX_INVERTER ) {
       // QPhiX inverts M(mu)M(mu)^dag or M(mu), no gamma_5 multiplication required
       iter = invert_eo_qphix_oneflavour(Odd_new, g_spinor_field[DUM_DERI],
-                                        precision, max_iter,
+                                        max_iter, precision,
                                         solver_flag, rel_prec,
                                         solver_params,
                                         sloppy,

--- a/invert_clover_eo.h
+++ b/invert_clover_eo.h
@@ -13,6 +13,6 @@ int invert_clover_eo(spinor * const Even_new, spinor * const Odd_new,
                      const int solver_flag, const int rel_prec,
 		     const int even_odd_flag, solver_params_t solver_params,
                      su3 *** gf, matrix_mult Qsq, matrix_mult Qm,
-                     const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression);
+                     const ExternalInverter external_inverter, const SloppyPrecision sloppy, const CompressionType compression);
 
 #endif

--- a/invert_clover_eo.h
+++ b/invert_clover_eo.h
@@ -3,6 +3,7 @@
 
 #include "global.h"
 #include "su3.h"
+#include "misc_types.h"
 #include "solver/matrix_mult_typedef.h"
 #include "solver/solver_params.h"
 

--- a/invert_doublet_eo.c
+++ b/invert_doublet_eo.c
@@ -50,7 +50,9 @@
 #ifdef QUDA
 #  include "quda_interface.h"
 #endif
-
+#ifdef TM_USE_QPHIX
+#include "qphix_interface.h"
+#endif
 
 #ifdef HAVE_GPU
 #  include"GPU/cudadefs.h"
@@ -63,20 +65,19 @@ extern su3* g_trafo;
 #  endif
 #endif
 
-
 int invert_doublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s, 
                       spinor * const Even_new_c, spinor * const Odd_new_c,
                       spinor * const Even_s, spinor * const Odd_s,
                       spinor * const Even_c, spinor * const Odd_c,
                       const double precision, const int max_iter,
                       const int solver_flag, const int rel_prec, 
-                      solver_params_t solver_params, const ExternalInverter inverter, 
+                      solver_params_t solver_params, const ExternalInverter external_inverter, 
                       const SloppyPrecision sloppy, const CompressionType compression) {
 
   int iter = 0;
 
 #ifdef QUDA
-  if( inverter==QUDA_INVERTER ) {
+  if( external_inverter==QUDA_INVERTER ) {
     return invert_doublet_eo_quda( Even_new_s, Odd_new_s, Even_new_c, Odd_new_c,
                                    Even_s, Odd_s, Even_c, Odd_c,
                                    precision, max_iter,
@@ -118,43 +119,51 @@ int invert_doublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
     printf("# Using CG for TMWILSON flavour doublet!\n"); 
     fflush(stdout);
   }
-  gamma5(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI], VOLUME/2);
-  gamma5(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI+1], VOLUME/2);
-  
+  if ( external_inverter == NO_EXT_INV ){
+    gamma5(g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI], VOLUME/2);
+    gamma5(g_spinor_field[DUM_DERI+1], g_spinor_field[DUM_DERI+1], VOLUME/2);
   
 #ifdef HAVE_GPU
-  if (usegpu_flag) {    // GPU, mixed precision solver
-#  if ( defined TM_USE_MPI  && defined PARALLELT )
-    iter = mixedsolve_eo_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
-                            max_iter, precision, rel_prec);
-#  elif ( !defined TM_USE_MPI  && !defined PARALLELT )
-    iter = mixedsolve_eo_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
-                            max_iter, precision, rel_prec);
-#  else
-    printf("MPI and/or PARALLELT are not appropriately set for the GPU implementation. Aborting...\n");
-    exit(-1);
-#  endif
-  }
-  else {                // CPU, conjugate gradient
-    iter = cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
-                     max_iter, precision, rel_prec, 
-                     VOLUME/2, &Qtm_pm_ndpsi);
-  }
+    if (usegpu_flag) {    // GPU, mixed precision solver
+#    if ( defined TM_USE_MPI  && defined PARALLELT )
+      iter = mixedsolve_eo_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
+                              max_iter, precision, rel_prec);
+#    elif ( !defined TM_USE_MPI  && !defined PARALLELT )
+      iter = mixedsolve_eo_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
+                              max_iter, precision, rel_prec);
+#    else
+      printf("MPI and/or PARALLELT are not appropriately set for the GPU implementation. Aborting...\n");
+      exit(-1);
+#    endif
+    }
+    else {                // CPU, conjugate gradient
+      iter = cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
+                       max_iter, precision, rel_prec, 
+                       VOLUME/2, &Qtm_pm_ndpsi);
+    }
 #else                   // CPU, conjugate gradient
-  if(solver_flag == RGMIXEDCG){
-    iter = rg_mixed_cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
-                              solver_params, max_iter, precision, rel_prec, VOLUME/2,
-                              &Qtm_pm_ndpsi, &Qtm_pm_ndpsi_32);
-  } 
-  else {
-    iter = cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
-                     max_iter, precision, rel_prec, VOLUME/2, &Qtm_pm_ndpsi);
-  }
+    if(solver_flag == RGMIXEDCG){
+      iter = rg_mixed_cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
+                                solver_params, max_iter, precision, rel_prec, VOLUME/2,
+                                &Qtm_pm_ndpsi, &Qtm_pm_ndpsi_32);
+    } 
+    else {
+      iter = cg_her_nd(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
+                       max_iter, precision, rel_prec, VOLUME/2, &Qtm_pm_ndpsi);
+    }
 #endif
-  
-  
-  Qtm_dagger_ndpsi(Odd_new_s, Odd_new_c,
-                   Odd_new_s, Odd_new_c);
+    Qtm_dagger_ndpsi(Odd_new_s, Odd_new_c,
+                     Odd_new_s, Odd_new_c);
+  } // if(NO_EXT_INV)
+#ifdef TM_USE_QPHIX
+  else if (external_inverter == QPHIX_INVERTER ) {
+    // using QPhiX, we invert M M^dagger y = b, so we don't need gamma_5 multiplications
+    iter = invert_eo_qphix_twoflavour(Odd_new_s, Odd_new_c, g_spinor_field[DUM_DERI], g_spinor_field[DUM_DERI+1],
+                                      max_iter, precision, solver_flag, rel_prec,
+                                      solver_params, sloppy, compression);
+    // and it multiplies y internally by M^dagger, returning M^{-1} b as required
+  }
+#endif // TM_USE_QPHIX
 
   /* Reconstruct the even sites                */
   Hopping_Matrix(EO, g_spinor_field[DUM_DERI], Odd_new_s);
@@ -188,12 +197,12 @@ int invert_cloverdoublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
                       spinor * const Even_c, spinor * const Odd_c,
                       const double precision, const int max_iter,
                       const int solver_flag, const int rel_prec, solver_params_t solver_params,
-                      const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression) {
+                      const ExternalInverter external_inverter, const SloppyPrecision sloppy, const CompressionType compression) {
   
   int iter = 0;
 
 #ifdef QUDA
-  if( inverter==QUDA_INVERTER ) {
+  if( external_inverter==QUDA_INVERTER ) {
     return invert_doublet_eo_quda( Even_new_s, Odd_new_s, Even_new_c, Odd_new_c,
                                    Even_s, Odd_s, Even_c, Odd_c,
                                    precision, max_iter,

--- a/invert_doublet_eo.h
+++ b/invert_doublet_eo.h
@@ -40,7 +40,7 @@ int invert_doublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
                       spinor * const Even_c, spinor * const Odd_c,
                       const double precision, const int max_iter,
                       const int solver_flag, const int rel_prec, solver_params_t solver_params,
-                      const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression);
+                      const ExternalInverter extenral_inverter, const SloppyPrecision sloppy, const CompressionType compression);
 
 
 /* This is the full matrix multiplication */
@@ -57,5 +57,5 @@ int invert_cloverdoublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
                       spinor * const Even_c, spinor * const Odd_c,
                       const double precision, const int max_iter,
                       const int solver_flag, const int rel_prec, solver_params_t solver_params,
-                      const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression);
+                      const ExternalInverter external_inverter, const SloppyPrecision sloppy, const CompressionType compression);
 #endif

--- a/invert_doublet_eo.h
+++ b/invert_doublet_eo.h
@@ -31,6 +31,7 @@
 #define _INVERT_DOUBLET_EO_H
 
 #include "global.h"
+#include "misc_types.h"
 #include "solver/solver_params.h"
 
 int invert_doublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s, 

--- a/invert_eo.c
+++ b/invert_eo.c
@@ -86,12 +86,12 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
               const int solver_flag, const int rel_prec,
               const int sub_evs_flag, const int even_odd_flag,
               const int no_extra_masses, double * const extra_masses, solver_params_t solver_params, const int id,
-              const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression )  {
+              const ExternalInverter external_inverter, const SloppyPrecision sloppy, const CompressionType compression )  {
 
   int iter = 0;
 
 #ifdef QUDA
-  if( inverter==QUDA_INVERTER ) {
+  if( external_inverter==QUDA_INVERTER ) {
     return invert_eo_quda(Even_new, Odd_new, Even, Odd,
                           precision, max_iter,
                           solver_flag, rel_prec,
@@ -159,10 +159,10 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
     /* matrix to get the odd sites               */
     
 #ifdef TM_USE_QPHIX
-    if( inverter==QPHIX_INVERTER ) {
+    if( external_inverter==QPHIX_INVERTER ) {
       // QPhiX inverts M(mu)M(mu)^dag or M(mu), no gamma_5 source multiplication required
       iter = invert_eo_qphix_oneflavour(Odd_new, g_spinor_field[DUM_DERI],
-                                        precision, max_iter,
+                                        max_iter, precision,
                                         solver_flag, rel_prec,
                                         solver_params,
                                         sloppy,

--- a/invert_eo.c
+++ b/invert_eo.c
@@ -161,12 +161,12 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
 #ifdef TM_USE_QPHIX
     if( inverter==QPHIX_INVERTER ) {
       // QPhiX inverts M(mu)M(mu)^dag or M(mu), no gamma_5 source multiplication required
-      iter = invert_eo_qphix(NULL, Odd_new, NULL, g_spinor_field[DUM_DERI],
-                            precision, max_iter,
-                            solver_flag, rel_prec,
-                            solver_params,
-                            sloppy,
-                            compression, &Qtm_pm_psi);    
+      iter = invert_eo_qphix_oneflavour(Odd_new, g_spinor_field[DUM_DERI],
+                                        precision, max_iter,
+                                        solver_flag, rel_prec,
+                                        solver_params,
+                                        sloppy,
+                                        compression);    
       // for solver_params.solution_type == TM_SOLUTION_M (the default)
       // QPhiX applies M(mu)^dag internally for normal equation solves, no call to tmLQCD operaor required
     } else

--- a/invert_eo.c
+++ b/invert_eo.c
@@ -166,7 +166,7 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
                             solver_flag, rel_prec,
                             solver_params,
                             sloppy,
-                            compression, &Qtm_pm_psi);
+                            compression, &Qtm_pm_psi);    
       // for solver_params.solution_type == TM_SOLUTION_M (the default)
       // QPhiX applies M(mu)^dag internally for normal equation solves, no call to tmLQCD operaor required
     } else

--- a/invert_eo.c
+++ b/invert_eo.c
@@ -166,7 +166,7 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
                                         solver_flag, rel_prec,
                                         solver_params,
                                         sloppy,
-                                        compression);    
+                                        compression);
       // for solver_params.solution_type == TM_SOLUTION_M (the default)
       // QPhiX applies M(mu)^dag internally for normal equation solves, no call to tmLQCD operaor required
     } else

--- a/invert_eo.h
+++ b/invert_eo.h
@@ -27,6 +27,7 @@
 #ifndef _INVERT_EO_H
 #define _INVERT_EO_H
 #include "global.h"
+#include "misc_types.h"
 #include "solver/solver_params.h"
 
 int invert_eo(spinor * const Even_new, spinor * const Odd_new, 

--- a/invert_eo.h
+++ b/invert_eo.h
@@ -36,6 +36,6 @@ int invert_eo(spinor * const Even_new, spinor * const Odd_new,
               const int solver_flag, const int rel_prec,
               const int sub_evs_flag, const int even_odd_flag,
               const int no_extra_masses, double * const extra_masses, solver_params_t solver_params, const int id,
-              const ExternalInverter inverter, const SloppyPrecision sloppy, const CompressionType compression );
+              const ExternalInverter external_inverter, const SloppyPrecision sloppy, const CompressionType compression );
 
 #endif

--- a/linalg/Makefile.in
+++ b/linalg/Makefile.in
@@ -46,7 +46,8 @@ liblinalg_TARGETS = assign_add_mul_r_add_mul \
 	assign_mul_add_r_and_square \
 	addto_32 scalar_prod_r_32 assign_mul_add_r_32 assign_add_mul_r_32 \
 	square_norm_32 assign_to_32 diff_32 \
-	convert_odd_to_lexic set_even_to_zero mul_gamma5
+	convert_odd_to_lexic set_even_to_zero mul_gamma5 \
+	mul_r_gamma5
 
 liblinalg_STARGETS = diff assign_add_mul_r assign_mul_add_r square_norm
 

--- a/linalg/mul_r_gamma5.c
+++ b/linalg/mul_r_gamma5.c
@@ -1,0 +1,68 @@
+/***********************************************************************
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008 Carsten Urbach
+ *               2017                               Bartosz Kostrzewa
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ ***********************************************************************/
+
+#ifdef HAVE_CONFIG_H
+# include<config.h>
+#endif
+#ifdef TM_USE_OMP
+# include <omp.h>
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include "su3.h"
+#include "mul_r_gamma5.h"
+
+void mul_r_gamma5(spinor * const R, const double c, const int N){
+#ifdef TM_USE_OMP
+#pragma omp parallel
+  {
+#endif
+
+  int ix;
+  spinor *r;
+  
+#ifdef TM_USE_OMP
+#pragma omp for
+#endif
+  for (ix = 0; ix < N; ix++){
+    r=(spinor *) R + ix;
+    
+    r->s0.c0 = c * r->s0.c0;
+    r->s0.c1 = c * r->s0.c1;
+    r->s0.c2 = c * r->s0.c2;
+    
+    r->s1.c0 = c * r->s1.c0;
+    r->s1.c1 = c * r->s1.c1;
+    r->s1.c2 = c * r->s1.c2;
+    
+    r->s2.c0 = -c * r->s2.c0;
+    r->s2.c1 = -c * r->s2.c1;
+    r->s2.c2 = -c * r->s2.c2;
+    
+    r->s3.c0 = -c * r->s3.c0;
+    r->s3.c1 = -c * r->s3.c1;
+    r->s3.c2 = -c * r->s3.c2;
+  }
+#ifdef TM_USE_OMP
+  } /*OpenMP closing brace */
+#endif
+
+}

--- a/linalg/mul_r_gamma5.h
+++ b/linalg/mul_r_gamma5.h
@@ -1,0 +1,29 @@
+/***********************************************************************
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008 Carsten Urbach
+ *               2017                               Bartosz Kostrzewa
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ ***********************************************************************/
+
+#ifndef MUL_R_GAMMA5_H
+#define MUL_R_GAMMA5_H
+
+#include "su3.h"
+
+/*   Makes (*R) = c*\gamma5 (*R)   c is a real constant*/
+void mul_r_gamma5(spinor * const R, const double c, const int N);
+
+#endif

--- a/meas/measurements.c
+++ b/meas/measurements.c
@@ -61,11 +61,15 @@ int init_measurements(){
     if(measurement_list[i].type == ONLINE) {
       measurement_list[i].measurefunc = &correlators_measurement;
       measurement_list[i].max_source_slice = g_nproc_t*T;
+      measurement_list[i].no_samples = 1;
+      measurement_list[i].all_time_slices = 0;
     }
 
     if(measurement_list[i].type == PIONNORM) {
       measurement_list[i].measurefunc = &pion_norm_measurement;
       measurement_list[i].max_source_slice = g_nproc_z*LZ;
+      measurement_list[i].no_samples = 1;
+      measurement_list[i].all_time_slices = 0;
     }
     
     if(measurement_list[i].type == POLYAKOV) {

--- a/misc_types.h
+++ b/misc_types.h
@@ -1,0 +1,50 @@
+/***********************************************************************
+ *
+ * Copyright (C) 2017 Bartosz Kostrzewa
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ ***********************************************************************/
+
+#ifndef MISC_TYPES_H
+#define MISC_TYPES_H
+
+/* enumeration type for the sloppy prec. of the inverter */
+typedef enum SloppyPrecision_s {
+  SLOPPY_DOUBLE = 0,
+  SLOPPY_SINGLE,
+  SLOPPY_HALF
+} SloppyPrecision;
+
+/* enumeration type for the compression of the inverter */
+typedef enum CompressionType_s {
+  NO_COMPRESSION = 18,
+  COMPRESSION_12 = 12,
+  COMPRESSION_8  = 8
+} CompressionType;
+
+/* enumeration type for the external inverter */
+typedef enum ExternalInverter_s {
+  NO_EXT_INV = 0,
+  QUDA_INVERTER,
+  QPHIX_INVERTER
+} ExternalInverter;
+
+typedef enum backup_restore_t {
+  TM_BACKUP_GLOBALS = 0,
+  TM_RESTORE_GLOBALS
+} backup_restore_t;
+
+#endif // MISC_TYPES_H

--- a/misc_types.h
+++ b/misc_types.h
@@ -47,4 +47,9 @@ typedef enum backup_restore_t {
   TM_RESTORE_GLOBALS
 } backup_restore_t;
 
+typedef enum real_imag_t {
+  TM_REAL = 0,
+  TM_IMAG
+} real_imag_t;
+
 #endif // MISC_TYPES_H

--- a/monomial/cloverdet_monomial.c
+++ b/monomial/cloverdet_monomial.c
@@ -94,8 +94,9 @@ void cloverdet_derivative(const int id, hamiltonian_field_t * const hf) {
   // X_o -> w_fields[1]
   chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
                mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
-  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->forceprec, 
-                                 g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
+  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, mnl->maxiter,
+                                 mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, 
+                                 mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
                       mnl->csg_N, &mnl->csg_n, N);
   
@@ -229,12 +230,14 @@ double cloverdet_acc(const int id, hamiltonian_field_t * const hf) {
       chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, N, mnl->Qp);
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->accprec,  
-				     g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver); 
+				     g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver,
+                                     mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
   } else {
       chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, N, mnl->Qsq);
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->accprec,  
-				     g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver); 
+				     g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
+                                     mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
       mnl->Qm(mnl->w_fields[0], mnl->w_fields[0]);
   }
   g_sloppy_precision_flag = save_sloppy;

--- a/monomial/cloverdet_monomial.c
+++ b/monomial/cloverdet_monomial.c
@@ -99,7 +99,7 @@ void cloverdet_derivative(const int id, hamiltonian_field_t * const hf) {
                mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
   mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, mnl->maxiter,
                                  mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, 
-                                 mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+                                 mnl->solver);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
                       mnl->csg_N, &mnl->csg_n, N);
   
@@ -233,14 +233,12 @@ double cloverdet_acc(const int id, hamiltonian_field_t * const hf) {
       chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, N, mnl->Qp);
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->accprec,  
-				     g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver,
-                                     mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
+				     g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver); 
   } else {
       chrono_guess(mnl->w_fields[1], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		   mnl->csg_N, mnl->csg_n, N, mnl->Qsq);
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->accprec,  
-				     g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
-                                     mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
+				     g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver); 
       mnl->Qm(mnl->w_fields[0], mnl->w_fields[0]);
   }
   g_sloppy_precision_flag = save_sloppy;

--- a/monomial/cloverdet_monomial.c
+++ b/monomial/cloverdet_monomial.c
@@ -72,8 +72,11 @@ void cloverdet_derivative(const int id, hamiltonian_field_t * const hf) {
    *
    *********************************************************************/
   
+  mnl_backup_restore_globals(TM_BACKUP_GLOBALS);
+  g_c_sw = mnl->c_sw;
   g_mu = mnl->mu;
   g_mu3 = mnl->rho;
+  g_kappa = mnl->kappa;
   boundary(mnl->kappa);
   
   // we compute the clover term (1 + T_ee(oo)) for all sites x
@@ -143,9 +146,7 @@ void cloverdet_derivative(const int id, hamiltonian_field_t * const hf) {
   // uses the gaugefields in hf and changes the derivative field in hf
   sw_all(hf, mnl->kappa, mnl->c_sw);
 
-  g_mu = g_mu1;
-  g_mu3 = 0.;
-  boundary(g_kappa);
+  mnl_backup_restore_globals(TM_RESTORE_GLOBALS);
   etime = gettime();
   if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
@@ -161,9 +162,11 @@ void cloverdet_heatbath(const int id, hamiltonian_field_t * const hf) {
   atime = gettime();
   int N = VOLUME/2;
 
+  mnl_backup_restore_globals(TM_BACKUP_GLOBALS);
   g_mu = mnl->mu;
   g_mu3 = mnl->rho;
   g_c_sw = mnl->c_sw;
+  g_kappa = mnl->kappa;
   boundary(mnl->kappa);
   mnl->csg_n = 0;
   mnl->csg_n2 = 0;
@@ -187,9 +190,7 @@ void cloverdet_heatbath(const int id, hamiltonian_field_t * const hf) {
   chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
                       mnl->csg_N, &mnl->csg_n, N);
 
-  g_mu = g_mu1;
-  g_mu3 = 0.;
-  boundary(g_kappa);
+  mnl_backup_restore_globals(TM_RESTORE_GLOBALS);
   etime = gettime();
   if(g_proc_id == 0) {
     if(g_debug_level > 1) {
@@ -210,9 +211,11 @@ double cloverdet_acc(const int id, hamiltonian_field_t * const hf) {
   atime = gettime();
   int N = VOLUME/2;
 
+  mnl_backup_restore_globals(TM_BACKUP_GLOBALS);
   g_mu = mnl->mu;
   g_mu3 = mnl->rho;
   g_c_sw = mnl->c_sw;
+  g_kappa = mnl->kappa;
   boundary(mnl->kappa);
 
   sw_term( (const su3**) hf->gaugefield, mnl->kappa, mnl->c_sw); 
@@ -244,9 +247,7 @@ double cloverdet_acc(const int id, hamiltonian_field_t * const hf) {
   /* Compute the energy contr. from first field */
   mnl->energy1 = square_norm(mnl->w_fields[0], N, 1);
 
-  g_mu = g_mu1;
-  g_mu3 = 0.;
-  boundary(g_kappa);
+  mnl_backup_restore_globals(TM_RESTORE_GLOBALS);
   etime = gettime();
   if(g_proc_id == 0) {
     if(g_debug_level > 1) {

--- a/monomial/cloverdetratio_monomial.c
+++ b/monomial/cloverdetratio_monomial.c
@@ -87,8 +87,7 @@ void cloverdetratio_derivative_orig(const int no, hamiltonian_field_t * const hf
   chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 	       mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
   mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, mnl->maxiter, 
-		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
-                       mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 		      mnl->csg_N, &mnl->csg_n, VOLUME/2);
   /* Y_W -> w_fields[0]  */
@@ -198,8 +197,7 @@ void cloverdetratio_derivative(const int no, hamiltonian_field_t * const hf) {
   chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 	       mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
   mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, mnl->maxiter, 
-		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
-                       mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 		      mnl->csg_N, &mnl->csg_n, VOLUME/2);
   // Apply Q_{-} to get Y_W -> w_fields[0] 
@@ -266,15 +264,13 @@ void cloverdetratio_heatbath(const int id, hamiltonian_field_t * const hf) {
 
   if( mnl->solver == MG ){
       mnl->iter0 = solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,  
-				    g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver,
-                                    mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
+				    g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver); 
       
       chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
   } else {
       mnl->iter0 = solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,  
-				    g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
-                                    mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
+				    g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver); 
       
       chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -317,12 +313,10 @@ double cloverdetratio_acc(const int id, hamiltonian_field_t * const hf) {
 
   if( mnl->solver == MG ){
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter, 
-				     mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver,
-                                     mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				     mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver);
   } else {
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter, 
-				     mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
-                                     mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				     mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
       mnl->Qm(mnl->w_fields[0], mnl->w_fields[0]);
   }
   g_sloppy_precision_flag = save_sloppy;

--- a/monomial/cloverdetratio_monomial.c
+++ b/monomial/cloverdetratio_monomial.c
@@ -65,6 +65,7 @@ void cloverdetratio_derivative_orig(const int no, hamiltonian_field_t * const hf
    *********************************************************************/
   /* First term coming from the second field */
   /* Multiply with W_+ */
+  mnl_backup_restore_globals(TM_BACKUP_GLOBALS);
   g_mu = mnl->mu;
   g_mu3 = mnl->rho2; //rho2
   boundary(mnl->kappa);
@@ -141,9 +142,7 @@ void cloverdetratio_derivative_orig(const int no, hamiltonian_field_t * const hf
 
   sw_all(hf, mnl->kappa, mnl->c_sw);
   
-  g_mu = g_mu1;
-  g_mu3 = 0.;
-  boundary(g_kappa);
+  mnl_backup_restore_globals(TM_RESTORE_GLOBALS);
   etime = gettime();
   if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
@@ -174,8 +173,11 @@ void cloverdetratio_derivative(const int no, hamiltonian_field_t * const hf) {
    *********************************************************************/
   /* First term coming from the second field */
   /* Multiply with W_+ */
+  mnl_backup_restore_globals(TM_BACKUP_GLOBALS);
   g_mu = mnl->mu;
-  boundary(mnl->kappa);
+  g_kappa = mnl->kappa;
+  g_c_sw = mnl->c_sw;
+  boundary(g_kappa);
 
   // we compute the clover term (1 + T_ee(oo)) for all sites x
   sw_term( (const su3**) hf->gaugefield, mnl->kappa, mnl->c_sw); 
@@ -226,10 +228,8 @@ void cloverdetratio_derivative(const int no, hamiltonian_field_t * const hf) {
   sw_spinor_eo(OE, mnl->w_fields[0], mnl->w_fields[1], mnl->forcefactor);
 
   sw_all(hf, mnl->kappa, mnl->c_sw);
-  
-  g_mu = g_mu1;
-  g_mu3 = 0.;
-  boundary(g_kappa);
+
+  mnl_backup_restore_globals(TM_RESTORE_GLOBALS);
   etime = gettime();
     if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
@@ -242,9 +242,11 @@ void cloverdetratio_heatbath(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
   double atime, etime;
   atime = gettime();
+  mnl_backup_restore_globals(TM_BACKUP_GLOBALS);
   g_mu = mnl->mu;
   g_c_sw = mnl->c_sw;
-  boundary(mnl->kappa);
+  g_kappa = mnl->kappa;
+  boundary(g_kappa);
   mnl->csg_n = 0;
   mnl->csg_n2 = 0;
   mnl->iter0 = 0;
@@ -287,9 +289,7 @@ void cloverdetratio_heatbath(const int id, hamiltonian_field_t * const hf) {
       printf("called cloverdetratio_heatbath for id %d energy %f\n", id, mnl->energy0);
     }
   }
-  g_mu3 = 0.;
-  g_mu = g_mu1;
-  boundary(g_kappa);
+  mnl_backup_restore_globals(TM_RESTORE_GLOBALS);
   return;
 }
 
@@ -298,7 +298,10 @@ double cloverdetratio_acc(const int id, hamiltonian_field_t * const hf) {
   int save_sloppy = g_sloppy_precision_flag;
   double atime, etime;
   atime = gettime();
+  mnl_backup_restore_globals(TM_BACKUP_GLOBALS);
   g_mu = mnl->mu;
+  g_kappa = mnl->kappa;
+  g_c_sw = mnl->c_sw;
   boundary(mnl->kappa);
 
   sw_term( (const su3**) hf->gaugefield, mnl->kappa, mnl->c_sw); 
@@ -327,9 +330,7 @@ double cloverdetratio_acc(const int id, hamiltonian_field_t * const hf) {
   /* Compute the energy contr. from second field */
   mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME/2, 1);
 
-  g_mu = g_mu1;
-  g_mu3 = 0.;
-  boundary(g_kappa);
+  mnl_backup_restore_globals(TM_RESTORE_GLOBALS);
   etime = gettime();
   if(g_proc_id == 0) {
     if(g_debug_level > 1) {

--- a/monomial/cloverdetratio_monomial.c
+++ b/monomial/cloverdetratio_monomial.c
@@ -86,7 +86,8 @@ void cloverdetratio_derivative_orig(const int no, hamiltonian_field_t * const hf
   chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 	       mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
   mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, mnl->maxiter, 
-		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
+		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
+                       mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 		      mnl->csg_N, &mnl->csg_n, VOLUME/2);
   /* Y_W -> w_fields[0]  */
@@ -195,7 +196,8 @@ void cloverdetratio_derivative(const int no, hamiltonian_field_t * const hf) {
   chrono_guess(mnl->w_fields[1], mnl->w_fields[2], mnl->csg_field, 
 	       mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
   mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, mnl->maxiter, 
-		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
+		       mnl->forceprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
+                       mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
   chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 		      mnl->csg_N, &mnl->csg_n, VOLUME/2);
   // Apply Q_{-} to get Y_W -> w_fields[0] 
@@ -262,13 +264,15 @@ void cloverdetratio_heatbath(const int id, hamiltonian_field_t * const hf) {
 
   if( mnl->solver == MG ){
       mnl->iter0 = solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,  
-				    g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver); 
+				    g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver,
+                                    mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
       
       chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
   } else {
       mnl->iter0 = solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,  
-				    g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver); 
+				    g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
+                                    mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
       
       chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -310,10 +314,12 @@ double cloverdetratio_acc(const int id, hamiltonian_field_t * const hf) {
 
   if( mnl->solver == MG ){
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter, 
-				     mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver);
+				     mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver,
+                                     mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
   } else {
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter, 
-				     mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
+				     mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
+                                     mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
       mnl->Qm(mnl->w_fields[0], mnl->w_fields[0]);
   }
   g_sloppy_precision_flag = save_sloppy;

--- a/monomial/cloverdetratio_rwmonomial.c
+++ b/monomial/cloverdetratio_rwmonomial.c
@@ -74,12 +74,10 @@ double cloverdetratio_rwacc(const int id, hamiltonian_field_t * const hf) {
   if( mnl->solver == MG ) {
     mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, 
                                    mnl->maxiter, mnl->accprec,
-				   g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver,
-                                   mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				   g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver);
   } else {
     mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,
-				   g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
-                                   mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				   g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
     mnl->Qm(mnl->w_fields[0], mnl->w_fields[0]);
   }
 

--- a/monomial/cloverdetratio_rwmonomial.c
+++ b/monomial/cloverdetratio_rwmonomial.c
@@ -72,11 +72,14 @@ double cloverdetratio_rwacc(const int id, hamiltonian_field_t * const hf) {
 	       mnl->csg_N, mnl->csg_n, VOLUME/2, &Qtm_plus_psi);
   g_sloppy_precision_flag = 0;    
   if( mnl->solver == MG ) {
-    mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,
-				   g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver);
+    mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, 
+                                   mnl->maxiter, mnl->accprec,
+				   g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver,
+                                   mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
   } else {
     mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,
-				   g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
+				   g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
+                                   mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
     mnl->Qm(mnl->w_fields[0], mnl->w_fields[0]);
   }
 

--- a/monomial/det_monomial.c
+++ b/monomial/det_monomial.c
@@ -174,12 +174,14 @@ void det_heatbath(const int id, hamiltonian_field_t * const hf) {
     mnl->energy0 = square_norm(mnl->w_fields[0], VOLUME/2, 1);
 
     mnl->Qp(mnl->pf, mnl->w_fields[0]);
+    
     // FIXME: there needs to be a better way to take care of this... this is an ugly
     // hack to get the right number of factors of gamma5 in the result of solve_degenerate
     // when using QPhiX solvers qhich employ M(mu) and M^dag(mu) directly, rather than Q+ and Q-
     if(mnl->external_inverter == QPHIX_INVERTER){
       mul_gamma5(mnl->pf, VOLUME/2);
     }
+    
     chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			mnl->csg_N, &mnl->csg_n, VOLUME/2);
     if(mnl->solver != CG) {

--- a/monomial/det_monomial.c
+++ b/monomial/det_monomial.c
@@ -73,11 +73,11 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
     {      
 	  fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (det_monomial.c)\n");
 	  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->forceprec, 
-			 g_relative_precision_flag, VOLUME/2, mnl->Qsq, CG, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+			 g_relative_precision_flag, VOLUME/2, mnl->Qsq, CG);
     }
     else{
 	  mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, mnl->maxiter, mnl->forceprec, 
-			 g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+			 g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
     }
 
 
@@ -113,7 +113,7 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
       mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME, &Q_pm_psi, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				     VOLUME, &Q_pm_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME);
 
@@ -128,7 +128,7 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_plus_psi);
       mnl->iter1 += solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME, &Q_plus_psi, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				     VOLUME, &Q_plus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[0], mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
       
@@ -139,7 +139,7 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
 		   mnl->csg_index_array2, mnl->csg_N2, mnl->csg_n2, VOLUME/2, &Q_minus_psi);
       mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[0], mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME, &Q_minus_psi, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				     VOLUME, &Q_minus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field2, mnl->csg_index_array2,
 			  mnl->csg_N2, &mnl->csg_n2, VOLUME/2);
         
@@ -229,16 +229,14 @@ double det_acc(const int id, hamiltonian_field_t * const hf) {
 	chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		     mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qp);
 	mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, mnl->maxiter,
-				      mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver,
-                                      mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				      mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver);
 	/* Compute the energy contr. from second field */
 	mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME/2, 1); 
     } else {
 	chrono_guess(mnl->w_fields[0], mnl->pf, mnl->csg_field, mnl->csg_index_array,
 		     mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
 	mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, mnl->maxiter, 
-				       mnl->accprec, g_relative_precision_flag,VOLUME/2, mnl->Qsq, mnl->solver,
-                                       mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				       mnl->accprec, g_relative_precision_flag,VOLUME/2, mnl->Qsq, mnl->solver);
 	mnl->Qm(mnl->w_fields[1], mnl->w_fields[0]);
 	/* Compute the energy contr. from first field */
 	mnl->energy1 = square_norm(mnl->w_fields[1], VOLUME/2, 1);
@@ -251,7 +249,7 @@ double det_acc(const int id, hamiltonian_field_t * const hf) {
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
       mnl->iter0 += solve_degenerate(mnl->w_fields[1], mnl->pf, mnl->solver_params, mnl->maxiter, 
                                      mnl->accprec, g_relative_precision_flag, 
-			  VOLUME, &Q_pm_psi, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+			  VOLUME, &Q_pm_psi, mnl->solver);
       Q_minus_psi(mnl->w_fields[0], mnl->w_fields[1]);
       /* Compute the energy contr. from first field */
       mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME, 1);
@@ -261,7 +259,7 @@ double det_acc(const int id, hamiltonian_field_t * const hf) {
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_plus_psi);
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->pf, mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME,  &Q_plus_psi, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				     VOLUME,  &Q_plus_psi, mnl->solver);
       mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME, 1);
     }
   }

--- a/monomial/detratio_monomial.c
+++ b/monomial/detratio_monomial.c
@@ -84,13 +84,11 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
     if(mnl->solver == BICGSTAB) {
       fprintf(stderr, "Bicgstab currently not implemented, using CG instead! (detratio_monomial.c)\n"); 
        mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, mnl->maxiter, 
-			                                mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, CG,
-                                                        mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+			                                mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, CG);
     }
     else{
        mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, mnl->maxiter, 
-			                                mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, mnl->solver,
-                                                        mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
+			                                mnl->forceprec, g_relative_precision_flag, VOLUME/2, &Qtm_pm_psi, mnl->solver); 
     }
     chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 			mnl->csg_N, &mnl->csg_n, VOLUME/2);
@@ -151,7 +149,7 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
 		   mnl->csg_index_array, mnl->csg_N, mnl->csg_n, VOLUME/2, &Q_pm_psi);
       mnl->iter1 += solve_degenerate(mnl->w_fields[1], mnl->w_fields[2], mnl->solver_params, 
 			   mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-			   VOLUME, &Q_pm_psi, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+			   VOLUME, &Q_pm_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
       
@@ -167,7 +165,7 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
       gamma5(mnl->w_fields[0], mnl->w_fields[0], VOLUME);
       mnl->iter1 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[2], mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME, Q_plus_psi, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				     VOLUME, Q_plus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[0], mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
 
@@ -179,7 +177,7 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
       gamma5(mnl->w_fields[1], mnl->w_fields[1], VOLUME);
       mnl->iter1 += solve_degenerate(mnl->w_fields[1],mnl->w_fields[0], mnl->solver_params, 
 				     mnl->maxiter, mnl->forceprec, g_relative_precision_flag, 
-				     VOLUME, Q_minus_psi, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				     VOLUME, Q_minus_psi, mnl->solver);
       chrono_add_solution(mnl->w_fields[1], mnl->csg_field2, mnl->csg_index_array2,
 			  mnl->csg_N2, &mnl->csg_n2, VOLUME/2);
         
@@ -235,12 +233,12 @@ void detratio_heatbath(const int id, hamiltonian_field_t * const hf) {
     zero_spinor_field(mnl->w_fields[0], VOLUME/2);
     if( mnl->solver == MG ){
       mnl->iter0 = solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,
-				    g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				    g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver);
       chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);      
     } else {
       mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter,
-				    mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				    mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
       mnl->Qm(mnl->pf, mnl->w_fields[0]);
 
       chrono_add_solution(mnl->w_fields[0], mnl->csg_field, mnl->csg_index_array,
@@ -261,21 +259,18 @@ void detratio_heatbath(const int id, hamiltonian_field_t * const hf) {
     if((mnl->solver == CG) || (mnl->solver == MIXEDCG)){
       mnl->iter0 = solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params,
                                     mnl->maxiter, mnl->accprec, 
-				    g_relative_precision_flag, VOLUME, Q_pm_psi, mnl->solver, 
-                                    mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				    g_relative_precision_flag, VOLUME, Q_pm_psi, mnl->solver);
       Q_minus_psi(mnl->pf, mnl->w_fields[0]);
       chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);      
     } else if( mnl->solver == MG ){
       mnl->iter0 = solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec,
-				    g_relative_precision_flag, VOLUME, Q_plus_psi, mnl->solver, 
-                                    mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				    g_relative_precision_flag, VOLUME, Q_plus_psi, mnl->solver);
       chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);      
     } else {
       mnl->iter0 = solve_degenerate(mnl->pf, mnl->w_fields[1], mnl->solver_params, mnl->maxiter, mnl->accprec, 
-				    g_relative_precision_flag, VOLUME, Q_plus_psi, mnl->solver, 
-                                    mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				    g_relative_precision_flag, VOLUME, Q_plus_psi, mnl->solver);
       chrono_add_solution(mnl->pf, mnl->csg_field, mnl->csg_index_array,
 			  mnl->csg_N, &mnl->csg_n, VOLUME/2);
       chrono_add_solution(mnl->pf, mnl->csg_field2, mnl->csg_index_array2,
@@ -319,16 +314,14 @@ double detratio_acc(const int id, hamiltonian_field_t * const hf) {
       chrono_guess(mnl->w_fields[0], mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array, 
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qp);
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter,
-				    mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver,
-                                    mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				    mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qp, mnl->solver);
       /* Compute the energy contr. from second field */
       mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME/2, 1); 
     } else {
       chrono_guess(mnl->w_fields[0], mnl->w_fields[1], mnl->csg_field, mnl->csg_index_array, 
 		   mnl->csg_N, mnl->csg_n, VOLUME/2, mnl->Qsq);
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter,
-				     mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver,
-                                     mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type);
+				     mnl->accprec, g_relative_precision_flag, VOLUME/2, mnl->Qsq, mnl->solver);
       mnl->Qm(mnl->w_fields[1], mnl->w_fields[0]);
       /* Compute the energy contr. from second field */
       mnl->energy1 = square_norm(mnl->w_fields[1], VOLUME/2, 1);
@@ -348,8 +341,7 @@ double detratio_acc(const int id, hamiltonian_field_t * const hf) {
     if((mnl->solver == CG) || (mnl->solver == MIXEDCG)){
       
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, mnl->maxiter,
-				     mnl->accprec, g_relative_precision_flag, VOLUME, &Q_pm_psi, mnl->solver,
-                                     mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
+				     mnl->accprec, g_relative_precision_flag, VOLUME, &Q_pm_psi, mnl->solver); 
       Q_minus_psi(mnl->w_fields[1], mnl->w_fields[0]);
       /* Compute the energy contr. from second field */
       mnl->energy1 = square_norm(mnl->w_fields[1], VOLUME, 1);      
@@ -357,7 +349,7 @@ double detratio_acc(const int id, hamiltonian_field_t * const hf) {
     else{
       mnl->iter0 += solve_degenerate(mnl->w_fields[0], mnl->w_fields[1], mnl->solver_params, 
 				     mnl->maxiter, mnl->accprec, g_relative_precision_flag, 
-				     VOLUME, Q_plus_psi, mnl->solver, mnl->external_inverter, mnl->sloppy_precision, mnl->compression_type); 
+				     VOLUME, Q_plus_psi, mnl->solver); 
     
       /* Compute the energy contr. from second field */
       mnl->energy1 = square_norm(mnl->w_fields[0], VOLUME, 1); 

--- a/monomial/monomial.c
+++ b/monomial/monomial.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <string.h>
 #include "global.h"
+#include "boundary.h"
 #include "su3.h"
 #include "su3adj.h"
 #include "su3spinor.h"
@@ -42,8 +43,6 @@
 #include "default_input_values.h"
 #include "read_input.h"
 #include "monomial/monomial.h"
-
-
 
 monomial monomial_list[max_no_monomials];
 int no_monomials = 0;
@@ -668,4 +667,35 @@ double dummy_acc(const int id, hamiltonian_field_t * const hf) {
     fprintf(stderr, "callers monomial ID was %d\n", id);
   }
   return(0.);
+}
+
+void mnl_backup_restore_globals(const backup_restore_t mode){
+  static double backup_kappa;
+  static double backup_mu;
+  static double backup_mu1;
+  static double backup_mu2;
+  static double backup_mu3;
+  static double backup_c_sw;
+  static double backup_mubar;
+  static double backup_epsbar;
+  if( mode == TM_BACKUP_GLOBALS ){
+    backup_kappa  = g_kappa;
+    backup_c_sw   = g_c_sw;
+    backup_mu     = g_mu;
+    backup_mu1    = g_mu1;
+    backup_mu2    = g_mu2;
+    backup_mu3    = g_mu3;
+    backup_mubar  = g_mubar;
+    backup_epsbar = g_epsbar;
+  } else {
+    g_kappa  = backup_kappa;
+    g_c_sw   = backup_c_sw;
+    g_mu     = backup_mu;
+    g_mu1    = backup_mu1;
+    g_mu2    = backup_mu2;
+    g_mu3    = backup_mu3;
+    g_mubar  = backup_mubar;
+    g_epsbar = backup_epsbar;
+    boundary(g_kappa);
+  }
 }

--- a/monomial/monomial.c
+++ b/monomial/monomial.c
@@ -105,9 +105,13 @@ int add_monomial(const int type) {
   }
   monomial_list[no_monomials].solver_params.mcg_delta = _default_mixcg_innereps;
   monomial_list[no_monomials].solver_params.solution_type = TM_SOLUTION_M_MDAG;
-  monomial_list[no_monomials].compression_type = _default_compression_type;
-  monomial_list[no_monomials].external_inverter = _default_external_inverter;
-  monomial_list[no_monomials].sloppy_precision = _default_operator_sloppy_precision_flag;
+  // the defaut is 1 because the QPhiX interface is generalised in such a way
+  // that normal solves correspond to solves with one shift, this does not 
+  // affect the used parameters in any way!
+  monomial_list[no_monomials].solver_params.no_shifts = 1;
+  monomial_list[no_monomials].solver_params.compression_type = _default_compression_type;
+  monomial_list[no_monomials].solver_params.external_inverter = _default_external_inverter;
+  monomial_list[no_monomials].solver_params.sloppy_precision = _default_operator_sloppy_precision_flag;
   monomial_list[no_monomials].even_odd_flag = _default_even_odd_flag;
   monomial_list[no_monomials].forcefactor = 1.;
   monomial_list[no_monomials].use_rectangles = 0;

--- a/monomial/monomial.c
+++ b/monomial/monomial.c
@@ -105,6 +105,9 @@ int add_monomial(const int type) {
   }
   monomial_list[no_monomials].solver_params.mcg_delta = _default_mixcg_innereps;
   monomial_list[no_monomials].solver_params.solution_type = TM_SOLUTION_M_MDAG;
+  monomial_list[no_monomials].compression_type = _default_compression_type;
+  monomial_list[no_monomials].external_inverter = _default_external_inverter;
+  monomial_list[no_monomials].sloppy_precision = _default_operator_sloppy_precision_flag;
   monomial_list[no_monomials].even_odd_flag = _default_even_odd_flag;
   monomial_list[no_monomials].forcefactor = 1.;
   monomial_list[no_monomials].use_rectangles = 0;

--- a/monomial/monomial.c
+++ b/monomial/monomial.c
@@ -105,6 +105,7 @@ int add_monomial(const int type) {
     monomial_list[no_monomials].solver = _default_solver_flag;
   }
   monomial_list[no_monomials].solver_params.mcg_delta = _default_mixcg_innereps;
+  monomial_list[no_monomials].solver_params.solution_type = TM_SOLUTION_M_MDAG;
   monomial_list[no_monomials].even_odd_flag = _default_even_odd_flag;
   monomial_list[no_monomials].forcefactor = 1.;
   monomial_list[no_monomials].use_rectangles = 0;

--- a/monomial/monomial.h
+++ b/monomial/monomial.h
@@ -64,10 +64,6 @@ typedef struct {
   int rngrepro;
   int solver;
   
-  ExternalInverter external_inverter;
-  CompressionType  compression_type;
-  SloppyPrecision sloppy_precision;
-  
   int iter0, iter1, iter2;
   int csg_N, csg_N2;
   int csg_n, csg_n2;

--- a/monomial/monomial.h
+++ b/monomial/monomial.h
@@ -62,6 +62,11 @@ typedef struct {
   int even_odd_flag;
   int rngrepro;
   int solver;
+  
+  ExternalInverter external_inverter;
+  CompressionType  compression_type;
+  SloppyPrecision sloppy_precision;
+  
   int iter0, iter1, iter2;
   int csg_N, csg_N2;
   int csg_n, csg_n2;

--- a/monomial/monomial.h
+++ b/monomial/monomial.h
@@ -26,6 +26,7 @@
 #include "hamiltonian_field.h"
 #include "rational/rational.h"
 #include "solver/solver_params.h"
+#include "misc_types.h"
 
 #define DET 0
 #define DETRATIO 1
@@ -173,5 +174,8 @@ int init_poly_monomial(const int V,const int id);
 void dummy_derivative(const int id, hamiltonian_field_t * const hf);
 void dummy_heatbath(const int id, hamiltonian_field_t * const hf);
 double dummy_acc(const int id, hamiltonian_field_t * const hf);
+
+void mnl_set_globals(const int id);
+void mnl_backup_restore_globals(const backup_restore_t mode);
 
 #endif

--- a/monomial/ndrat_monomial.c
+++ b/monomial/ndrat_monomial.c
@@ -74,7 +74,7 @@ void nd_set_global_parameter(monomial * const mnl) {
 
 void ndrat_derivative(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_pm_t solver_pm;
+  solver_params_t solver_params;
   double atime, etime;
   atime = gettime();
   nd_set_global_parameter(mnl);
@@ -94,23 +94,23 @@ void ndrat_derivative(const int id, hamiltonian_field_t * const hf) {
   }
   mnl->forcefactor = mnl->EVMaxInv;
 
-  solver_pm.max_iter = mnl->maxiter;
-  solver_pm.squared_solver_prec = mnl->forceprec;
-  solver_pm.no_shifts = mnl->rat.np;
-  solver_pm.shifts = mnl->rat.mu;
-  solver_pm.rel_prec = g_relative_precision_flag;
-  solver_pm.type = mnl->solver; 
+  solver_params.max_iter = mnl->maxiter;
+  solver_params.squared_solver_prec = mnl->forceprec;
+  solver_params.no_shifts = mnl->rat.np;
+  solver_params.shifts = mnl->rat.mu;
+  solver_params.rel_prec = g_relative_precision_flag;
+  solver_params.type = mnl->solver; 
 
-  solver_pm.M_ndpsi = &Qtm_pm_ndpsi;
-  solver_pm.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
+  solver_params.M_ndpsi = &Qtm_pm_ndpsi;
+  solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
   if(mnl->type == NDCLOVERRAT) {
-    solver_pm.M_ndpsi = &Qsw_pm_ndpsi;
-    solver_pm.M_ndpsi32 = &Qsw_pm_ndpsi_32;
+    solver_params.M_ndpsi = &Qsw_pm_ndpsi;
+    solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
   }
-  solver_pm.sdim = VOLUME/2;
+  solver_params.sdim = VOLUME/2;
   // this generates all X_j,o (odd sites only) -> g_chi_up|dn_spinor_field
   mnl->iter1 += solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
-                   		      mnl->pf, mnl->pf2,&solver_pm);
+                   		      mnl->pf, mnl->pf2,&solver_params);
   
   for(int j = (mnl->rat.np-1); j > -1; j--) {
     if(mnl->type == NDCLOVERRAT) {
@@ -193,7 +193,7 @@ void ndrat_derivative(const int id, hamiltonian_field_t * const hf) {
 
 void ndrat_heatbath(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_pm_t solver_pm;
+  solver_params_t solver_params;
   double atime, etime;
   atime = gettime();
   nd_set_global_parameter(mnl);
@@ -218,21 +218,21 @@ void ndrat_heatbath(const int id, hamiltonian_field_t * const hf) {
   random_spinor_field_eo(mnl->pf2, mnl->rngrepro, RN_GAUSS);
   mnl->energy0 += square_norm(mnl->pf2, VOLUME/2, 1);
   // set solver parameters
-  solver_pm.max_iter = mnl->maxiter;
-  solver_pm.squared_solver_prec = mnl->accprec;
-  solver_pm.no_shifts = mnl->rat.np;
-  solver_pm.shifts = mnl->rat.nu;
-  solver_pm.type = mnl->solver;
-  solver_pm.M_ndpsi = &Qtm_pm_ndpsi;
-  solver_pm.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
+  solver_params.max_iter = mnl->maxiter;
+  solver_params.squared_solver_prec = mnl->accprec;
+  solver_params.no_shifts = mnl->rat.np;
+  solver_params.shifts = mnl->rat.nu;
+  solver_params.type = mnl->solver;
+  solver_params.M_ndpsi = &Qtm_pm_ndpsi;
+  solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
   if(mnl->type == NDCLOVERRAT) {
-    solver_pm.M_ndpsi = &Qsw_pm_ndpsi;
-    solver_pm.M_ndpsi32 = &Qsw_pm_ndpsi_32;
+    solver_params.M_ndpsi = &Qsw_pm_ndpsi;
+    solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
   }
-  solver_pm.sdim = VOLUME/2;
-  solver_pm.rel_prec = g_relative_precision_flag;
+  solver_params.sdim = VOLUME/2;
+  solver_params.rel_prec = g_relative_precision_flag;
   mnl->iter0 = solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
-                   		      mnl->pf, mnl->pf2, &solver_pm);
+                   		      mnl->pf, mnl->pf2, &solver_params);
 
   assign(mnl->w_fields[2], mnl->pf, VOLUME/2);
   assign(mnl->w_fields[3], mnl->pf2, VOLUME/2);
@@ -269,7 +269,7 @@ void ndrat_heatbath(const int id, hamiltonian_field_t * const hf) {
 
 
 double ndrat_acc(const int id, hamiltonian_field_t * const hf) {
-  solver_pm_t solver_pm;
+  solver_params_t solver_params;
   monomial * mnl = &monomial_list[id];
   double atime, etime;
   atime = gettime();
@@ -281,22 +281,22 @@ double ndrat_acc(const int id, hamiltonian_field_t * const hf) {
   }
   mnl->energy1 = 0.;
 
-  solver_pm.max_iter = mnl->maxiter;
-  solver_pm.squared_solver_prec = mnl->accprec;
-  solver_pm.no_shifts = mnl->rat.np;
-  solver_pm.shifts = mnl->rat.mu;
-  solver_pm.type = mnl->solver;
+  solver_params.max_iter = mnl->maxiter;
+  solver_params.squared_solver_prec = mnl->accprec;
+  solver_params.no_shifts = mnl->rat.np;
+  solver_params.shifts = mnl->rat.mu;
+  solver_params.type = mnl->solver;
   
-  solver_pm.M_ndpsi = &Qtm_pm_ndpsi;
-  solver_pm.M_ndpsi32 = &Qtm_pm_ndpsi_32; 
+  solver_params.M_ndpsi = &Qtm_pm_ndpsi;
+  solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32; 
   if(mnl->type == NDCLOVERRAT) {
-    solver_pm.M_ndpsi = &Qsw_pm_ndpsi;
-    solver_pm.M_ndpsi32 = &Qsw_pm_ndpsi_32;
+    solver_params.M_ndpsi = &Qsw_pm_ndpsi;
+    solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
   }
-  solver_pm.sdim = VOLUME/2;
-  solver_pm.rel_prec = g_relative_precision_flag;
+  solver_params.sdim = VOLUME/2;
+  solver_params.rel_prec = g_relative_precision_flag;
   mnl->iter0 += solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
-                             mnl->pf, mnl->pf2,&solver_pm);
+                             mnl->pf, mnl->pf2,&solver_params);
 
   // apply R to the pseudo-fermion fields
   assign(mnl->w_fields[0], mnl->pf, VOLUME/2);

--- a/monomial/ndrat_monomial.c
+++ b/monomial/ndrat_monomial.c
@@ -74,7 +74,7 @@ void nd_set_global_parameter(monomial * const mnl) {
 
 void ndrat_derivative(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_params_t solver_params;
+//   solver_params_t solver_params;
   double atime, etime;
   atime = gettime();
   nd_set_global_parameter(mnl);
@@ -94,23 +94,23 @@ void ndrat_derivative(const int id, hamiltonian_field_t * const hf) {
   }
   mnl->forcefactor = mnl->EVMaxInv;
 
-  solver_params.max_iter = mnl->maxiter;
-  solver_params.squared_solver_prec = mnl->forceprec;
-  solver_params.no_shifts = mnl->rat.np;
-  solver_params.shifts = mnl->rat.mu;
-  solver_params.rel_prec = g_relative_precision_flag;
-  solver_params.type = mnl->solver; 
+  mnl->solver_params.max_iter = mnl->maxiter;
+  mnl->solver_params.squared_solver_prec = mnl->forceprec;
+  mnl->solver_params.no_shifts = mnl->rat.np;
+  mnl->solver_params.shifts = mnl->rat.mu;
+  mnl->solver_params.rel_prec = g_relative_precision_flag;
+  mnl->solver_params.type = mnl->solver; 
 
-  solver_params.M_ndpsi = &Qtm_pm_ndpsi;
-  solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
+  mnl->solver_params.M_ndpsi = &Qtm_pm_ndpsi;
+  mnl->solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
   if(mnl->type == NDCLOVERRAT) {
-    solver_params.M_ndpsi = &Qsw_pm_ndpsi;
-    solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
+    mnl->solver_params.M_ndpsi = &Qsw_pm_ndpsi;
+    mnl->solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
   }
-  solver_params.sdim = VOLUME/2;
+  mnl->solver_params.sdim = VOLUME/2;
   // this generates all X_j,o (odd sites only) -> g_chi_up|dn_spinor_field
   mnl->iter1 += solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
-                   		      mnl->pf, mnl->pf2,&solver_params);
+                             mnl->pf, mnl->pf2, &(mnl->solver_params) );
   
   for(int j = (mnl->rat.np-1); j > -1; j--) {
     if(mnl->type == NDCLOVERRAT) {
@@ -193,7 +193,6 @@ void ndrat_derivative(const int id, hamiltonian_field_t * const hf) {
 
 void ndrat_heatbath(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_params_t solver_params;
   double atime, etime;
   atime = gettime();
   nd_set_global_parameter(mnl);
@@ -218,21 +217,21 @@ void ndrat_heatbath(const int id, hamiltonian_field_t * const hf) {
   random_spinor_field_eo(mnl->pf2, mnl->rngrepro, RN_GAUSS);
   mnl->energy0 += square_norm(mnl->pf2, VOLUME/2, 1);
   // set solver parameters
-  solver_params.max_iter = mnl->maxiter;
-  solver_params.squared_solver_prec = mnl->accprec;
-  solver_params.no_shifts = mnl->rat.np;
-  solver_params.shifts = mnl->rat.nu;
-  solver_params.type = mnl->solver;
-  solver_params.M_ndpsi = &Qtm_pm_ndpsi;
-  solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
+  mnl->solver_params.max_iter = mnl->maxiter;
+  mnl->solver_params.squared_solver_prec = mnl->accprec;
+  mnl->solver_params.no_shifts = mnl->rat.np;
+  mnl->solver_params.shifts = mnl->rat.nu;
+  mnl->solver_params.type = mnl->solver;
+  mnl->solver_params.M_ndpsi = &Qtm_pm_ndpsi;
+  mnl->solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
   if(mnl->type == NDCLOVERRAT) {
-    solver_params.M_ndpsi = &Qsw_pm_ndpsi;
-    solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
+    mnl->solver_params.M_ndpsi = &Qsw_pm_ndpsi;
+    mnl->solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
   }
-  solver_params.sdim = VOLUME/2;
-  solver_params.rel_prec = g_relative_precision_flag;
+  mnl->solver_params.sdim = VOLUME/2;
+  mnl->solver_params.rel_prec = g_relative_precision_flag;
   mnl->iter0 = solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
-                   		      mnl->pf, mnl->pf2, &solver_params);
+                            mnl->pf, mnl->pf2, &(mnl->solver_params) );
 
   assign(mnl->w_fields[2], mnl->pf, VOLUME/2);
   assign(mnl->w_fields[3], mnl->pf2, VOLUME/2);
@@ -269,7 +268,6 @@ void ndrat_heatbath(const int id, hamiltonian_field_t * const hf) {
 
 
 double ndrat_acc(const int id, hamiltonian_field_t * const hf) {
-  solver_params_t solver_params;
   monomial * mnl = &monomial_list[id];
   double atime, etime;
   atime = gettime();
@@ -281,22 +279,22 @@ double ndrat_acc(const int id, hamiltonian_field_t * const hf) {
   }
   mnl->energy1 = 0.;
 
-  solver_params.max_iter = mnl->maxiter;
-  solver_params.squared_solver_prec = mnl->accprec;
-  solver_params.no_shifts = mnl->rat.np;
-  solver_params.shifts = mnl->rat.mu;
-  solver_params.type = mnl->solver;
+  mnl->solver_params.max_iter = mnl->maxiter;
+  mnl->solver_params.squared_solver_prec = mnl->accprec;
+  mnl->solver_params.no_shifts = mnl->rat.np;
+  mnl->solver_params.shifts = mnl->rat.mu;
+  mnl->solver_params.type = mnl->solver;
   
-  solver_params.M_ndpsi = &Qtm_pm_ndpsi;
-  solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32; 
+  mnl->solver_params.M_ndpsi = &Qtm_pm_ndpsi;
+  mnl->solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32; 
   if(mnl->type == NDCLOVERRAT) {
-    solver_params.M_ndpsi = &Qsw_pm_ndpsi;
-    solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
+    mnl->solver_params.M_ndpsi = &Qsw_pm_ndpsi;
+    mnl->solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
   }
-  solver_params.sdim = VOLUME/2;
-  solver_params.rel_prec = g_relative_precision_flag;
+  mnl->solver_params.sdim = VOLUME/2;
+  mnl->solver_params.rel_prec = g_relative_precision_flag;
   mnl->iter0 += solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
-                             mnl->pf, mnl->pf2,&solver_params);
+                             mnl->pf, mnl->pf2, &(mnl->solver_params) );
 
   // apply R to the pseudo-fermion fields
   assign(mnl->w_fields[0], mnl->pf, VOLUME/2);

--- a/monomial/ndrat_monomial.c
+++ b/monomial/ndrat_monomial.c
@@ -259,7 +259,7 @@ void ndrat_heatbath(const int id, hamiltonian_field_t * const hf) {
     if(g_debug_level > 1) {
       printf("# Time for %s monomial heatbath: %e s\n", mnl->name, etime-atime);
     }
-    if(g_debug_level > 3) { 
+    if(g_debug_level > 3) {
       printf("called ndrat_heatbath for id %d energy %f\n", id, mnl->energy0);
     }
   }
@@ -313,8 +313,8 @@ double ndrat_acc(const int id, hamiltonian_field_t * const hf) {
     if(g_debug_level > 1) {
       printf("# Time for %s monomial acc step: %e s\n", mnl->name, etime-atime);
     }
-    if(g_debug_level > 0) { // shoud be 3
-      printf("called ndrat_acc for id %d dH = %1.10e\n", id, mnl->energy1 - mnl->energy0);
+    if(g_debug_level > 3) {
+      printf("called ndrat_acc for id %d, H_1 = %.10e, dH = %1.10e\n", id, mnl->energy1,  mnl->energy1 - mnl->energy0);
     }
   }
   return(mnl->energy1 - mnl->energy0);

--- a/monomial/ndrat_monomial.c
+++ b/monomial/ndrat_monomial.c
@@ -74,7 +74,6 @@ void nd_set_global_parameter(monomial * const mnl) {
 
 void ndrat_derivative(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-//   solver_params_t solver_params;
   double atime, etime;
   atime = gettime();
   nd_set_global_parameter(mnl);

--- a/monomial/ndratcor_monomial.c
+++ b/monomial/ndratcor_monomial.c
@@ -53,19 +53,19 @@
 void check_C_ndpsi(spinor * const k_up, spinor * const k_dn,
 		   spinor * const l_up, spinor * const l_dn,
 		   const int id, hamiltonian_field_t * const hf,
-		   solver_pm_t * solver_pm);
+		   solver_params_t * solver_params);
 
 // applies (Q^2 R^2 -1) phi
 double apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
 		     spinor * const l_up, spinor * const l_dn,
 		     const int id, hamiltonian_field_t * const hf,
-		     solver_pm_t * solver_pm);
+		     solver_params_t * solver_params);
 
 
 
 void ndratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_pm_t solver_pm;
+  solver_params_t solver_params;
   double atime, etime, delta;
   spinor * up0, * dn0, * up1, * dn1, * tup, * tdn;
   double coefs[6] = {1./4., -3./32., 7./128., -77./2048., 231./8192., -1463./65536.};
@@ -93,19 +93,19 @@ void ndratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   random_spinor_field_eo(mnl->pf2, mnl->rngrepro, RN_GAUSS);
   mnl->energy0 += square_norm(mnl->pf2, VOLUME/2, 1);
 
-  solver_pm.max_iter = mnl->maxiter;
-  solver_pm.squared_solver_prec = mnl->accprec;
-  solver_pm.no_shifts = mnl->rat.np;
-  solver_pm.shifts = mnl->rat.mu;
-  solver_pm.type = mnl->solver;
-  solver_pm.M_ndpsi = &Qtm_pm_ndpsi;
-  solver_pm.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
+  solver_params.max_iter = mnl->maxiter;
+  solver_params.squared_solver_prec = mnl->accprec;
+  solver_params.no_shifts = mnl->rat.np;
+  solver_params.shifts = mnl->rat.mu;
+  solver_params.type = mnl->solver;
+  solver_params.M_ndpsi = &Qtm_pm_ndpsi;
+  solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
   if(mnl->type == NDCLOVERRATCOR) {
-    solver_pm.M_ndpsi = &Qsw_pm_ndpsi;
-    solver_pm.M_ndpsi32 = &Qsw_pm_ndpsi_32;
+    solver_params.M_ndpsi = &Qsw_pm_ndpsi;
+    solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
   }
-  solver_pm.sdim = VOLUME/2;
-  solver_pm.rel_prec = g_relative_precision_flag;
+  solver_params.sdim = VOLUME/2;
+  solver_params.rel_prec = g_relative_precision_flag;
 
   // apply B to the random field to generate pseudo-fermion fields
   assign(mnl->w_fields[0], mnl->pf, VOLUME/2);
@@ -114,7 +114,7 @@ void ndratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   up1 = mnl->w_fields[2]; dn1 = mnl->w_fields[3];
 	 
   for(int i = 1; i < 8; i++) {
-    delta = apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &solver_pm);
+    delta = apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &solver_params);
     assign_add_mul_r(mnl->pf, up1, coefs[i-1], VOLUME/2);
     assign_add_mul_r(mnl->pf2, dn1, coefs[i-1], VOLUME/2);
     if(delta < mnl->accprec) break;
@@ -136,7 +136,7 @@ void ndratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
 
 
 double ndratcor_acc(const int id, hamiltonian_field_t * const hf) {
-  solver_pm_t solver_pm;
+  solver_params_t solver_params;
   monomial * mnl = &monomial_list[id];
   double atime, etime, delta;
   spinor * up0, * dn0, * up1, * dn1, * tup, * tdn;
@@ -151,19 +151,19 @@ double ndratcor_acc(const int id, hamiltonian_field_t * const hf) {
   }
   mnl->energy1 = 0.;
 
-  solver_pm.max_iter = mnl->maxiter;
-  solver_pm.squared_solver_prec = mnl->accprec;
-  solver_pm.no_shifts = mnl->rat.np;
-  solver_pm.shifts = mnl->rat.mu;
-  solver_pm.type = mnl->solver;
-  solver_pm.M_ndpsi = &Qtm_pm_ndpsi;
-  solver_pm.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
+  solver_params.max_iter = mnl->maxiter;
+  solver_params.squared_solver_prec = mnl->accprec;
+  solver_params.no_shifts = mnl->rat.np;
+  solver_params.shifts = mnl->rat.mu;
+  solver_params.type = mnl->solver;
+  solver_params.M_ndpsi = &Qtm_pm_ndpsi;
+  solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
   if(mnl->type == NDCLOVERRATCOR) {
-    solver_pm.M_ndpsi = &Qsw_pm_ndpsi;
-    solver_pm.M_ndpsi32 = &Qsw_pm_ndpsi_32;
+    solver_params.M_ndpsi = &Qsw_pm_ndpsi;
+    solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
   }
-  solver_pm.sdim = VOLUME/2;
-  solver_pm.rel_prec = g_relative_precision_flag;
+  solver_params.sdim = VOLUME/2;
+  solver_params.rel_prec = g_relative_precision_flag;
 
   // apply (Q R)^(-1) to pseudo-fermion fields
   assign(mnl->w_fields[4], mnl->pf, VOLUME/2);
@@ -171,13 +171,13 @@ double ndratcor_acc(const int id, hamiltonian_field_t * const hf) {
   up0 = mnl->w_fields[0]; dn0 = mnl->w_fields[1];
   up1 = mnl->w_fields[2]; dn1 = mnl->w_fields[3];
 
-  delta = apply_Z_ndpsi(up0, dn0, mnl->pf, mnl->pf2, id, hf, &solver_pm);
+  delta = apply_Z_ndpsi(up0, dn0, mnl->pf, mnl->pf2, id, hf, &solver_params);
   assign_add_mul_r(mnl->w_fields[4], up0, coefs[0], VOLUME/2);
   assign_add_mul_r(mnl->w_fields[5], dn0, coefs[0], VOLUME/2);
 
   for(int i = 2; i < 8; i++) {
     if(delta < mnl->accprec) break;
-    delta = apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &solver_pm);
+    delta = apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &solver_params);
     assign_add_mul_r(mnl->w_fields[4], up1, coefs[i-1], VOLUME/2);
     assign_add_mul_r(mnl->w_fields[5], dn1, coefs[i-1], VOLUME/2);
     tup = up0; tdn = dn0;
@@ -204,11 +204,11 @@ double ndratcor_acc(const int id, hamiltonian_field_t * const hf) {
 double apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
 		     spinor * const l_up, spinor * const l_dn,
 		     const int id, hamiltonian_field_t * const hf,
-		     solver_pm_t * solver_pm) {
+		     solver_params_t * solver_params) {
   monomial * mnl = &monomial_list[id];
 
   mnl->iter0 += solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
-			                       l_up, l_dn, solver_pm);  
+			                       l_up, l_dn, solver_params);  
   
   // apply R to the pseudo-fermion fields
   assign(k_up, l_up, VOLUME/2);
@@ -223,7 +223,7 @@ double apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
   // apply R a second time
   solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
 	       k_up, k_dn,
-	       solver_pm);
+	       solver_params);
   for(int j = (mnl->rat.np-1); j > -1; j--) {
     assign_add_mul_r(k_up, g_chi_up_spinor_field[j], 
 		     mnl->rat.rmu[j], VOLUME/2);
@@ -235,7 +235,7 @@ double apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
   mul_r(g_chi_dn_spinor_field[mnl->rat.np], mnl->rat.A*mnl->rat.A, 
 	k_dn, VOLUME/2);
   // apply Q^2 and compute the residue
-  solver_pm->M_ndpsi(k_up, k_dn,
+  solver_params->M_ndpsi(k_up, k_dn,
 		     g_chi_up_spinor_field[mnl->rat.np], g_chi_dn_spinor_field[mnl->rat.np]);
   diff(k_up, k_up, l_up, VOLUME/2);
   diff(k_dn, k_dn, l_dn, VOLUME/2);
@@ -251,10 +251,10 @@ double apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
 void check_C_ndpsi(spinor * const k_up, spinor * const k_dn,
 		   spinor * const l_up, spinor * const l_dn,
 		   const int id, hamiltonian_field_t * const hf,
-		   solver_pm_t * solver_pm) {
+		   solver_params_t * solver_params) {
   monomial * mnl = &monomial_list[id];
   mnl->iter0 = solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
-			     l_up, l_dn, solver_pm);
+			     l_up, l_dn, solver_params);
 
   assign(k_up, l_up, VOLUME/2);
   assign(k_dn, l_dn, VOLUME/2);
@@ -277,10 +277,10 @@ void check_C_ndpsi(spinor * const k_up, spinor * const k_dn,
     assign_add_mul(k_dn, g_chi_dn_spinor_field[mnl->rat.np], I*mnl->rat.rnu[j], VOLUME/2);
   }
   //apply R
-  solver_pm->shifts = mnl->rat.mu;
+  solver_params->shifts = mnl->rat.mu;
   solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
 	       k_up, k_dn,
-	       solver_pm);
+	       solver_params);
   for(int j = (mnl->rat.np-1); j > -1; j--) {
     assign_add_mul_r(k_up, g_chi_up_spinor_field[j], 
 		     mnl->rat.rmu[j], VOLUME/2);
@@ -288,9 +288,9 @@ void check_C_ndpsi(spinor * const k_up, spinor * const k_dn,
 		     mnl->rat.rmu[j], VOLUME/2);
   }
   // apply C^dagger
-  solver_pm->shifts = mnl->rat.nu;
+  solver_params->shifts = mnl->rat.nu;
   solve_mms_nd(g_chi_up_spinor_field, g_chi_dn_spinor_field,
-	       k_up, k_dn, solver_pm);
+	       k_up, k_dn, solver_params);
   for(int j = (mnl->rat.np-1); j > -1; j--) {
     // Q_h * tau^1 + i nu_j
     if(mnl->type == NDCLOVERRATCOR || mnl->type == NDCLOVERRAT) {

--- a/monomial/ndratcor_monomial.c
+++ b/monomial/ndratcor_monomial.c
@@ -65,7 +65,6 @@ double apply_Z_ndpsi(spinor * const k_up, spinor * const k_dn,
 
 void ndratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_params_t solver_params;
   double atime, etime, delta;
   spinor * up0, * dn0, * up1, * dn1, * tup, * tdn;
   double coefs[6] = {1./4., -3./32., 7./128., -77./2048., 231./8192., -1463./65536.};
@@ -93,19 +92,19 @@ void ndratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   random_spinor_field_eo(mnl->pf2, mnl->rngrepro, RN_GAUSS);
   mnl->energy0 += square_norm(mnl->pf2, VOLUME/2, 1);
 
-  solver_params.max_iter = mnl->maxiter;
-  solver_params.squared_solver_prec = mnl->accprec;
-  solver_params.no_shifts = mnl->rat.np;
-  solver_params.shifts = mnl->rat.mu;
-  solver_params.type = mnl->solver;
-  solver_params.M_ndpsi = &Qtm_pm_ndpsi;
-  solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
+  mnl->solver_params.max_iter = mnl->maxiter;
+  mnl->solver_params.squared_solver_prec = mnl->accprec;
+  mnl->solver_params.no_shifts = mnl->rat.np;
+  mnl->solver_params.shifts = mnl->rat.mu;
+  mnl->solver_params.type = mnl->solver;
+  mnl->solver_params.M_ndpsi = &Qtm_pm_ndpsi;
+  mnl->solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
   if(mnl->type == NDCLOVERRATCOR) {
-    solver_params.M_ndpsi = &Qsw_pm_ndpsi;
-    solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
+    mnl->solver_params.M_ndpsi = &Qsw_pm_ndpsi;
+    mnl->solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
   }
-  solver_params.sdim = VOLUME/2;
-  solver_params.rel_prec = g_relative_precision_flag;
+  mnl->solver_params.sdim = VOLUME/2;
+  mnl->solver_params.rel_prec = g_relative_precision_flag;
 
   // apply B to the random field to generate pseudo-fermion fields
   assign(mnl->w_fields[0], mnl->pf, VOLUME/2);
@@ -114,7 +113,7 @@ void ndratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   up1 = mnl->w_fields[2]; dn1 = mnl->w_fields[3];
 	 
   for(int i = 1; i < 8; i++) {
-    delta = apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &solver_params);
+    delta = apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &(mnl->solver_params) );
     assign_add_mul_r(mnl->pf, up1, coefs[i-1], VOLUME/2);
     assign_add_mul_r(mnl->pf2, dn1, coefs[i-1], VOLUME/2);
     if(delta < mnl->accprec) break;
@@ -136,7 +135,6 @@ void ndratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
 
 
 double ndratcor_acc(const int id, hamiltonian_field_t * const hf) {
-  solver_params_t solver_params;
   monomial * mnl = &monomial_list[id];
   double atime, etime, delta;
   spinor * up0, * dn0, * up1, * dn1, * tup, * tdn;
@@ -151,19 +149,19 @@ double ndratcor_acc(const int id, hamiltonian_field_t * const hf) {
   }
   mnl->energy1 = 0.;
 
-  solver_params.max_iter = mnl->maxiter;
-  solver_params.squared_solver_prec = mnl->accprec;
-  solver_params.no_shifts = mnl->rat.np;
-  solver_params.shifts = mnl->rat.mu;
-  solver_params.type = mnl->solver;
-  solver_params.M_ndpsi = &Qtm_pm_ndpsi;
-  solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
+  mnl->solver_params.max_iter = mnl->maxiter;
+  mnl->solver_params.squared_solver_prec = mnl->accprec;
+  mnl->solver_params.no_shifts = mnl->rat.np;
+  mnl->solver_params.shifts = mnl->rat.mu;
+  mnl->solver_params.type = mnl->solver;
+  mnl->solver_params.M_ndpsi = &Qtm_pm_ndpsi;
+  mnl->solver_params.M_ndpsi32 = &Qtm_pm_ndpsi_32;    
   if(mnl->type == NDCLOVERRATCOR) {
-    solver_params.M_ndpsi = &Qsw_pm_ndpsi;
-    solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
+    mnl->solver_params.M_ndpsi = &Qsw_pm_ndpsi;
+    mnl->solver_params.M_ndpsi32 = &Qsw_pm_ndpsi_32;
   }
-  solver_params.sdim = VOLUME/2;
-  solver_params.rel_prec = g_relative_precision_flag;
+  mnl->solver_params.sdim = VOLUME/2;
+  mnl->solver_params.rel_prec = g_relative_precision_flag;
 
   // apply (Q R)^(-1) to pseudo-fermion fields
   assign(mnl->w_fields[4], mnl->pf, VOLUME/2);
@@ -171,13 +169,13 @@ double ndratcor_acc(const int id, hamiltonian_field_t * const hf) {
   up0 = mnl->w_fields[0]; dn0 = mnl->w_fields[1];
   up1 = mnl->w_fields[2]; dn1 = mnl->w_fields[3];
 
-  delta = apply_Z_ndpsi(up0, dn0, mnl->pf, mnl->pf2, id, hf, &solver_params);
+  delta = apply_Z_ndpsi(up0, dn0, mnl->pf, mnl->pf2, id, hf, &(mnl->solver_params));
   assign_add_mul_r(mnl->w_fields[4], up0, coefs[0], VOLUME/2);
   assign_add_mul_r(mnl->w_fields[5], dn0, coefs[0], VOLUME/2);
 
   for(int i = 2; i < 8; i++) {
     if(delta < mnl->accprec) break;
-    delta = apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &solver_params);
+    delta = apply_Z_ndpsi(up1, dn1, up0, dn0, id, hf, &(mnl->solver_params) );
     assign_add_mul_r(mnl->w_fields[4], up1, coefs[i-1], VOLUME/2);
     assign_add_mul_r(mnl->w_fields[5], dn1, coefs[i-1], VOLUME/2);
     tup = up0; tdn = dn0;

--- a/monomial/rat_monomial.c
+++ b/monomial/rat_monomial.c
@@ -54,7 +54,7 @@
 
 void rat_derivative(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_pm_t solver_pm;
+  solver_params_t solver_params;
   double atime, etime, dummy;
   atime = gettime();
   g_mu = 0;
@@ -78,17 +78,17 @@ void rat_derivative(const int id, hamiltonian_field_t * const hf) {
   //mnl->forcefactor = mnl->EVMaxInv*mnl->EVMaxInv;
   mnl->forcefactor = 1.;
 
-  solver_pm.max_iter = mnl->maxiter;
-  solver_pm.squared_solver_prec = mnl->forceprec;
-  solver_pm.no_shifts = mnl->rat.np;
-  solver_pm.shifts = mnl->rat.mu;
-  solver_pm.rel_prec = g_relative_precision_flag;
-  solver_pm.type = CGMMS;
-  solver_pm.M_psi = mnl->Qsq;
-  solver_pm.sdim = VOLUME/2;
+  solver_params.max_iter = mnl->maxiter;
+  solver_params.squared_solver_prec = mnl->forceprec;
+  solver_params.no_shifts = mnl->rat.np;
+  solver_params.shifts = mnl->rat.mu;
+  solver_params.rel_prec = g_relative_precision_flag;
+  solver_params.type = CGMMS;
+  solver_params.M_psi = mnl->Qsq;
+  solver_params.sdim = VOLUME/2;
   // this generates all X_j,o (odd sites only) -> g_chi_up_spinor_field
   mnl->iter1 += cg_mms_tm(g_chi_up_spinor_field, mnl->pf,
-			  &solver_pm, &dummy);
+			  &solver_params, &dummy);
   
   for(int j = (mnl->rat.np-1); j > -1; j--) {
     mnl->Qp(mnl->w_fields[0], g_chi_up_spinor_field[j]);
@@ -145,7 +145,7 @@ void rat_derivative(const int id, hamiltonian_field_t * const hf) {
 
 void rat_heatbath(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_pm_t solver_pm;
+  solver_params_t solver_params;
   double atime, etime, dummy;
   atime = gettime();
   // only for non-twisted operators
@@ -173,16 +173,16 @@ void rat_heatbath(const int id, hamiltonian_field_t * const hf) {
   mnl->energy0 = square_norm(mnl->pf, VOLUME/2, 1);
 
   // set solver parameters
-  solver_pm.max_iter = mnl->maxiter;
-  solver_pm.squared_solver_prec = mnl->accprec;
-  solver_pm.no_shifts = mnl->rat.np;
-  solver_pm.shifts = mnl->rat.nu;
-  solver_pm.type = CGMMS;
-  solver_pm.M_psi = mnl->Qsq;
-  solver_pm.sdim = VOLUME/2;
-  solver_pm.rel_prec = g_relative_precision_flag;
+  solver_params.max_iter = mnl->maxiter;
+  solver_params.squared_solver_prec = mnl->accprec;
+  solver_params.no_shifts = mnl->rat.np;
+  solver_params.shifts = mnl->rat.nu;
+  solver_params.type = CGMMS;
+  solver_params.M_psi = mnl->Qsq;
+  solver_params.sdim = VOLUME/2;
+  solver_params.rel_prec = g_relative_precision_flag;
   mnl->iter0 = cg_mms_tm(g_chi_up_spinor_field, mnl->pf,
-			 &solver_pm, &dummy);
+			 &solver_params, &dummy);
 
   assign(mnl->w_fields[2], mnl->pf, VOLUME/2);
 
@@ -208,7 +208,7 @@ void rat_heatbath(const int id, hamiltonian_field_t * const hf) {
 
 
 double rat_acc(const int id, hamiltonian_field_t * const hf) {
-  solver_pm_t solver_pm;
+  solver_params_t solver_params;
   monomial * mnl = &monomial_list[id];
   double atime, etime, dummy;
   atime = gettime();
@@ -223,16 +223,16 @@ double rat_acc(const int id, hamiltonian_field_t * const hf) {
   }
   mnl->energy1 = 0.;
 
-  solver_pm.max_iter = mnl->maxiter;
-  solver_pm.squared_solver_prec = mnl->accprec;
-  solver_pm.no_shifts = mnl->rat.np;
-  solver_pm.shifts = mnl->rat.mu;
-  solver_pm.type = CGMMS;
-  solver_pm.M_psi = mnl->Qsq;
-  solver_pm.sdim = VOLUME/2;
-  solver_pm.rel_prec = g_relative_precision_flag;
+  solver_params.max_iter = mnl->maxiter;
+  solver_params.squared_solver_prec = mnl->accprec;
+  solver_params.no_shifts = mnl->rat.np;
+  solver_params.shifts = mnl->rat.mu;
+  solver_params.type = CGMMS;
+  solver_params.M_psi = mnl->Qsq;
+  solver_params.sdim = VOLUME/2;
+  solver_params.rel_prec = g_relative_precision_flag;
   mnl->iter0 += cg_mms_tm(g_chi_up_spinor_field, mnl->pf,
-			  &solver_pm, &dummy);
+			  &solver_params, &dummy);
 
   // apply R to the pseudo-fermion fields
   assign(mnl->w_fields[0], mnl->pf, VOLUME/2);

--- a/monomial/rat_monomial.c
+++ b/monomial/rat_monomial.c
@@ -253,7 +253,7 @@ double rat_acc(const int id, hamiltonian_field_t * const hf) {
     if(g_debug_level > 1) {
       printf("# Time for %s monomial acc step: %e s\n", mnl->name, etime-atime);
     }
-    if(g_debug_level > 0) { // shoud be 3
+    if(g_debug_level > 3) {
       printf("called rat_acc for id %d dH = %1.10e\n", id, mnl->energy1 - mnl->energy0);
     }
   }

--- a/monomial/rat_monomial.c
+++ b/monomial/rat_monomial.c
@@ -30,7 +30,8 @@
 #include "linalg_eo.h"
 #include "start.h"
 #include "gettime.h"
-#include "solver/solver.h"
+#include "solver/monomial_solve.h"
+#include "solver/solver_types.h"
 #include "deriv_Sb.h"
 #include "init/init_chi_spinor_field.h"
 #include "operator/tm_operators.h"
@@ -54,9 +55,10 @@
 
 void rat_derivative(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_params_t solver_params;
   double atime, etime, dummy;
   atime = gettime();
+  mnl_backup_restore_globals(TM_BACKUP_GLOBALS);
+  g_kappa = mnl->kappa;
   g_mu = 0;
   g_mu3 = 0.;
   boundary(mnl->kappa);
@@ -78,17 +80,17 @@ void rat_derivative(const int id, hamiltonian_field_t * const hf) {
   //mnl->forcefactor = mnl->EVMaxInv*mnl->EVMaxInv;
   mnl->forcefactor = 1.;
 
-  solver_params.max_iter = mnl->maxiter;
-  solver_params.squared_solver_prec = mnl->forceprec;
-  solver_params.no_shifts = mnl->rat.np;
-  solver_params.shifts = mnl->rat.mu;
-  solver_params.rel_prec = g_relative_precision_flag;
-  solver_params.type = CGMMS;
-  solver_params.M_psi = mnl->Qsq;
-  solver_params.sdim = VOLUME/2;
+  mnl->solver_params.max_iter = mnl->maxiter;
+  mnl->solver_params.squared_solver_prec = mnl->forceprec;
+  mnl->solver_params.no_shifts = mnl->rat.np;
+  mnl->solver_params.shifts = mnl->rat.mu;
+  mnl->solver_params.rel_prec = g_relative_precision_flag;
+  mnl->solver_params.type = CGMMS;
+  mnl->solver_params.M_psi = mnl->Qsq;
+  mnl->solver_params.sdim = VOLUME/2;
   // this generates all X_j,o (odd sites only) -> g_chi_up_spinor_field
-  mnl->iter1 += cg_mms_tm(g_chi_up_spinor_field, mnl->pf,
-			  &solver_params, &dummy);
+  mnl->iter1 += solve_mshift_oneflavour(g_chi_up_spinor_field, mnl->pf,
+                                        &(mnl->solver_params) );
   
   for(int j = (mnl->rat.np-1); j > -1; j--) {
     mnl->Qp(mnl->w_fields[0], g_chi_up_spinor_field[j]);
@@ -139,15 +141,17 @@ void rat_derivative(const int id, hamiltonian_field_t * const hf) {
   if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
   }
+  mnl_backup_restore_globals(TM_RESTORE_GLOBALS);
   return;
 }
 
 
 void rat_heatbath(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_params_t solver_params;
   double atime, etime, dummy;
   atime = gettime();
+  mnl_backup_restore_globals(TM_BACKUP_GLOBALS);
+  g_kappa = mnl->kappa;
   // only for non-twisted operators
   g_mu = 0.;
   g_mu3 = 0.;
@@ -173,16 +177,16 @@ void rat_heatbath(const int id, hamiltonian_field_t * const hf) {
   mnl->energy0 = square_norm(mnl->pf, VOLUME/2, 1);
 
   // set solver parameters
-  solver_params.max_iter = mnl->maxiter;
-  solver_params.squared_solver_prec = mnl->accprec;
-  solver_params.no_shifts = mnl->rat.np;
-  solver_params.shifts = mnl->rat.nu;
-  solver_params.type = CGMMS;
-  solver_params.M_psi = mnl->Qsq;
-  solver_params.sdim = VOLUME/2;
-  solver_params.rel_prec = g_relative_precision_flag;
-  mnl->iter0 = cg_mms_tm(g_chi_up_spinor_field, mnl->pf,
-			 &solver_params, &dummy);
+  mnl->solver_params.max_iter = mnl->maxiter;
+  mnl->solver_params.squared_solver_prec = mnl->accprec;
+  mnl->solver_params.no_shifts = mnl->rat.np;
+  mnl->solver_params.shifts = mnl->rat.nu;
+  mnl->solver_params.type = CGMMS;
+  mnl->solver_params.M_psi = mnl->Qsq;
+  mnl->solver_params.sdim = VOLUME/2;
+  mnl->solver_params.rel_prec = g_relative_precision_flag;
+  mnl->iter0 = solve_mshift_oneflavour(g_chi_up_spinor_field, mnl->pf,
+			               &(mnl->solver_params) );
 
   assign(mnl->w_fields[2], mnl->pf, VOLUME/2);
 
@@ -203,15 +207,17 @@ void rat_heatbath(const int id, hamiltonian_field_t * const hf) {
       printf("called rat_heatbath for id %d energy %f\n", id, mnl->energy0);
     }
   }
+  mnl_backup_restore_globals(TM_RESTORE_GLOBALS);
   return;
 }
 
 
 double rat_acc(const int id, hamiltonian_field_t * const hf) {
-  solver_params_t solver_params;
   monomial * mnl = &monomial_list[id];
   double atime, etime, dummy;
   atime = gettime();
+  mnl_backup_restore_globals(TM_BACKUP_GLOBALS);
+  g_kappa = mnl->kappa;
   // only for non-twisted operators
   g_mu = 0.;
   g_mu3 = 0.;
@@ -223,16 +229,16 @@ double rat_acc(const int id, hamiltonian_field_t * const hf) {
   }
   mnl->energy1 = 0.;
 
-  solver_params.max_iter = mnl->maxiter;
-  solver_params.squared_solver_prec = mnl->accprec;
-  solver_params.no_shifts = mnl->rat.np;
-  solver_params.shifts = mnl->rat.mu;
-  solver_params.type = CGMMS;
-  solver_params.M_psi = mnl->Qsq;
-  solver_params.sdim = VOLUME/2;
-  solver_params.rel_prec = g_relative_precision_flag;
-  mnl->iter0 += cg_mms_tm(g_chi_up_spinor_field, mnl->pf,
-			  &solver_params, &dummy);
+  mnl->solver_params.max_iter = mnl->maxiter;
+  mnl->solver_params.squared_solver_prec = mnl->accprec;
+  mnl->solver_params.no_shifts = mnl->rat.np;
+  mnl->solver_params.shifts = mnl->rat.mu;
+  mnl->solver_params.type = CGMMS;
+  mnl->solver_params.M_psi = mnl->Qsq;
+  mnl->solver_params.sdim = VOLUME/2;
+  mnl->solver_params.rel_prec = g_relative_precision_flag;
+  mnl->iter0 += solve_mshift_oneflavour(g_chi_up_spinor_field, mnl->pf,
+			                &(mnl->solver_params) );
 
   // apply R to the pseudo-fermion fields
   assign(mnl->w_fields[0], mnl->pf, VOLUME/2);
@@ -240,7 +246,7 @@ double rat_acc(const int id, hamiltonian_field_t * const hf) {
     assign_add_mul_r(mnl->w_fields[0], g_chi_up_spinor_field[j], 
 		     mnl->rat.rmu[j], VOLUME/2);
   }
-
+  
   mnl->energy1 = scalar_prod_r(mnl->pf, mnl->w_fields[0], VOLUME/2, 1);
   etime = gettime();
   if(g_proc_id == 0) {
@@ -251,6 +257,7 @@ double rat_acc(const int id, hamiltonian_field_t * const hf) {
       printf("called rat_acc for id %d dH = %1.10e\n", id, mnl->energy1 - mnl->energy0);
     }
   }
+  mnl_backup_restore_globals(TM_RESTORE_GLOBALS);
   return(mnl->energy1 - mnl->energy0);
 }
 

--- a/monomial/ratcor_monomial.c
+++ b/monomial/ratcor_monomial.c
@@ -59,10 +59,9 @@ double apply_Z_psi(spinor * const k_up, spinor * const l_up,
 
 void ratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   monomial * mnl = &monomial_list[id];
-  solver_params_t solver_params;
   double atime, etime, delta;
   spinor * up0, * up1, * tup;
-  double coefs[6] = {1./4., -3./32., 7./122., -77./2048., 231./8192., -1463./65536.};
+  double coefs[6] = {1./4., -3./32., 7./128., -77./2048., 231./8192., -1463./65536.};
   atime = gettime();
   nd_set_global_parameter(mnl);
   g_mu = 0.;
@@ -87,14 +86,14 @@ void ratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   random_spinor_field_eo(mnl->pf, mnl->rngrepro, RN_GAUSS);
   mnl->energy0 = square_norm(mnl->pf, VOLUME/2, 1);
 
-  solver_params.max_iter = mnl->maxiter;
-  solver_params.squared_solver_prec = mnl->accprec;
-  solver_params.no_shifts = mnl->rat.np;
-  solver_params.shifts = mnl->rat.mu;
-  solver_params.type = CGMMS;
-  solver_params.M_psi = mnl->Qsq;
-  solver_params.sdim = VOLUME/2;
-  solver_params.rel_prec = g_relative_precision_flag;
+  mnl->solver_params.max_iter = mnl->maxiter;
+  mnl->solver_params.squared_solver_prec = mnl->accprec;
+  mnl->solver_params.no_shifts = mnl->rat.np;
+  mnl->solver_params.shifts = mnl->rat.mu;
+  mnl->solver_params.type = CGMMS;
+  mnl->solver_params.M_psi = mnl->Qsq;
+  mnl->solver_params.sdim = VOLUME/2;
+  mnl->solver_params.rel_prec = g_relative_precision_flag;
 
   // apply B to the random field to generate pseudo-fermion fields
   assign(mnl->w_fields[0], mnl->pf, VOLUME/2);
@@ -102,7 +101,7 @@ void ratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
   up1 = mnl->w_fields[2]; 
 	 
   for(int i = 1; i < 8; i++) {
-    delta = apply_Z_psi(up1, up0, id, hf, &solver_params);
+    delta = apply_Z_psi(up1, up0, id, hf, &(mnl->solver_params) );
     assign_add_mul_r(mnl->pf, up1, coefs[i-1], VOLUME/2);
     if(delta < mnl->accprec) break;
     tup = up0;
@@ -114,7 +113,7 @@ void ratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
     if(g_debug_level > 1) {
       printf("# Time for %s monomial heatbath: %e s\n", mnl->name, etime-atime);
     }
-    if(g_debug_level > 3) { 
+    if(g_debug_level > 3) {
       printf("called ratcor_heatbath for id %d energy %f\n", id, mnl->energy0);
     }
   }
@@ -123,7 +122,6 @@ void ratcor_heatbath(const int id, hamiltonian_field_t * const hf) {
 
 
 double ratcor_acc(const int id, hamiltonian_field_t * const hf) {
-  solver_params_t solver_params;
   monomial * mnl = &monomial_list[id];
   double atime, etime, delta;
   spinor * up0, * up1, * tup;
@@ -141,26 +139,26 @@ double ratcor_acc(const int id, hamiltonian_field_t * const hf) {
   }
   mnl->energy1 = 0.;
 
-  solver_params.max_iter = mnl->maxiter;
-  solver_params.squared_solver_prec = mnl->accprec;
-  solver_params.no_shifts = mnl->rat.np;
-  solver_params.shifts = mnl->rat.mu;
-  solver_params.type = CGMMS;
-  solver_params.M_psi = mnl->Qsq;
-  solver_params.sdim = VOLUME/2;
-  solver_params.rel_prec = g_relative_precision_flag;
+  mnl->solver_params.max_iter = mnl->maxiter;
+  mnl->solver_params.squared_solver_prec = mnl->accprec;
+  mnl->solver_params.no_shifts = mnl->rat.np;
+  mnl->solver_params.shifts = mnl->rat.mu;
+  mnl->solver_params.type = CGMMS;
+  mnl->solver_params.M_psi = mnl->Qsq;
+  mnl->solver_params.sdim = VOLUME/2;
+  mnl->solver_params.rel_prec = g_relative_precision_flag;
 
   // apply (Q R)^(-1) to pseudo-fermion fields
   assign(mnl->w_fields[4], mnl->pf, VOLUME/2);
   up0 = mnl->w_fields[0];
   up1 = mnl->w_fields[2];
 
-  delta = apply_Z_psi(up0, mnl->pf, id, hf, &solver_params);
+  delta = apply_Z_psi(up0, mnl->pf, id, hf, &(mnl->solver_params) );
   assign_add_mul_r(mnl->w_fields[4], up0, coefs[0], VOLUME/2);
 
   for(int i = 2; i < 8; i++) {
     if(delta < mnl->accprec) break;
-    delta = apply_Z_psi(up1, up0, id, hf, &solver_params);
+    delta = apply_Z_psi(up1, up0, id, hf, &(mnl->solver_params) );
     assign_add_mul_r(mnl->w_fields[4], up1, coefs[i-1], VOLUME/2);
     tup = up0;
     up0 = up1;
@@ -173,7 +171,7 @@ double ratcor_acc(const int id, hamiltonian_field_t * const hf) {
     if(g_debug_level > 1) {
       printf("# Time for %s monomial acc step: %e s\n", mnl->name, etime-atime);
     }
-    if(g_debug_level > 3) { // shoud be 3
+    if(g_debug_level > 3) {
       printf("called ratcor_acc for id %d dH = %1.10e\n", id, mnl->energy1 - mnl->energy0);
     }
   }
@@ -186,10 +184,9 @@ double apply_Z_psi(spinor * const k_up,	spinor * const l_up,
 		     const int id, hamiltonian_field_t * const hf,
 		     solver_params_t * solver_params) {
   monomial * mnl = &monomial_list[id];
-  double dummy;
 
-  mnl->iter0 += cg_mms_tm(g_chi_up_spinor_field, l_up,
-			  solver_params, &dummy);  
+  mnl->iter0 += solve_mshift_oneflavour(g_chi_up_spinor_field, l_up,
+                                        solver_params);  
   
   // apply R to the pseudo-fermion fields
   assign(k_up, l_up, VOLUME/2);
@@ -199,8 +196,8 @@ double apply_Z_psi(spinor * const k_up,	spinor * const l_up,
   }
 
   // apply R a second time
-  cg_mms_tm(g_chi_up_spinor_field, k_up,
-	    solver_params, &dummy);
+  solve_mshift_oneflavour(g_chi_up_spinor_field, k_up,
+                          solver_params);
   for(int j = (mnl->rat.np-1); j > -1; j--) {
     assign_add_mul_r(k_up, g_chi_up_spinor_field[j], 
 		     mnl->rat.rmu[j], VOLUME/2);
@@ -208,10 +205,12 @@ double apply_Z_psi(spinor * const k_up,	spinor * const l_up,
   mul_r(g_chi_up_spinor_field[mnl->rat.np], mnl->rat.A*mnl->rat.A, 
 	k_up, VOLUME/2);
 
-  // apply Q^2 and compute the residue
+  // apply Q^2 
   solver_params->M_psi(k_up, g_chi_up_spinor_field[mnl->rat.np]);
+  // compute the residue
   diff(k_up, k_up, l_up, VOLUME/2);
   double resi = square_norm(k_up, VOLUME/2, 1);
+  
   if(g_debug_level > 2 && g_proc_id == 0) {
     printf("# RATCOR: ||Z * phi|| = %e\n", resi);
   }
@@ -224,8 +223,7 @@ void check_C_psi(spinor * const k_up, spinor * const l_up,
 		 const int id, hamiltonian_field_t * const hf,
 		 solver_params_t * solver_params) {
   monomial * mnl = &monomial_list[id];
-  double dummy;
-  mnl->iter0 = cg_mms_tm(g_chi_up_spinor_field, l_up, solver_params, &dummy);
+  mnl->iter0 = solve_mshift_oneflavour(g_chi_up_spinor_field, l_up, solver_params);
 
   assign(k_up, l_up, VOLUME/2);
 
@@ -244,16 +242,15 @@ void check_C_psi(spinor * const k_up, spinor * const l_up,
   }
   //apply R
   solver_params->shifts = mnl->rat.mu;
-  cg_mms_tm(g_chi_up_spinor_field, k_up,
-	    solver_params, &dummy);
+  solve_mshift_oneflavour(g_chi_up_spinor_field, k_up,
+                          solver_params);
   for(int j = (mnl->rat.np-1); j > -1; j--) {
     assign_add_mul_r(k_up, g_chi_up_spinor_field[j], 
 		     mnl->rat.rmu[j], VOLUME/2);
   }
   // apply C^dagger
   solver_params->shifts = mnl->rat.nu;
-  cg_mms_tm(g_chi_up_spinor_field, k_up,
-	    solver_params, &dummy);
+  solve_mshift_oneflavour(g_chi_up_spinor_field, k_up, solver_params);
   for(int j = (mnl->rat.np-1); j > -1; j--) {
     if(mnl->type == NDCLOVERRATCOR || mnl->type == NDCLOVERRAT) {
       //Qsw_tau1_sub_const_ndpsi(g_chi_up_spinor_field[mnl->rat.np], g_chi_dn_spinor_field[mnl->rat.np],

--- a/operator.c
+++ b/operator.c
@@ -619,6 +619,7 @@ void op_backup_restore_globals(const backup_restore_t mode){
     g_mu     = backup_mu;
     g_mubar  = backup_mubar;
     g_epsbar = backup_epsbar;
+    boundary(g_kappa);
   }
 }
   

--- a/operator.c
+++ b/operator.c
@@ -641,4 +641,14 @@ void op_set_globals(const int op_id){
     g_mubar = op->mubar;
     g_epsbar = op->epsbar;
   }
+  if(g_debug_level > 2 && g_proc_id == 0){
+    printf("# op_set_globals set globals to:\n");
+    printf("# g_kappa = %.12lf\n", g_kappa);
+    printf("# g_c_sw = %.12lf\n", g_c_sw);
+    printf("# g_mu = %.12lf\n", g_mu);
+    printf("# g_mu2 = %.12lf\n", g_mu2);
+    printf("# g_mu3 = %.12lf\n", g_mu3);
+    printf("# g_mubar = %.12lf\n", g_mubar);
+    printf("# g_epsbar = %.12lf\n", g_epsbar);
+  }
 }

--- a/operator.c
+++ b/operator.c
@@ -94,6 +94,7 @@ int add_operator(const int type) {
   optr->compression_type = _default_compression_type;
   optr->external_inverter = _default_external_inverter;
   optr->solver_params.solution_type = TM_SOLUTION_M;
+  optr->solver_params.no_shifts = 1;
   optr->coefs = NULL;
   optr->rel_prec = _default_g_relative_precision_flag;
   optr->eps_sq = _default_solver_precision;
@@ -190,9 +191,11 @@ int init_operators() {
           optr->applyMm = &M_minus_psi;
         }
         if(optr->solver == CGMMS) {
-          if (g_cart_id == 0 && optr->even_odd_flag == 1)
-            fprintf(stderr, "CG Multiple mass solver works only without even/odd! Forcing!\n");
-          optr->even_odd_flag = 0;
+          if( optr->external_inverter != QPHIX_INVERTER ){
+            if (g_cart_id == 0 && optr->even_odd_flag == 1)
+              fprintf(stderr, "CG Multiple mass solver works only without even/odd! Forcing!\n");
+            optr->even_odd_flag = 0;
+          }
           if (g_cart_id == 0 && optr->DownProp)
             fprintf(stderr, "CGMMS doesn't need AddDownPropagator! Switching Off!\n");
           optr->DownProp = 0;
@@ -230,9 +233,11 @@ int init_operators() {
           optr->applyMm = &Msw_full_minus_psi;
         }
         if(optr->solver == CGMMS) {
-          if (g_cart_id == 0 && optr->even_odd_flag == 1)
-            fprintf(stderr, "CG Multiple mass solver works only without even/odd! Forcing!\n");
-          optr->even_odd_flag = 0;
+          if( optr->external_inverter != QPHIX_INVERTER ){
+            if (g_cart_id == 0 && optr->even_odd_flag == 1)
+              fprintf(stderr, "CG Multiple mass solver works only without even/odd! Forcing!\n");
+            optr->even_odd_flag = 0;
+          }
           if (g_cart_id == 0 && optr->DownProp)
             fprintf(stderr, "CGMMS doesn't need AddDownPropagator! Switching Off!\n");
           optr->DownProp = 0;

--- a/operator.c
+++ b/operator.c
@@ -93,6 +93,7 @@ int add_operator(const int type) {
   optr->sloppy_precision = _default_operator_sloppy_precision_flag;
   optr->compression_type = _default_compression_type;
   optr->external_inverter = _default_external_inverter;
+  optr->solver_params.solution_type = TM_SOLUTION_M;
   optr->coefs = NULL;
   optr->rel_prec = _default_g_relative_precision_flag;
   optr->eps_sq = _default_solver_precision;

--- a/operator.h
+++ b/operator.h
@@ -29,6 +29,11 @@
 
 #define max_no_operators 10
 
+typedef enum backup_restore_t {
+  TM_BACKUP_GLOBALS = 0,
+  TM_RESTORE_GLOBALS
+} backup_restore_t;
+
 typedef struct {
   /* ID of the operator */
   int type;
@@ -135,5 +140,6 @@ int add_operator(const int type);
 int init_operators();
 
 void op_set_globals(const int op_id);
+void op_backup_restore_globals(const backup_restore_t mode);
 
 #endif

--- a/operator.h
+++ b/operator.h
@@ -26,13 +26,9 @@
 #include "su3.h"
 #include "solver/solver_params.h"
 #include "operator_types.h"
+#include "misc_types.h"
 
 #define max_no_operators 10
-
-typedef enum backup_restore_t {
-  TM_BACKUP_GLOBALS = 0,
-  TM_RESTORE_GLOBALS
-} backup_restore_t;
 
 typedef struct {
   /* ID of the operator */

--- a/operator/clover_invert.c
+++ b/operator/clover_invert.c
@@ -77,6 +77,8 @@
   !______________________________________________________________!
 */
 
+// for debugging purposes, the print statements can be enabled
+// #define CLOVER_INVERT_DEBUG
 
 /* six_invert and six_det are called from multiple threads, they are thus
  * made thread-safe by removing the static keywords but they are NOT
@@ -264,8 +266,8 @@ void sw_invert(const int ieo, const double mu) {
  * for use in the QPhiX packing routine for the non-degenerate
  * clover doublet
  *
- * sw should be populated with (1+Tee) and sw_inv should contain 
- * 1 / ( (1 + Tee)^2 + \bar\mu^2 - \bar\epsilon^2 ) 
+ * sw_inv should contain 
+ *   1 / ( (1 + Tee)^2 + \bar\mu^2 - \bar\epsilon^2 ) 
  * the last VOLUME/2 elements (which should not be relevant at this stage) 
  * of sw_inv will be overwritten
  */ 
@@ -298,6 +300,10 @@ void sw_invert_epsbar(const double epsbar) {
 
       // scale by epsbar
       scale_real_6x6(a, epsbar);
+
+#ifdef CLOVER_INVERT_DEBUG
+      if(icx==0) print_6x6(a, "sw_invert_epsbar epsilon*sw_inv");
+#endif
 
       /*  and write the result into the last VOLUME/2 elements of sw_inv */
       get_3x3_block_matrix(&sw_inv[icy][0][i], a, 0, 0);
@@ -369,6 +375,13 @@ void sw_invert_mubar(const double mubar) {
       // the i index denotes the halfspinor block and thus implements gamma5
       add_tm(a, -(i==0?1.0:-1.0)*mubar);
       add_tm(b, +(i==0?1.0:-1.0)*mubar);
+
+#ifdef CLOVER_INVERT_DEBUG
+      if(icx==0) {
+        print_6x6(a,"sw_invert_mubar sw_up");
+        print_6x6(b,"sw_invert_mubar sw_dn");
+      }
+#endif
   
       // extract 1/((1+Tee)^2 + \bar\mu^2 - \bar\eps^2)
       populate_6x6_matrix(c, &sw_inv[icx][0][i], 0, 0);
@@ -385,6 +398,10 @@ void sw_invert_mubar(const double mubar) {
       get_3x3_block_matrix(&sw_inv[icx][2][i], d, 3, 3);
       get_3x3_block_matrix(&sw_inv[icx][3][i], d, 3, 0);
 
+#ifdef CLOVER_INVERT_DEBUG
+      if(icx==0) print_6x6(d,"sw_invert_mubar sw_inv_up");
+#endif
+
       // and the same for the 'down'
       mult_6x6(d, b, c);
   
@@ -392,6 +409,10 @@ void sw_invert_mubar(const double mubar) {
       get_3x3_block_matrix(&sw_inv[icy][1][i], d, 0, 3);
       get_3x3_block_matrix(&sw_inv[icy][2][i], d, 3, 3);
       get_3x3_block_matrix(&sw_inv[icy][3][i], d, 3, 0);
+
+#ifdef CLOVER_INVERT_DEBUG
+      if(icx==0) print_6x6(d,"sw_invert_mubar sw_inv_dn");
+#endif
     }
 #ifndef TM_USE_OMP
     icy++;
@@ -439,6 +460,10 @@ void sw_invert_nd(const double mshift) {
       populate_6x6_matrix(a, &v, 3, 0);
       populate_6x6_matrix(a, &sw[x][2][i], 3, 3);
 
+#ifdef CLOVER_INVERT_DEBUG
+      if(icx==0) print_6x6(a, "sw_invert_nd sw");
+#endif
+
       // compute (1+T)^2 and store in b
       mult_6x6(b, a, a);
       // we add the mass shift term, which is a real number
@@ -451,6 +476,10 @@ void sw_invert_nd(const double mshift) {
 	printf("# inversion failed in six_invert_nd code %d\n", err);
 	err = 0;
       }
+
+#ifdef CLOVER_INVERT_DEBUG
+      if(icx==0) print_6x6(b, "sw_invert_nd sw_inv");
+#endif
 
       /*  copy "a" back to sw_inv */
       get_3x3_block_matrix(&sw_inv[icx][0][i], b, 0, 0);

--- a/operator/clover_invert.c
+++ b/operator/clover_invert.c
@@ -3,6 +3,7 @@
  * Copyright (C) 1995 Ulli Wolff, Stefan Sint
  *               2001,2005 Martin Hasenbusch
  *               2011,2012 Carsten Urbach
+ *               2017      Bartosz Kostrzewa
  *
  * This file is part of tmLQCD.
  *
@@ -256,9 +257,155 @@ void sw_invert(const int ieo, const double mu) {
   return;
 }
 
+/* This function computes 
+ * 
+ *   \bar\epsilon / ( (1 + Tee)^2 + \bar\mu^2 - \bar\epsilon^2 )
+ * 
+ * for use in the QPhiX packing routine for the non-degenerate
+ * clover doublet
+ *
+ * sw should be populated with (1+Tee) and sw_inv should contain 
+ * 1 / ( (1 + Tee)^2 + \bar\mu^2 - \bar\epsilon^2 ) 
+ * the last VOLUME/2 elements (which should not be relevant at this stage) 
+ * of sw_inv will be overwritten
+ */ 
+
+void sw_invert_epsbar(const double epsbar) {
+#ifdef TM_USE_OMP
+#pragma omp parallel
+  {
+#endif
+  int icy, i;
+  _Complex double ALIGN a[6][6];
+
+#ifndef TM_USE_OMP
+  icy=VOLUME/2;
+#endif
+
+#ifdef TM_USE_OMP
+#pragma omp for
+#endif
+  for(int icx = 0; icx < VOLUME/2; icx++) {
+#ifdef TM_USE_OMP
+    icy = icx + VOLUME/2;
+#endif
+    for(i = 0; i < 2; i++) {
+      // extract 1/((1+Tee)^2 + \bar\mu^2 - \bar\epsilon^2)
+      populate_6x6_matrix(a, &sw_inv[icx][0][i], 0, 0);
+      populate_6x6_matrix(a, &sw_inv[icx][1][i], 0, 3);
+      populate_6x6_matrix(a, &sw_inv[icx][2][i], 3, 3);
+      populate_6x6_matrix(a, &sw_inv[icx][3][i], 3, 0);
+
+      // scale by epsbar
+      scale_real_6x6(a, epsbar);
+
+      /*  and write the result into the last VOLUME/2 elements of sw_inv */
+      get_3x3_block_matrix(&sw_inv[icy][0][i], a, 0, 0);
+      get_3x3_block_matrix(&sw_inv[icy][1][i], a, 0, 3);
+      get_3x3_block_matrix(&sw_inv[icy][2][i], a, 3, 3);
+      get_3x3_block_matrix(&sw_inv[icy][3][i], a, 3, 0);
+    }
+#ifndef TM_USE_OMP
+    icy++;
+#endif
+  }
+#ifdef TM_USE_OMP
+  } /* OpenMP closing brace */
+#endif
+  return;
+}
+
+/* This function computes 
+ * 
+ *   (1 + Tee - I*\bar\mu\gamma_5\tau3 ) / ( 1 + Tee + \bar\mu^2 - \bar\eps^2 )
+ * 
+ * for use in the QPhiX packing routine for the non-degenerate
+ * clover doublet
+ *
+ * sw should be populated with (1+Tee) and 
+ * sw_inv should contain 1 / ( (1 + Tee)^2 + \bar\mu^2 - \bar\eps^2 )
+ *
+ * !! all elements of sw_inv will be overwritten !!
+ */ 
+
+void sw_invert_mubar(const double mubar) {
+#ifdef TM_USE_OMP
+#pragma omp parallel
+  {
+#endif
+  int err=0;
+  int icy, i, x;
+  su3 ALIGN v;
+  _Complex double ALIGN a[6][6];
+  _Complex double ALIGN b[6][6];
+  _Complex double ALIGN c[6][6];
+  _Complex double ALIGN d[6][6];
+
+#ifndef TM_USE_OMP
+  icy=VOLUME/2;
+#endif
+
+#ifdef TM_USE_OMP
+#pragma omp for
+#endif
+  for(int icx = 0; icx < VOLUME/2; icx++) {
+#ifdef TM_USE_OMP
+    icy = icx + VOLUME/2;
+#endif
+    x = g_eo2lexic[icx];
+    
+    for(i = 0; i < 2; i++) {
+      // extract (1+Tee)
+      populate_6x6_matrix(a, &sw[x][0][i], 0, 0);
+      populate_6x6_matrix(a, &sw[x][1][i], 0, 3);
+      _su3_dagger(v, sw[x][1][i]); 
+      populate_6x6_matrix(a, &v, 3, 0);
+      populate_6x6_matrix(a, &sw[x][2][i], 3, 3);
+
+      copy_6x6(b,a);
+
+      // we add the twisted quark masses for both the 'up' and the 'down' flavour
+      // (note that this is the inverse, so -mu is associated with 'up')
+      // the i index denotes the halfspinor block and thus implements gamma5
+      add_tm(a, -(i==0?1.0:-1.0)*mubar);
+      add_tm(b, +(i==0?1.0:-1.0)*mubar);
+  
+      // extract 1/((1+Tee)^2 + \bar\mu^2 - \bar\eps^2)
+      populate_6x6_matrix(c, &sw_inv[icx][0][i], 0, 0);
+      populate_6x6_matrix(c, &sw_inv[icx][1][i], 0, 3);
+      populate_6x6_matrix(c, &sw_inv[icx][2][i], 3, 3);
+      populate_6x6_matrix(c, &sw_inv[icx][3][i], 3, 0);
+  
+      // multiply the two together and store in d
+      mult_6x6(d, a, c);
+  
+      /*  and write the result into sw_inv */
+      get_3x3_block_matrix(&sw_inv[icx][0][i], d, 0, 0);
+      get_3x3_block_matrix(&sw_inv[icx][1][i], d, 0, 3);
+      get_3x3_block_matrix(&sw_inv[icx][2][i], d, 3, 3);
+      get_3x3_block_matrix(&sw_inv[icx][3][i], d, 3, 0);
+
+      // and the same for the 'down'
+      mult_6x6(d, b, c);
+  
+      get_3x3_block_matrix(&sw_inv[icy][0][i], d, 0, 0);
+      get_3x3_block_matrix(&sw_inv[icy][1][i], d, 0, 3);
+      get_3x3_block_matrix(&sw_inv[icy][2][i], d, 3, 3);
+      get_3x3_block_matrix(&sw_inv[icy][3][i], d, 3, 0);
+    }
+#ifndef TM_USE_OMP
+    icy++;
+#endif
+  }
+#ifdef TM_USE_OMP
+  } /* OpenMP closing brace */
+#endif
+  return;
+}
+
 // This function computes
 //
-// 1/((1+T)^2 + barmu^2 - bareps^2)^{-1}
+// 1/((1+T)^2 + \bar\mu^2 - \bar\epsilon^2)
 //
 // for all even x,
 // which is stored in sw_inv[0-(VOLUME/2-1)]

--- a/operator/clover_leaf.c
+++ b/operator/clover_leaf.c
@@ -98,9 +98,30 @@ void copy_6x6(_Complex double a[6][6], const _Complex double b[6][6]) {
   return;
 }
 
+void scale_real_6x6(_Complex double a[6][6], const double scale){
+  for(int i = 0; i < 6; i++) {
+    for(int j = 0; j < 6; j++) {
+      a[i][j] *= scale;
+    }
+  }
+  return;
+}
 
+void scale_cplx_6x6(_Complex double a[6][6], const _Complex double scale){
+  for(int i = 0; i < 6; i++) {
+    for(int j = 0; j < 6; j++) {
+      a[i][j] *= scale;
+    }
+  }
+  return;
+}
 
-
+void one_6x6(_Complex double a[6][6]){
+  memset((void*)(&a[0][0]), 0, 36*sizeof(_Complex double));
+  for(int i = 0; i < 6; i++){
+    a[i][i] = 1.0;
+  }
+}
 
 
 

--- a/operator/clover_leaf.c
+++ b/operator/clover_leaf.c
@@ -123,8 +123,18 @@ void one_6x6(_Complex double a[6][6]){
   }
 }
 
-
-
+void print_6x6(_Complex double a[6][6], const char * const text){
+  if(g_proc_id==0){
+    printf("%s\n",text);
+    for(int i = 0; i < 6; i++){
+      for(int j = 0; j < 6; j++){
+        printf("(%+.2e %+.2e) ", creal(a[i][j]), cimag(a[i][j]));
+      }
+      printf("\n");
+    }
+    printf("\n");
+  }
+}
 
 su3 * _swp;
 

--- a/operator/clover_leaf.h
+++ b/operator/clover_leaf.h
@@ -49,5 +49,6 @@ void copy_6x6(_Complex double a[6][6], const _Complex double b[6][6]);
 void scale_real_6x6(_Complex double a[6][6], const double scale);
 void scale_cplx_6x6(_Complex double a[6][6], const _Complex double scale);
 void one_6x6(_Complex double a[6][6]);
+void print_6x6(_Complex double a[6][6], const char * const text );
 
 #endif

--- a/operator/clover_leaf.h
+++ b/operator/clover_leaf.h
@@ -2,6 +2,7 @@
  *
  * Copyright (C) 2005 Martin Hasenbusch
  *               2011 Carsten Urbach
+ *               2017 Bartosz Kostrzewa
  *
  * This file is part of tmLQCD.
  *
@@ -32,6 +33,8 @@ double sw_trace(const int ieo, const double mu);
 double sw_trace_nd(const int ieo, const double mu, const double eps);
 void sw_invert(const int ieo, const double mu);
 void sw_invert_nd(const double mshift);
+void sw_invert_epsbar(const double epsbar);
+void sw_invert_mubar(const double mubar);
 void sw_deriv(const int ieo, const double mu);
 void sw_deriv_nd(const int ieo);
 void sw_spinor_eo(const int ieo, const spinor * const kk, const spinor * const ll, const double fac);
@@ -43,5 +46,8 @@ void mult_6x6(_Complex double a[6][6], _Complex double b[6][6], _Complex double 
 void add_6x6(_Complex double a[6][6], _Complex double b[6][6], _Complex double d[6][6]);
 void sub_6x6(_Complex double a[6][6], _Complex double b[6][6], _Complex double d[6][6]);
 void copy_6x6(_Complex double a[6][6], const _Complex double b[6][6]);
+void scale_real_6x6(_Complex double a[6][6], const double scale);
+void scale_cplx_6x6(_Complex double a[6][6], const _Complex double scale);
+void one_6x6(_Complex double a[6][6]);
 
 #endif

--- a/operator/clovertm_operators.c
+++ b/operator/clovertm_operators.c
@@ -53,7 +53,6 @@
 #include "tm_operators.h"
 #include "tm_operators_32.h"
 
-#include "operator/clover_invert.c"
 #include "operator/clovertm_operators.h"
 #include "operator/D_psi.h"
 
@@ -169,12 +168,11 @@ void Msw_full(spinor * const Even_new, spinor * const Odd_new,
   Hopping_Matrix(EO, g_spinor_field[DUM_MATRIX], Odd);
   assign_mul_one_sw_pm_imu(EE, Even_new, Even, +g_mu);
   assign_add_mul_r(Even_new, g_spinor_field[DUM_MATRIX], -1., VOLUME/2);
-
+  
   /* Odd sites */
   Hopping_Matrix(OE, g_spinor_field[DUM_MATRIX], Even);
   assign_mul_one_sw_pm_imu(OO, Odd_new, Odd, +g_mu);
   assign_add_mul_r(Odd_new, g_spinor_field[DUM_MATRIX], -1., VOLUME/2);
-
 }
 
 
@@ -336,74 +334,6 @@ void clover_inv(spinor * const l, const int tau3sign, const double mu) {
       _su3_multiply(chi,*w2,(*rn).s3);
       _vector_add((*rn).s2,psi,chi);
       _su3_multiply(psi,*w4,phi3); 
-      _su3_multiply(chi,*w3,(*rn).s3);
-      _vector_add((*rn).s3,psi,chi);
-
-#ifndef TM_USE_OMP
-      ++icy;
-#endif
-
-      /******************************** end of loop *********************************/
-    }
-#ifdef TM_USE_OMP
-  } /* OpenMP closing brace */
-#endif
-  return;
-}
-
-// apply clover term to an even-odd-ordered VOLUME/2 spinor on ieo=0 (even) and ieo=1 (odd) sites
-void clover_mult(spinor * const l, int ieo) {
-#ifdef TM_USE_OMP
-#pragma omp parallel
-  {
-#endif
-    int icy, ix;
-    su3_vector ALIGN psi, chi, phi1, phi3;
-    int ioff = 0;
-    const su3 *w1, *w2, *w3;
-    spinor *rn;
-
-    if(ieo > 0) {
-      ioff = (VOLUME+RAND)/2;
-    }
-
-#ifndef TM_USE_OMP
-    icy = 0;
-#endif
-    
-    /************************ loop over all lattice sites *************************/
-#ifdef TM_USE_OMP
-#pragma omp for
-#endif
-    for(int icx = ioff; icx < (VOLUME/2+ioff); icx++) {
-#ifdef TM_USE_OMP
-      icy = icx - ioff;
-#endif
-      ix = g_eo2lexic[icx];
-
-      rn = l + icy;
-      _vector_assign(phi1,(*rn).s0);
-      _vector_assign(phi3,(*rn).s2);
-
-      w1=&sw[ix][0][0];
-      w2=w1+2;  /* &sw_inv[ix][1][0]; */
-      w3=w1+4;  /* &sw_inv[ix][2][0]; */
-      _su3_multiply(psi,*w1,phi1); 
-      _su3_multiply(chi,*w2,(*rn).s1);
-      _vector_add((*rn).s0,psi,chi);
-      
-      _su3_inverse_multiply(psi,*w2,phi1); 
-      _su3_multiply(chi,*w3,(*rn).s1);
-      _vector_add((*rn).s1,psi,chi);
-
-      w1++; /* &sw[ix][0][1]; */
-      w2++; /* &sw[ix][1][1]; */
-      w3++; /* &sw[ix][2][1]; */
-      _su3_multiply(psi,*w1,phi3); 
-      _su3_multiply(chi,*w2,(*rn).s3);
-      _vector_add((*rn).s2,psi,chi);
-      
-      _su3_inverse_multiply(psi,*w2,phi3); 
       _su3_multiply(chi,*w3,(*rn).s3);
       _vector_add((*rn).s3,psi,chi);
 

--- a/operator/clovertm_operators.h
+++ b/operator/clovertm_operators.h
@@ -55,6 +55,7 @@ void Mee_sw_psi(spinor * const l, spinor * const k, const double mu);
 void Mee_sw_inv_psi(spinor * const k, spinor * const l, const double mu);
 void Msw_full(spinor * const Even_new, spinor * const Odd_new, 
 	      spinor * const Even, spinor * const Odd);
+void clover_mult(spinor * const l, int ieo);
 void clover_inv(spinor * const l, const int tau3sign, const double mu);
 void Qsw_psi(spinor * const l, spinor * const k);
 void Qsw_plus_psi(spinor * const l, spinor * const k);
@@ -73,6 +74,7 @@ void clover_nd(const int ieo,
 	       const spinor * const k_s, const spinor * const k_c, 
 	       const spinor * const j_s, const spinor * const j_c,
 	       const double mubar, const double epsbar);
+
 void clover_gamma5_nd(const int ieo, 
 		      spinor * const l_s, spinor * const l_c, 
 		      const spinor * const k_s, const spinor * const k_c, 

--- a/operator/clovertm_operators.h
+++ b/operator/clovertm_operators.h
@@ -55,7 +55,7 @@ void Mee_sw_psi(spinor * const l, spinor * const k, const double mu);
 void Mee_sw_inv_psi(spinor * const k, spinor * const l, const double mu);
 void Msw_full(spinor * const Even_new, spinor * const Odd_new, 
 	      spinor * const Even, spinor * const Odd);
-void clover_mult(spinor * const l, int ieo);
+
 void clover_inv(spinor * const l, const int tau3sign, const double mu);
 void Qsw_psi(spinor * const l, spinor * const k);
 void Qsw_plus_psi(spinor * const l, spinor * const k);

--- a/qphix_base_classes.hpp
+++ b/qphix_base_classes.hpp
@@ -128,7 +128,9 @@ struct InnerCloverProduct<FT, veclen, soalen, compress12,
                 auto const idx15 = sc_in * (sc_in - 1) / 2 + sc_out;
                 cplx_mul_acc(
                     spinor_out[c_out][four_s_out][re][xi], spinor_out[c_out][four_s_out][im][xi],
-                    off_diag_in[idx15][re][veclen_idx], -off_diag_in[idx15][im][veclen_idx],
+                    off_diag_in[idx15][re][veclen_idx],
+                    // aww hell, maybe one should just add negation to QPhiX::half ?
+                    QPhiX::rep<FT,double>(-QPhiX::rep<double,FT>(off_diag_in[idx15][im][veclen_idx])),
                     spinor_in[c_in][four_s_in][re][xi], spinor_in[c_in][four_s_in][im][xi]);
               } else {
                 auto const idx15 = sc_out * (sc_out - 1) / 2 + sc_in;

--- a/qphix_base_classes.hpp
+++ b/qphix_base_classes.hpp
@@ -624,11 +624,13 @@ class WilsonClovTMDslash : public Dslash<FT, veclen, soalen, compress12> {
   typedef typename ::QPhiX::Geometry<FT, veclen, soalen, compress12>::SU3MatrixBlock SU3MatrixBlock;
   typedef
       typename ::QPhiX::Geometry<FT, veclen, soalen, compress12>::FullCloverBlock FullCloverBlock;
+  typedef
+      typename ::QPhiX::Geometry<FT, veclen, soalen, compress12>::CloverBlock CloverBlock;
 
   WilsonClovTMDslash(::QPhiX::Geometry<FT, veclen, soalen, compress12> *geom_,
                      double const t_boundary_, double const aniso_coeff_S_,
                      double const aniso_coeff_T_, double const mass_, double const twisted_mass_,
-                     FullCloverBlock *const (&clover_)[2][2],
+                     CloverBlock *const (&clover_)[2],
                      FullCloverBlock *const (&inv_clover_)[2][2], bool use_tbc_[4] = nullptr,
                      double tbc_phases_[4][2] = nullptr)
       : Dslash<FT, veclen, soalen, compress12>(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_,
@@ -640,19 +642,16 @@ class WilsonClovTMDslash : public Dslash<FT, veclen, soalen, compress12> {
         derived_mu_inv(mass_factor_alpha /
                        (mass_factor_alpha * mass_factor_alpha + twisted_mass_ * twisted_mass_)) {
     for (int cb : {0, 1}) {
+      clover[cb] = clover_[cb];
       for (int fl : {0, 1}) {
-        clover[cb][fl] = clover_[cb][fl];
         inv_clover[cb][fl] = inv_clover_[cb][fl];
       }
     }
   }
 
   void A_chi(Spinor *const out, Spinor const *const in, int const isign, int const cb) override {
-    if (isign == -1) {
-      clover_product(out, in, clover[cb][1], upstream_dslash.getGeometry());
-    } else {
-      clover_product(out, in, clover[cb][0], upstream_dslash.getGeometry());
-    }
+    clover_product(out, in, clover[cb], upstream_dslash.getGeometry());
+    // TODO: add twisted mass here
   }
 
   void A_inv_chi(Spinor *const out, Spinor const *const in, int const isign,
@@ -672,7 +671,7 @@ class WilsonClovTMDslash : public Dslash<FT, veclen, soalen, compress12> {
   void achimbdpsi(Spinor *const res, const Spinor *const psi, const Spinor *const chi,
                   const SU3MatrixBlock *const u, double const alpha, double const beta,
                   int const isign, int const cb) override {
-    upstream_dslash.dslashAChiMinusBDPsi(res, psi, chi, u, (const FullCloverBlock **)clover[cb],
+    upstream_dslash.dslashAChiMinusBDPsi(res, psi, chi, u, clover[cb],
                                          mass_factor_beta, isign, cb);
   }
 
@@ -684,7 +683,7 @@ class WilsonClovTMDslash : public Dslash<FT, veclen, soalen, compress12> {
   double const derived_mu;
   double const derived_mu_inv;
 
-  FullCloverBlock *clover[2][2];
+  CloverBlock *clover[2];
   FullCloverBlock *inv_clover[2][2];
 };
 

--- a/qphix_base_classes.hpp
+++ b/qphix_base_classes.hpp
@@ -122,7 +122,7 @@ struct InnerCloverProduct<FT, veclen, soalen, compress12,
               if (sc_out == sc_in) {
                 cplx_mul_acc(spinor_out[c_out][four_s_out][re][xi],
                              spinor_out[c_out][four_s_out][im][xi], diag_in[sc_in][veclen_idx],
-                             FT{0}, spinor_in[c_in][four_s_in][re][xi],
+                             QPhiX::rep<FT,double>(0.0), spinor_in[c_in][four_s_in][re][xi],
                              spinor_in[c_in][four_s_in][im][xi]);
               } else if (sc_out < sc_in) {
                 auto const idx15 = sc_in * (sc_in - 1) / 2 + sc_out;

--- a/qphix_base_classes.hpp
+++ b/qphix_base_classes.hpp
@@ -314,7 +314,8 @@ class Dslash {
   typedef typename Geom::SU3MatrixBlock SU3MatrixBlock;
 
   explicit Dslash(Geom *geom, double const t_boundary_, double const aniso_coeff_S_,
-                  double const aniso_coeff_T_, double const mass_)
+                  double const aniso_coeff_T_, double const mass_, bool use_tbc_[4] = nullptr,
+                  double tbc_phases_[4][2] = nullptr)
       : geom(geom),
         t_boundary(t_boundary_),
         aniso_coeff_S(aniso_coeff_S_),
@@ -446,10 +447,11 @@ class WilsonDslash : public Dslash<FT, veclen, soalen, compress12> {
   typedef typename ::QPhiX::Geometry<FT, veclen, soalen, compress12>::SU3MatrixBlock SU3MatrixBlock;
 
   WilsonDslash(::QPhiX::Geometry<FT, veclen, soalen, compress12> *geom_, double const t_boundary_,
-               double const aniso_coeff_S_, double const aniso_coeff_T_, double const mass_)
+               double const aniso_coeff_S_, double const aniso_coeff_T_, double const mass_,
+               bool use_tbc_[4] = nullptr, double tbc_phases_[4][2] = nullptr)
       : Dslash<FT, veclen, soalen, compress12>(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_,
-                                               mass_),
-        upstream_dslash(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_),
+                                               mass_, use_tbc_, tbc_phases_),
+        upstream_dslash(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_, use_tbc_, tbc_phases_),
         mass_factor_alpha(4.0 + mass_),
         mass_factor_beta(1.0 / (4.0 * mass_factor_alpha)) {}
 
@@ -503,10 +505,12 @@ class WilsonTMDslash : public Dslash<FT, veclen, soalen, compress12> {
 
   WilsonTMDslash(::QPhiX::Geometry<FT, veclen, soalen, compress12> *geom_, double const t_boundary_,
                  double const aniso_coeff_S_, double const aniso_coeff_T_, double const mass_,
-                 double const twisted_mass_)
+                 double const twisted_mass_, bool use_tbc_[4] = nullptr,
+                 double tbc_phases_[4][2] = nullptr)
       : Dslash<FT, veclen, soalen, compress12>(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_,
-                                               mass_),
-        upstream_dslash(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_, mass_, twisted_mass_),
+                                               mass_, use_tbc_, tbc_phases_),
+        upstream_dslash(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_, mass_, twisted_mass_,
+                        use_tbc_, tbc_phases_),
         mass_factor_alpha(4.0 + mass_),
         mass_factor_beta(0.25),
         derived_mu(twisted_mass_ / mass_factor_alpha),
@@ -556,10 +560,11 @@ class WilsonClovDslash : public Dslash<FT, veclen, soalen, compress12> {
   WilsonClovDslash(::QPhiX::Geometry<FT, veclen, soalen, compress12> *geom_,
                    double const t_boundary_, double const aniso_coeff_S_,
                    double const aniso_coeff_T_, double const mass_,
-                   CloverBlock *const (&clover_)[2], CloverBlock *const (&inv_clover_)[2])
+                   CloverBlock *const (&clover_)[2], CloverBlock *const (&inv_clover_)[2],
+                   bool use_tbc_[4] = nullptr, double tbc_phases_[4][2] = nullptr)
       : Dslash<FT, veclen, soalen, compress12>(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_,
-                                               mass_),
-        upstream_dslash(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_),
+                                               mass_, use_tbc_, tbc_phases_),
+        upstream_dslash(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_, use_tbc_, tbc_phases_),
         mass_factor_alpha(4.0 + mass_),
         mass_factor_beta(1.0 / (4.0 * mass_factor_alpha)) {
     for (int cb : {0, 1}) {
@@ -622,10 +627,11 @@ class WilsonClovTMDslash : public Dslash<FT, veclen, soalen, compress12> {
                      double const t_boundary_, double const aniso_coeff_S_,
                      double const aniso_coeff_T_, double const mass_, double const twisted_mass_,
                      FullCloverBlock *const (&clover_)[2][2],
-                     FullCloverBlock *const (&inv_clover_)[2][2])
+                     FullCloverBlock *const (&inv_clover_)[2][2], bool use_tbc_[4] = nullptr,
+                     double tbc_phases_[4][2] = nullptr)
       : Dslash<FT, veclen, soalen, compress12>(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_,
-                                               mass_),
-        upstream_dslash(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_),
+                                               mass_, use_tbc_, tbc_phases_),
+        upstream_dslash(geom_, t_boundary_, aniso_coeff_S_, aniso_coeff_T_, use_tbc_, tbc_phases_),
         mass_factor_alpha(4.0 + mass_),
         mass_factor_beta(0.25),
         derived_mu(twisted_mass_ / mass_factor_alpha),

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -1461,15 +1461,16 @@ int invert_eo_qphix_helper(std::vector< std::vector < spinor* > > &tmlqcd_odd_ou
     delete (SolverQPhiX);
     delete (InnerSolverQPhiX);
     delete (MultiSolverQPhiX);
-    geom.free(qphix_clover);
-    geom.free(qphix_inv_clover);
-    geom_inner.free(qphix_clover_inner);
-    geom_inner.free(qphix_inv_clover_inner);
+    // on KNL, it seems that munmap is problematic, so we check for nullptr
+    if(qphix_clover) geom.free(qphix_clover);
+    if(qphix_inv_clover) geom.free(qphix_inv_clover);
+    if(qphix_clover_inner) geom_inner.free(qphix_clover_inner);
+    if(qphix_inv_clover_inner) geom_inner.free(qphix_inv_clover_inner);
     for (int fl : {0, 1}) {
-      geom.free(qphix_fullclover[fl]);
-      geom.free(qphix_inv_fullclover[fl]);
-      geom_inner.free(qphix_fullclover_inner[fl]);
-      geom_inner.free(qphix_inv_fullclover_inner[fl]);
+      if(qphix_fullclover[fl]) geom.free(qphix_fullclover[fl]);
+      if(qphix_inv_fullclover[fl]) geom.free(qphix_inv_fullclover[fl]);
+      if(qphix_fullclover_inner[fl]) geom_inner.free(qphix_fullclover_inner[fl]);
+      if(qphix_inv_fullclover_inner[fl]) geom_inner.free(qphix_inv_fullclover_inner[fl]);
     }
     QPhiX::masterPrintf("# QPHIX: ...done.\n\n");
 
@@ -1640,8 +1641,8 @@ int invert_eo_qphix_helper(std::vector< std::vector < spinor* > > &tmlqcd_odd_ou
   } // if(num_flavour)
 
   for (int cb : {0, 1}) {
-    geom.free(u_packed[cb]);
-    geom_inner.free(u_packed_inner[cb]);
+    if(u_packed[cb]) geom.free(u_packed[cb]);
+    if(u_packed_inner[cb]) geom_inner.free(u_packed_inner[cb]);
   }
 
   // FIXME: This should be called properly somewhere else

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -1222,9 +1222,9 @@ int invert_eo_qphix_helper(std::vector< std::vector < spinor* > > &tmlqcd_odd_ou
   uint64_t site_flops = -1;
   uint64_t mv_apps = -1;
   
-  // support for multi-shift solves
+  // support for multi-shift solves via the length of the output vector,
+  // which counts the shifts on the outer index and the flavour on the inner index
   const int num_shifts = tmlqcd_odd_out.size();
-  QPhiX::masterPrintf("# QPHIX: number of shifts %d\n\n", num_shifts);
   std::vector < double > shifts; shifts.resize( num_shifts );
   std::vector <double> RsdTargetArr; RsdTargetArr.resize(num_shifts);
   std::vector <double> RsdFinalArr; RsdFinalArr.resize(num_shifts);
@@ -1412,14 +1412,14 @@ int invert_eo_qphix_helper(std::vector< std::vector < spinor* > > &tmlqcd_odd_ou
       }
     } else if (solver_flag == CGMMS ){
       // TODO: handle the residuals properly
-      if(g_debug_level > 1 ) QPhiX::masterPrintf("# QPHIX CGMMS: shifts: \n");
+      if(g_debug_level > 2 ) QPhiX::masterPrintf("# QPHIX CGMMS: shifts: \n");
       for( int shift = 0; shift < num_shifts; shift++ ){
         RsdTargetArr[shift] = RsdTarget;
         RsdFinalArr[shift] = -1.0;
         shifts[shift] = solver_params.shifts[shift]*solver_params.shifts[shift]/(4*g_kappa*g_kappa);
-        if(g_debug_level > 1 ) QPhiX::masterPrintf("# [%d] = %.6e\n", shift, shifts[shift]);
+        if(g_debug_level > 2 ) QPhiX::masterPrintf("# [%d] = %.6e\n", shift, shifts[shift]);
       }
-      if(g_debug_level > 1 ) QPhiX::masterPrintf("\n");
+      if(g_debug_level > 2 ) QPhiX::masterPrintf("\n");
       (*MultiSolverQPhiX)(qphix_out.data(), qphix_in[0], num_shifts, shifts.data(), 
                           RsdTargetArr.data(), niters, RsdFinalArr.data(), site_flops, mv_apps, -1, verbose );
       rsd_final = RsdFinalArr[0];
@@ -1592,17 +1592,16 @@ int invert_eo_qphix_helper(std::vector< std::vector < spinor* > > &tmlqcd_odd_ou
       }
     } else if (solver_flag == CGMMSND ){
       // TODO: handle the residuals properly
-      if(g_debug_level > 2 ) QPhiX::masterPrintf("# QPHIX CGMMSND: shifts: \n");
+      if(g_debug_level > 1 ) QPhiX::masterPrintf("# QPHIX CGMMSND: shifts: \n");
       for( int shift = 0; shift < num_shifts; shift++ ){
         RsdTargetArr[shift] = RsdTarget;
         RsdFinalArr[shift] = -1.0;
-        shifts[shift] = solver_params.shifts[shift]*solver_params.shifts[shift]/(4*g_kappa*g_kappa)/*  - 
-                        shift > 0 ? shifts[0] : 0*/;
-        if(g_debug_level > 2 ) QPhiX::masterPrintf("# [%d] = %lf\n", shift, shifts[shift]);
+        shifts[shift] = solver_params.shifts[shift]*solver_params.shifts[shift]/(4*g_kappa*g_kappa); 
+        if(g_debug_level > 1 ) QPhiX::masterPrintf("# [%d] = %lf\n", shift, shifts[shift]);
       }
-      if(g_debug_level > 2 ) QPhiX::masterPrintf("\n");
+      if(g_debug_level > 1 ) QPhiX::masterPrintf("\n");
       (*TwoFlavMultiSolverQPhiX)(qphix_out.data(), qphix_in, num_shifts, shifts.data(), 
-                          RsdTargetArr.data(), niters, RsdFinalArr.data(), site_flops, mv_apps, 1, verbose );
+                          RsdTargetArr.data(), niters, RsdFinalArr.data(), site_flops, mv_apps, -1, verbose );
       rsd_final = RsdFinalArr[0];
     }
     double end = gettime();

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -46,6 +46,9 @@ extern "C" {
 #include "linalg/square_norm.h"
 #include "linalg/square_norm.h"
 #include "misc_types.h"
+// for the normalisation of the heavy doublet when running
+// RHMC
+#include "phmc.h"
 #include "operator/clover_leaf.h"
 #include "operator/clovertm_operators.h"
 #include "operator_types.h"
@@ -1607,10 +1610,16 @@ int invert_eo_qphix_helper(std::vector< std::vector < spinor* > > &tmlqcd_odd_ou
     } else if (solver_flag == CGMMSND ){
       // TODO: handle the residuals properly
       if(g_debug_level > 2 ) QPhiX::masterPrintf("# QPHIX CGMMSND: shifts: \n");
+      // tmLQCD weights the operator with 1/maxev in the RHMC relative to the shifts
+      // we will do this externally on the inverse (in monomial_solve) and thus need to weight
+      // the shifts by maxev^2
+      const double maxev_sq = (1.0/phmc_invmaxev)*(1.0/phmc_invmaxev);
       for( int shift = 0; shift < num_shifts; shift++ ){
         RsdTargetArr[shift] = RsdTarget;
         RsdFinalArr[shift] = -1.0;
-        shifts[shift] = solver_params.shifts[shift]*solver_params.shifts[shift]/(4*g_kappa*g_kappa); 
+        shifts[shift] = maxev_sq *
+                        solver_params.shifts[shift]*solver_params.shifts[shift] /
+                        (4*g_kappa*g_kappa); 
         if(g_debug_level > 2 ) QPhiX::masterPrintf("# [%d] = %lf\n", shift, shifts[shift]);
       }
       if(g_debug_level > 2 ) QPhiX::masterPrintf("\n");

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -1055,7 +1055,7 @@ void Mfull_helper(spinor *Even_out, spinor *Odd_out, const spinor *Even_in, cons
   typedef typename QPhiX::Geometry<FT, V, S, compress>::CloverBlock QClover;
   typedef typename QPhiX::Geometry<FT, V, S, compress>::FullCloverBlock QFullClover;
 
-  if (g_debug_level > 1) tmlqcd::printQphixDiagnostics(V, S, compress);
+  if (g_debug_level > 1) tmlqcd::printQphixDiagnostics(V, S, compress, V, S, compress);
 
   double coeff_s = (FT)(1);
   double coeff_t = (FT)(1);
@@ -1196,7 +1196,7 @@ int invert_eo_qphix_helper(std::vector< std::vector < spinor* > > &tmlqcd_odd_ou
   ************************/
 
   if (g_debug_level > 1) {
-    tmlqcd::printQphixDiagnostics(V, S, compress);
+    tmlqcd::printQphixDiagnostics(V, S, compress, V_inner, S_inner, compress_inner);
   }
 
   QPhiX::Geometry<FT, V, S, compress> geom(subLattSize, By, Bz, NCores, Sy, Sz, PadXY, PadXYZ,
@@ -1997,8 +1997,8 @@ void tmlqcd::checkQphixInputParameters(const tm_QPhiXParams_t &params) {
   }
 }
 
-void tmlqcd::printQphixDiagnostics(int VECLEN, int SOALEN, bool compress) {
-  QPhiX::masterPrintf("# QphiX: VECLEN=%d SOALEN=%d\n", VECLEN, SOALEN);
+void tmlqcd::printQphixDiagnostics(int VECLEN, int SOALEN, bool compress, int VECLEN_inner, int SOALEN_inner, bool compress_inner) {
+  QPhiX::masterPrintf("# QphiX: VECLEN=%d SOALEN=%d VECLEN_inner=%d, SOALEN_inner=%d\n", VECLEN, SOALEN, VECLEN_inner, SOALEN_inner);
 
   QPhiX::masterPrintf("# QphiX: Declared QMP Topology (xyzt):");
   for (int mu = 0; mu < 4; mu++) QPhiX::masterPrintf(" %d", qmp_geom[mu]);
@@ -2026,6 +2026,9 @@ void tmlqcd::printQphixDiagnostics(int VECLEN, int SOALEN, bool compress) {
   QPhiX::masterPrintf("# QphiX: MinCt = %d\n", MinCt);
   if (compress) {
     QPhiX::masterPrintf("# QphiX: Using two-row gauge compression (compress12)\n");
+  }
+  if (compress_inner) {
+    QPhiX::masterPrintf("# QphiX: Inner solver using two-row gauge compression (compress12)\n");
   }
 }
 

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -39,6 +39,7 @@ extern "C" {
 #include "geometry_eo.h"
 #include "gettime.h"
 #include "global.h"
+#include "misc_types.h"
 #include "linalg/convert_eo_to_lexic.h"
 #include "linalg/diff.h"
 #include "linalg/square_norm.h"

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -1944,8 +1944,7 @@ int invert_eo_qphix_nflavour_mshift(std::vector< std::vector< spinor* > > &Odd_o
             Odd_out, Odd_in, target_precision, max_iter, solver_flag, solver_params, num_flavour);
       } else {
         return invert_eo_qphix_helper<QPhiX::half, VECLEN_HP, QPHIX_SOALEN, false>(
-            Odd_out, Odd_in, target_precision, max_iter, solver_flag, rel_prec, solver_params,
-            num_flavour);
+            Odd_out, Odd_in, target_precision, max_iter, solver_flag, solver_params, num_flavour);
       }
     } else
  #else

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -1463,9 +1463,13 @@ int invert_eo_qphix_helper(std::vector< std::vector < spinor* > > &tmlqcd_odd_ou
     delete (MultiSolverQPhiX);
     geom.free(qphix_clover);
     geom.free(qphix_inv_clover);
+    geom_inner.free(qphix_clover_inner);
+    geom_inner.free(qphix_inv_clover_inner);
     for (int fl : {0, 1}) {
       geom.free(qphix_fullclover[fl]);
       geom.free(qphix_inv_fullclover[fl]);
+      geom_inner.free(qphix_fullclover_inner[fl]);
+      geom_inner.free(qphix_inv_fullclover_inner[fl]);
     }
     QPhiX::masterPrintf("# QPHIX: ...done.\n\n");
 

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -716,16 +716,6 @@ void reorder_gauge_to_QPhiX(
                       //    ordering of the dimensions.
                       int q_mu = 2 * dim + dir;
 
-                      // 2. QPhiX gauge field matrices are transposed w.r.t.
-                      // tmLQCD.
-                      // 3. tmlQCD always uses 3x3 color matrices (Nc2*Nc2).
-                      int64_t t_inner_idx_cb0 = reim + c1 * Nz + c2 * Nz * Nc2 +
-                                                change_dim[dim] * Nz * Nc2 * Nc2 +
-                                                tm_idx_cb0 * Nz * Nc2 * Nc2 * 4;
-                      int64_t t_inner_idx_cb1 = reim + c1 * Nz + c2 * Nz * Nc2 +
-                                                change_dim[dim] * Nz * Nc2 * Nc2 +
-                                                tm_idx_cb1 * Nz * Nc2 * Nc2 * 4;
-                                                
                       qphix_gauge_cb0[block][q_mu][c1][c2][reim][xx] = QPhiX::rep<FT, double>(
                         su3_get_elem(&(g_gauge_field[tm_idx_cb0][change_dim[dim]]), c2, c1, reim ) );
                       qphix_gauge_cb1[block][q_mu][c1][c2][reim][xx] = QPhiX::rep<FT, double>(
@@ -850,11 +840,11 @@ void reorder_eo_spinor_from_QPhiX(
                 spinor_set_elem( &(tm_eo_spinor[tm_eo_ind]),
                                  change_spin[q_spin],
                                  col,
-                                 QPhiX::rep<double, FT>(
-                                  change_sign[q_spin] * normFac * qphix_spinor[q_ind][col][q_spin][0][x_soa]
+                                 change_sign[q_spin] * normFac * QPhiX::rep<double, FT>(
+                                  qphix_spinor[q_ind][col][q_spin][0][x_soa]
                                  ),
-                                 QPhiX::rep<double, FT>(
-                                  change_sign[q_spin] * normFac * qphix_spinor[q_ind][col][q_spin][1][x_soa]
+                                 change_sign[q_spin] * normFac * QPhiX::rep<double, FT>(
+                                  qphix_spinor[q_ind][col][q_spin][1][x_soa]
                                  )
                                );
               }

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -1128,15 +1128,12 @@ int invert_eo_qphix_helper(spinor *const tmlqcd_even_out, spinor *const tmlqcd_o
   tmlqcd::Dslash<FT, V, S, compress> *DslashQPhiX;
   QPhiX::EvenOddLinearOperator<FT, V, S, compress> *FermionMatrixQPhiX;
   if (g_mu > DBL_EPSILON && g_c_sw > DBL_EPSILON) {  // TWISTED-MASS-CLOVER
-    for (int cb : {0, 1}) {
-      for (int fl : {0, 1}) {
-        qphix_fullclover[cb][fl] = (QFullClover *)geom.allocCBFullClov();
-        qphix_inv_fullclover[cb][fl] = (QFullClover *)geom.allocCBFullClov();
-      }
-      reorder_clover_to_QPhiX(geom, qphix_fullclover[cb], cb, false);
-      sw_invert(cb, g_mu);
-      reorder_clover_to_QPhiX(geom, qphix_inv_fullclover[cb], cb, true);
+    for (int fl : {0, 1}) {
+      qphix_fullclover[cb_odd][fl] = (QFullClover *)geom.allocCBFullClov();
+      qphix_inv_fullclover[cb_even][fl] = (QFullClover *)geom.allocCBFullClov();
     }
+    reorder_clover_to_QPhiX(geom, qphix_fullclover[cb_odd], cb_odd, false);
+    reorder_clover_to_QPhiX(geom, qphix_inv_fullclover[cb_even], cb_even, true);
 
     DslashQPhiX = new tmlqcd::WilsonClovTMDslash<FT, V, S, compress>(
         &geom, t_boundary, coeff_s, coeff_t, mass, -g_mu / (2.0 * g_kappa), qphix_fullclover,
@@ -1159,14 +1156,11 @@ int invert_eo_qphix_helper(spinor *const tmlqcd_even_out, spinor *const tmlqcd_o
         mass, TwistedMass, u_packed, &geom, t_boundary, coeff_s, coeff_t);
     QPhiX::masterPrintf("# ...done.\n");
   } else if (g_c_sw > DBL_EPSILON) {  // WILSON CLOVER
-    for (int cb : {0, 1}) {
-      qphix_clover[cb] = (QClover *)geom.allocCBClov();
-      qphix_inv_clover[cb] = (QClover *)geom.allocCBClov();
+    qphix_clover[cb_odd] = (QClover *)geom.allocCBClov();
+    qphix_inv_clover[cb_even] = (QClover *)geom.allocCBClov();
 
-      reorder_clover_to_QPhiX(geom, qphix_clover[cb], cb, false);
-      sw_invert(cb, 0);
-      reorder_clover_to_QPhiX(geom, qphix_inv_clover[cb], cb, true);
-    }
+    reorder_clover_to_QPhiX(geom, qphix_clover[cb_odd], cb_odd, false);
+    reorder_clover_to_QPhiX(geom, qphix_inv_clover[cb_even], cb_even, true);
 
     QPhiX::masterPrintf("# Creating QPhiX Wilson Clover Dslash...\n");
     DslashQPhiX = new tmlqcd::WilsonClovDslash<FT, V, S, compress>(

--- a/qphix_interface.h
+++ b/qphix_interface.h
@@ -61,6 +61,7 @@
 #define QPHIX_INTERFACE_H_
 
 #include "global.h"
+#include "misc_types.h"
 #include "operator_types.h"
 #include "qphix_types.h"
 #include "solver/matrix_mult_typedef.h"

--- a/qphix_interface.h
+++ b/qphix_interface.h
@@ -76,23 +76,22 @@ extern "C" {
 void initQPhiX(int argc, char** argv, QphixParams_t params, int c12, QphixPrec_t precision);
 void _endQphix();
 
-int invert_eo_qphix_oneflavour(spinor * const Odd_out, spinor* const Odd_in, 
-                               const double precision, const int max_iter,
-                               const int solver_flag, const int rel_prec, solver_params_t solver_params,
-                               const SloppyPrecision sloppy, const CompressionType compression);
+int invert_eo_qphix_oneflavour(spinor* const Odd_out, spinor* const Odd_in, const int max_iter,
+                               const double precision, const int solver_flag, const int rel_prec,
+                               solver_params_t solver_params, const SloppyPrecision sloppy,
+                               const CompressionType compression);
 
-int invert_eo_qphix_twoflavour(spinor * Odd_out_s, spinor * Odd_out_c,
-                               spinor * Odd_in_s, spinor * Odd_in_c, 
-                               const double precision, const int max_iter,
-                               const int solver_flag, const int rel_prec, solver_params_t solver_params,
-                               const SloppyPrecision sloppy, const CompressionType compression);
+int invert_eo_qphix_twoflavour(spinor* Odd_out_s, spinor* Odd_out_c, spinor* Odd_in_s,
+                               spinor* Odd_in_c, const int max_iter, const double precision,
+                               const int solver_flag, const int rel_prec,
+                               solver_params_t solver_params, const SloppyPrecision sloppy,
+                               const CompressionType compression);
 
-int invert_eo_qphix_nflavour(spinor ** Odd_out, spinor ** Odd_in,
-                            const double target_precision, const double precision_lambda,
-                            const int max_iter,
-                            const int solver_flag, solver_params_t solver_params,
-                            const SloppyPrecision sloppy, const CompressionType compression,
-                            const int num_flavour);
+int invert_eo_qphix_nflavour(spinor** Odd_out, spinor** Odd_in, const double target_precision,
+                             const double precision_lambda, const int max_iter,
+                             const int solver_flag, solver_params_t solver_params,
+                             const SloppyPrecision sloppy, const CompressionType compression,
+                             const int num_flavour);
 
 void Mfull_qphix(spinor* Even_out, spinor* Odd_out, const spinor* Even_in, const spinor* Odd_in,
                  const op_type_t op_type);

--- a/qphix_interface.h
+++ b/qphix_interface.h
@@ -1,6 +1,7 @@
 /***********************************************************************
  *
  * Copyright (C) 2015 Mario Schroeck
+ *               2017 Peter Labus, Martin Ueding, Bartosz Kostrzewa
  *
  * This file is part of tmLQCD.
  *
@@ -18,44 +19,6 @@
  * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
  *
  ***********************************************************************/
-/***********************************************************************
-*
-* File qphix_interface.h
-*
-* Author: Mario Schroeck <mario.schroeck@roma3.infn.it>,
-*         Peter Labus <Peter.Labus@sissa.it>
-*
-* Last changes: 03/2017
-*
-*
-* Integration of the QPhiX library for Intel Xeon Phi usage
-*
-* The externally accessible functions are
-*
-*   void _initQphix(int argc, char **argv,
-*                   int By_, int Bz_, int NCores_,
-*                   int Sy_, int Sz_, int PadXY_,
-*                   int PadXYZ_, int MinCt_, int c12, QphixPrec precision_)
-*     Initializes the QPhiX library. Carries over the lattice size and the
-*     MPI process grid and thus must be called after initializing MPI (and
-*     after 'read_infile(argc,argv)').
-*
-*   void _endQphix()
-*     Finalizes the QPhiX library. Call before MPI_Finalize().
-* Integration of the QUDA inverter for multi-GPU usage
-*
-*
-* Notes:
-*
-* To enable compilation of the same code for QPhiX usage and standard non-QPhiX
-* usage, all calls of these functions should be wrapped in precompiler switches
-* of the form
-*
-*   #ifdef TM_USE_QPHIX
-*     ...
-*   #endif
-*
-**************************************************************************/
 
 #ifndef QPHIX_INTERFACE_H_
 #define QPHIX_INTERFACE_H_
@@ -78,18 +41,22 @@ int invert_eo_qphix_oneflavour(spinor* const Odd_out, spinor* const Odd_in, cons
                                solver_params_t solver_params, const SloppyPrecision sloppy,
                                const CompressionType compression);
 
+int invert_eo_qphix_oneflavour_mshift(spinor** Odd_out, spinor* const Odd_in, const int max_iter,
+                                      const double precision, const int solver_flag, const int rel_prec,
+                                      solver_params_t solver_params, const SloppyPrecision sloppy,
+                                      const CompressionType compression);
+
 int invert_eo_qphix_twoflavour(spinor* Odd_out_s, spinor* Odd_out_c, spinor* Odd_in_s,
                                spinor* Odd_in_c, const int max_iter, const double precision,
                                const int solver_flag, const int rel_prec,
                                solver_params_t solver_params, const SloppyPrecision sloppy,
                                const CompressionType compression);
 
-int invert_eo_qphix_nflavour(spinor** Odd_out, spinor** Odd_in, const double target_precision,
-                             const int max_iter,
-                             const int solver_flag, const int rel_prec,
-                             solver_params_t solver_params,
-                             const SloppyPrecision sloppy, const CompressionType compression,
-                             const int num_flavour);
+int invert_eo_qphix_twoflavour_mshift(spinor** Odd_out_s, spinor** Odd_out_c, spinor* Odd_in_s,
+                                      spinor* Odd_in_c, const int max_iter, const double precision,
+                                      const int solver_flag, const int rel_prec,
+                                      solver_params_t solver_params, const SloppyPrecision sloppy,
+                                      const CompressionType compression);
 
 void Mfull_qphix(spinor* Even_out, spinor* Odd_out, const spinor* Even_in, const spinor* Odd_in,
                  const op_type_t op_type);

--- a/qphix_interface.h
+++ b/qphix_interface.h
@@ -76,12 +76,23 @@ extern "C" {
 void initQPhiX(int argc, char** argv, QphixParams_t params, int c12, QphixPrec_t precision);
 void _endQphix();
 
-// Wrapper functions for Full Solver and Dslash
-int invert_eo_qphix(spinor* const Even_new, spinor* const Odd_new, spinor* const Even,
-                    spinor* const Odd, const double precision, const int max_iter,
-                    const int solver_flag, const int rel_prec, solver_params_t solver_params,
-                    const SloppyPrecision sloppy, const CompressionType compression,
-                    matrix_mult mat_op);
+int invert_eo_qphix_oneflavour(spinor * const Odd_out, spinor* const Odd_in, 
+                               const double precision, const int max_iter,
+                               const int solver_flag, const int rel_prec, solver_params_t solver_params,
+                               const SloppyPrecision sloppy, const CompressionType compression);
+
+int invert_eo_qphix_twoflavour(spinor * Odd_out_s, spinor * Odd_out_c,
+                               spinor * Odd_in_s, spinor * Odd_in_c, 
+                               const double precision, const int max_iter,
+                               const int solver_flag, const int rel_prec, solver_params_t solver_params,
+                               const SloppyPrecision sloppy, const CompressionType compression);
+
+int invert_eo_qphix_nflavour(spinor ** Odd_out, spinor ** Odd_in,
+                            const double target_precision, const double precision_lambda,
+                            const int max_iter,
+                            const int solver_flag, solver_params_t solver_params,
+                            const SloppyPrecision sloppy, const CompressionType compression,
+                            const int num_flavour);
 
 void Mfull_qphix(spinor* Even_out, spinor* Odd_out, const spinor* Even_in, const spinor* Odd_in,
                  const op_type_t op_type);

--- a/qphix_interface.h
+++ b/qphix_interface.h
@@ -61,20 +61,17 @@
 #define QPHIX_INTERFACE_H_
 
 #include "global.h"
-#include "misc_types.h"
-#include "operator_types.h"
 #include "qphix_types.h"
-#include "solver/matrix_mult_typedef.h"
-#include "solver/solver_params.h"
-#include "su3.h"
 
 #ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
 extern "C" {
 #endif
 
-// Initialize and Finalize QPhiX
-void initQPhiX(int argc, char** argv, QphixParams_t params, int c12, QphixPrec_t precision);
-void _endQphix();
+#include "misc_types.h"
+#include "operator_types.h"
+#include "solver/matrix_mult_typedef.h"
+#include "solver/solver_params.h"
+#include "su3.h"
 
 int invert_eo_qphix_oneflavour(spinor* const Odd_out, spinor* const Odd_in, const int max_iter,
                                const double precision, const int solver_flag, const int rel_prec,
@@ -88,8 +85,9 @@ int invert_eo_qphix_twoflavour(spinor* Odd_out_s, spinor* Odd_out_c, spinor* Odd
                                const CompressionType compression);
 
 int invert_eo_qphix_nflavour(spinor** Odd_out, spinor** Odd_in, const double target_precision,
-                             const double precision_lambda, const int max_iter,
-                             const int solver_flag, solver_params_t solver_params,
+                             const int max_iter,
+                             const int solver_flag, const int rel_prec,
+                             solver_params_t solver_params,
                              const SloppyPrecision sloppy, const CompressionType compression,
                              const int num_flavour);
 

--- a/qphix_interface.h
+++ b/qphix_interface.h
@@ -64,6 +64,7 @@
 #include "operator_types.h"
 #include "qphix_types.h"
 #include "solver/solver_params.h"
+#include "solver/matrix_mult_typedef.h"
 #include "su3.h"
 
 #ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
@@ -71,14 +72,16 @@ extern "C" {
 #endif
 
 // Initialize and Finalize QPhiX
-void _initQphix(int argc, char** argv, QphixParams_t params, int c12, QphixPrec_t precision);
+void initQPhiX(int argc, char** argv, QphixParams_t params, int c12, QphixPrec_t precision);
 void _endQphix();
 
 // Wrapper functions for Full Solver and Dslash
 int invert_eo_qphix(spinor* const Even_new, spinor* const Odd_new, spinor* const Even,
                     spinor* const Odd, const double precision, const int max_iter,
                     const int solver_flag, const int rel_prec, solver_params_t solver_params,
-                    const SloppyPrecision sloppy, const CompressionType compression);
+                    const SloppyPrecision sloppy, const CompressionType compression,
+                    matrix_mult mat_op
+                   );
 
 void Mfull_qphix(spinor* Even_out, spinor* Odd_out, const spinor* Even_in, const spinor* Odd_in,
                  const op_type_t op_type);

--- a/qphix_interface.h
+++ b/qphix_interface.h
@@ -63,8 +63,8 @@
 #include "global.h"
 #include "operator_types.h"
 #include "qphix_types.h"
-#include "solver/solver_params.h"
 #include "solver/matrix_mult_typedef.h"
+#include "solver/solver_params.h"
 #include "su3.h"
 
 #ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
@@ -80,8 +80,7 @@ int invert_eo_qphix(spinor* const Even_new, spinor* const Odd_new, spinor* const
                     spinor* const Odd, const double precision, const int max_iter,
                     const int solver_flag, const int rel_prec, solver_params_t solver_params,
                     const SloppyPrecision sloppy, const CompressionType compression,
-                    matrix_mult mat_op
-                   );
+                    matrix_mult mat_op);
 
 void Mfull_qphix(spinor* Even_out, spinor* Odd_out, const spinor* Even_in, const spinor* Odd_in,
                  const op_type_t op_type);

--- a/qphix_interface.hpp
+++ b/qphix_interface.hpp
@@ -1,0 +1,51 @@
+/***********************************************************************
+ *
+ * Copyright (C) 2017 Bartosz Kostrzewa
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ***********************************************************************/
+
+#pragma once
+
+#include "global.h"
+#include "qphix_types.h"
+
+#ifdef __cplusplus /* If this is a C++ compiler, use C linkage */
+extern "C" {
+#endif
+
+#include "misc_types.h"
+#include "operator_types.h"
+#include "solver/matrix_mult_typedef.h"
+#include "solver/solver_params.h"
+#include "su3.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <vector>
+
+int invert_eo_qphix_nflavour_mshift(std::vector< std::vector< spinor* > > &Odd_out, 
+                                    std::vector< std::vector< spinor* > > &Odd_in, 
+                                    const double precision,
+                                    const int max_iter,
+                                    const int solver_flag, 
+                                    const int rel_prec,
+                                    solver_params_t solver_params,
+                                    const SloppyPrecision sloppy, const CompressionType compression,
+                                    const int num_flavour);

--- a/qphix_interface_utils.hpp
+++ b/qphix_interface_utils.hpp
@@ -28,6 +28,6 @@
 namespace tmlqcd {
 
 void checkQphixInputParameters(const tm_QPhiXParams_t &params);
-void printQphixDiagnostics(int VECLEN, int SOALEN, bool compress);
+void printQphixDiagnostics(int VECLEN, int SOALEN, bool compress, int VECLEN_inner, int SOALEN_inner, bool compress_inner);
 
 }  // namespace tmlqcd

--- a/qphix_interface_utils.hpp
+++ b/qphix_interface_utils.hpp
@@ -27,7 +27,7 @@
 
 namespace tmlqcd {
 
-void checkQphixInputParameters(const QphixParams_t &params);
+void checkQphixInputParameters(const tm_QPhiXParams_t &params);
 void printQphixDiagnostics(int VECLEN, int SOALEN, bool compress);
 
 }  // namespace tmlqcd

--- a/qphix_test_Dslash.c
+++ b/qphix_test_Dslash.c
@@ -342,8 +342,8 @@ double compare_spinors(spinor* s1, spinor* s2) {
               z = z_global - g_proc_coords[3] * LZ;
               int idx = g_ipt[t][x][y][z];
               for (int sc = 0; sc < 24; sc++) {
-                double e_tmlqcd = spinor_get_elem_linear(s2,sc/2,sc%2);
-                double e_qphix = spinor_get_elem_linear(s1,sc/2,sc%2);
+                double e_tmlqcd = spinor_get_elem_linear(&s2[idx],sc/2,sc%2);
+                double e_qphix = spinor_get_elem_linear(&s1[idx],sc/2,sc%2);
                 
                 if (fabs(e_tmlqcd) > 2 * DBL_EPSILON ||
                     fabs(e_qphix) > 2 * DBL_EPSILON) {
@@ -404,7 +404,7 @@ double compare_spinors(spinor* s1, spinor* s2) {
             z = z_global - g_proc_coords[3] * LZ;
             int idx = g_ipt[t][x][y][z];
             for (int sc = 0; sc < 24; sc++) {
-              double e_diff = spinor_get_elem_linear(s1,sc/2,sc%2);
+              double e_diff = spinor_get_elem_linear(&s1[idx],sc/2,sc%2);
               // when a volume source is used, these will be zero up to significant rounding
               // we account for that by the scaling of DBL_EPSILON
               if (fabs(e_diff) > 8 * 24 * DBL_EPSILON) {

--- a/qphix_types.h
+++ b/qphix_types.h
@@ -24,7 +24,7 @@
 #ifndef QPHIX_TYPES_H
 #define QPHIX_TYPES_H
 
-typedef struct QphixParams_t {
+typedef struct tm_QPhiXParams_t {
   int By;
   int Bz;
   int NCores;
@@ -34,7 +34,7 @@ typedef struct QphixParams_t {
   int PadXYZ;
   int MinCt;
   int soalen;
-} QphixParams_t;
+} tm_QPhiXParams_t;
 
 typedef enum QphixPrec_t { QPHIX_FLOAT_PREC = 0, QPHIX_HALF_PREC, QPHIX_DOUBLE_PREC } QphixPrec_t;
 

--- a/qphix_types.h
+++ b/qphix_types.h
@@ -33,6 +33,7 @@ typedef struct QphixParams_t {
   int PadXY;
   int PadXYZ;
   int MinCt;
+  int soalen;
 } QphixParams_t;
 
 typedef enum QphixPrec_t { QPHIX_FLOAT_PREC = 0, QPHIX_HALF_PREC, QPHIX_DOUBLE_PREC } QphixPrec_t;

--- a/qphix_veclen.h
+++ b/qphix_veclen.h
@@ -26,10 +26,6 @@
 
 #include <qphix/qphix_config.h>
 
-#ifndef QPHIX_SOALEN
-#error QPHIX_SOALEN must be defined. Check your qphix/qphix_config.h and qphix/qphix_config_internal.h !
-#endif
-
 #if (defined(QPHIX_MIC_SOURCE) || defined(QPHIX_AVX512_SOURCE))
 #define VECLEN_SP 16
 #define VECLEN_HP 16

--- a/read_input.l
+++ b/read_input.l
@@ -1110,6 +1110,11 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  Solver set to MixedBiCGstab line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
+  mixedcg {
+    optr->solver=MIXEDCG;
+    if(myverbose) printf("  Solver set to MixedCG line %d operator %d\n", line_of_file, current_operator);
+    BEGIN(name_caller);
+  }
   rgmixedcg {
     optr->solver=RGMIXEDCG;
     if(myverbose) printf("  Solver set to RGMixedCG line %d operator %d\n", line_of_file, current_operator);

--- a/read_input.l
+++ b/read_input.l
@@ -204,9 +204,9 @@ static inline void rmQuotes(char *str){
 #endif
 
 #ifdef TM_USE_QPHIX
-  extern QphixParams_t qphix_input;
+  extern tm_QPhiXParams_t qphix_input;
 #else
-  QphixParams_t qphix_input;
+  tm_QPhiXParams_t qphix_input;
 #endif
   
 %}
@@ -335,6 +335,7 @@ static inline void rmQuotes(char *str){
 %x MCSTR
 %x MSOLVER
 %x NDMSOLVER
+%x RATMSOLVER
 %x GTYPE
 
 %x COMMENT
@@ -1285,7 +1286,7 @@ static inline void rmQuotes(char *str){
   }
 }
 
-<INITEXTERNALINVERTER>{TYPE} {                                                                                                                    
+<INITEXTERNALINVERTER>{TYPE} {
   if(strcmp(yytext, "QPHIX")==0) {
 #ifdef TM_USE_QPHIX
     if(myverbose) printf("Setting QPHIX external inverter parameters line %d\n", line_of_file);
@@ -1594,51 +1595,51 @@ static inline void rmQuotes(char *str){
 <DETMONOMIAL,CLDETMONOMIAL,CLDETRATMONOMIAL,CLDETRATRWMONOMIAL,NDRATMONOMIAL,NDRATCORMONOMIAL,NDCLRATMONOMIAL,NDCLRATCORMONOMIAL,RATMONOMIAL,RATCORMONOMIAL,CLRATMONOMIAL,CLRATCORMONOMIAL>{
   {SPC}*UseExternalInverter{EQL}quda {
     if(myverbose) printf("  Use Quda inverter line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->external_inverter = QUDA_INVERTER;
+    mnl->solver_params.external_inverter = QUDA_INVERTER;
   }
   {SPC}*UseExternalInverter{EQL}qphix {
     if(myverbose) printf("  Use QPhiX inverter line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->external_inverter = QPHIX_INVERTER;
+    mnl->solver_params.external_inverter = QPHIX_INVERTER;
   }
   {SPC}*UseExternalInverter{EQL}no {
     if(myverbose) printf("  Use QPhiX inverter line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->external_inverter = NO_EXT_INV;
+    mnl->solver_params.external_inverter = NO_EXT_INV;
   }
   {SPC}*UseSloppyPrecision{EQL}yes {
     if(myverbose) printf("  Use use sloppy precision (single) in the inverter (if supported by the inverter) line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->sloppy_precision = SLOPPY_SINGLE;
+    mnl->solver_params.sloppy_precision = SLOPPY_SINGLE;
   }
   {SPC}*UseSloppyPrecision{EQL}float {
     if(myverbose) printf("  Use use sloppy precision (single) in the inverter (if supported by the inverter) line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->sloppy_precision = SLOPPY_SINGLE;
+    mnl->solver_params.sloppy_precision = SLOPPY_SINGLE;
   }
   {SPC}*UseSloppyPrecision{EQL}single {
     if(myverbose) printf("  Use use sloppy precision (single) in the inverter (if supported by the inverter) line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->sloppy_precision = SLOPPY_SINGLE;
+    mnl->solver_params.sloppy_precision = SLOPPY_SINGLE;
   }
   {SPC}*UseSloppyPrecision{EQL}no {
     if(myverbose) printf("  Use use sloppy precision (single) in the inverter line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->sloppy_precision = SLOPPY_DOUBLE;
+    mnl->solver_params.sloppy_precision = SLOPPY_DOUBLE;
   }
   {SPC}*UseSloppyPrecision{EQL}double {
     if(myverbose) printf("  Use use sloppy precision (single) in the inverter line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->sloppy_precision = SLOPPY_DOUBLE;
+    mnl->solver_params.sloppy_precision = SLOPPY_DOUBLE;
   }
   {SPC}*UseSloppyPrecision{EQL}half {
     if(myverbose) printf("  Use use sloppy precision (half) in the inverter (if supported by the inverter) line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->sloppy_precision = SLOPPY_HALF;
+    mnl->solver_params.sloppy_precision = SLOPPY_HALF;
   }
   {SPC}*UseCompression{EQL}12 {
     if(myverbose) printf("  Use 12 compression in the inverter (if supported) line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->compression_type = COMPRESSION_12;
+    mnl->solver_params.compression_type = COMPRESSION_12;
   }
   {SPC}*UseCompression{EQL}8 {
     if(myverbose) printf("  Use 8 compression in the inverter (if supported) line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->compression_type = COMPRESSION_8;
+    mnl->solver_params.compression_type = COMPRESSION_8;
   }
   {SPC}*UseCompression{EQL}18 {
     if(myverbose) printf("  Not using compression in the inverter line %d monomial %d\n", line_of_file, current_monomial);
-    mnl->compression_type = NO_COMPRESSION;
+    mnl->solver_params.compression_type = NO_COMPRESSION;
   }
 }
 
@@ -1669,6 +1670,13 @@ static inline void rmQuotes(char *str){
   {SPC}*Solver{EQL} {
    solver_caller=YY_START;
    BEGIN(NDMSOLVER);
+  }
+}
+
+<RATMONOMIAL,CLRATMONOMIAL>{
+  {SPC}*Solver{EQL} {
+    solver_caller=YY_START;
+    BEGIN(RATMSOLVER);
   }
 }
 
@@ -1916,7 +1924,14 @@ static inline void rmQuotes(char *str){
     mnl->solver = 14;
     BEGIN(solver_caller);
   }
+}
 
+<RATMSOLVER>{
+  cgmms {
+    if( myverbose ) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
+    mnl->solver = CGMMS;
+    BEGIN(solver_caller);
+  }
 }
 
 <GTYPE>{

--- a/read_input.l
+++ b/read_input.l
@@ -1131,6 +1131,11 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  Solver set to RGMixedCG line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
+  dummyhermtest {
+    optr->solver=DUMMYHERMTEST;
+    if(myverbose) printf("  Solver set to DummyHermTest line %d operator %d\n", line_of_file, current_operator);
+    BEGIN(name_caller);
+  }
 }
 
 <TMSOLVER>{

--- a/read_input.l
+++ b/read_input.l
@@ -1105,6 +1105,11 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  Solver set to BiCGstab line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
+  mixedbicgstab {
+    optr->solver=MIXEDBICGSTAB;
+    if(myverbose) printf("  Solver set to MixedBiCGstab line %d operator %d\n", line_of_file, current_operator);
+    BEGIN(name_caller);
+  }
   rgmixedcg {
     optr->solver=RGMIXEDCG;
     if(myverbose) printf("  Solver set to RGMixedCG line %d operator %d\n", line_of_file, current_operator);
@@ -1121,6 +1126,11 @@ static inline void rmQuotes(char *str){
   bicgstab {
     optr->solver=BICGSTAB;
     if(myverbose) printf("  Solver set to BiCGstab line %d operator %d\n", line_of_file, current_operator);
+    BEGIN(name_caller);
+  }
+  mixedbicgstab {
+    optr->solver=MIXEDBICGSTAB;
+    if(myverbose) printf("  Solver set to MixedBiCGstab line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
   bicg {
@@ -1272,6 +1282,11 @@ static inline void rmQuotes(char *str){
   bicgstab {
     optr->solver = BICGSTAB;
     if(myverbose) printf("  Solver set to BiCGstab line %d operator %d\n", line_of_file, current_operator);
+    BEGIN(name_caller);
+  }
+  mixedbicgstab {
+    optr->solver=MIXEDBICGSTAB;
+    if(myverbose) printf("  Solver set to MixedBiCGstab line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
   increigcg {
@@ -1832,6 +1847,11 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
     mnl->solver = BICGSTAB;
     BEGIN(solver_caller);
+  }
+  mixedbicgstab {
+    if(myverbose) printf("  Solver set to \"%s\" line %d monomial %d\n", yytext, line_of_file, current_monomial);
+    mnl->solver=MIXEDBICGSTAB;
+    BEGIN(name_caller);
   }
   DDalphaAMG {
     if(myverbose) printf("  Solver set to DDalphaAMG line %d operator %d\n", line_of_file, current_operator);

--- a/read_input.l
+++ b/read_input.l
@@ -1004,16 +1004,16 @@ static inline void rmQuotes(char *str){
   }
 }
 
-<WILSONOP,TMOP,DBTMOP,CLOVEROP,DBCLOVEROP>{  
-  {SPC}*UseQudaInverter{EQL}yes {
+<WILSONOP,TMOP,DBTMOP,CLOVEROP,DBCLOVEROP>{
+  {SPC}*UseExternalInverter{EQL}quda {
     if(myverbose) printf("  Use Quda inverter line %d operator %d\n", line_of_file, current_operator);
     optr->external_inverter = QUDA_INVERTER;
   }
-  {SPC}*UseQphixInverter{EQL}yes {
+  {SPC}*UseExternalInverter{EQL}qphix {
     if(myverbose) printf("  Use QPhiX inverter line %d operator %d\n", line_of_file, current_operator);
     optr->external_inverter = QPHIX_INVERTER;
   }
-  {SPC}*UseQphixInverter{EQL}no {
+  {SPC}*UseExternalInverter{EQL}no {
     if(myverbose) printf("  Use QPhiX inverter line %d operator %d\n", line_of_file, current_operator);
     optr->external_inverter = NO_EXT_INV;
   }
@@ -1528,6 +1528,57 @@ static inline void rmQuotes(char *str){
     sscanf(yytext, " %[2a-zA-Z] = %lf", name, &c);
     mnl->epsbar = c;
     if(myverbose) printf("  2KappaEpsbar set to %f line %d monomial %d\n", c, line_of_file, current_monomial);
+  }
+}
+
+<DETMONOMIAL,CLDETMONOMIAL,CLDETRATMONOMIAL,CLDETRATRWMONOMIAL,NDRATMONOMIAL,NDRATCORMONOMIAL,NDCLRATMONOMIAL,NDCLRATCORMONOMIAL,RATMONOMIAL,RATCORMONOMIAL,CLRATMONOMIAL,CLRATCORMONOMIAL>{
+  {SPC}*UseExternalInverter{EQL}quda {
+    if(myverbose) printf("  Use Quda inverter line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->external_inverter = QUDA_INVERTER;
+  }
+  {SPC}*UseExternalInverter{EQL}qphix {
+    if(myverbose) printf("  Use QPhiX inverter line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->external_inverter = QPHIX_INVERTER;
+  }
+  {SPC}*UseExternalInverter{EQL}no {
+    if(myverbose) printf("  Use QPhiX inverter line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->external_inverter = NO_EXT_INV;
+  }
+  {SPC}*UseSloppyPrecision{EQL}yes {
+    if(myverbose) printf("  Use use sloppy precision (single) in the inverter (if supported by the inverter) line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->sloppy_precision = SLOPPY_SINGLE;
+  }
+  {SPC}*UseSloppyPrecision{EQL}float {
+    if(myverbose) printf("  Use use sloppy precision (single) in the inverter (if supported by the inverter) line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->sloppy_precision = SLOPPY_SINGLE;
+  }
+  {SPC}*UseSloppyPrecision{EQL}single {
+    if(myverbose) printf("  Use use sloppy precision (single) in the inverter (if supported by the inverter) line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->sloppy_precision = SLOPPY_SINGLE;
+  }
+  {SPC}*UseSloppyPrecision{EQL}no {
+    if(myverbose) printf("  Use use sloppy precision (single) in the inverter line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->sloppy_precision = SLOPPY_DOUBLE;
+  }
+  {SPC}*UseSloppyPrecision{EQL}double {
+    if(myverbose) printf("  Use use sloppy precision (single) in the inverter line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->sloppy_precision = SLOPPY_DOUBLE;
+  }
+  {SPC}*UseSloppyPrecision{EQL}half {
+    if(myverbose) printf("  Use use sloppy precision (half) in the inverter (if supported by the inverter) line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->sloppy_precision = SLOPPY_HALF;
+  }
+  {SPC}*UseCompression{EQL}12 {
+    if(myverbose) printf("  Use 12 compression in the inverter (if supported) line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->compression_type = COMPRESSION_12;
+  }
+  {SPC}*UseCompression{EQL}8 {
+    if(myverbose) printf("  Use 8 compression in the inverter (if supported) line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->compression_type = COMPRESSION_8;
+  }
+  {SPC}*UseCompression{EQL}18 {
+    if(myverbose) printf("  Not using compression in the inverter line %d monomial %d\n", line_of_file, current_monomial);
+    mnl->compression_type = NO_COMPRESSION;
   }
 }
 

--- a/read_input.l
+++ b/read_input.l
@@ -1100,6 +1100,11 @@ static inline void rmQuotes(char *str){
     if(myverbose) printf("  Solver set to CG line %d operator %d\n", line_of_file, current_operator);
     BEGIN(name_caller);
   }
+  bicgstab {
+    optr->solver=BICGSTAB;
+    if(myverbose) printf("  Solver set to BiCGstab line %d operator %d\n", line_of_file, current_operator);
+    BEGIN(name_caller);
+  }
   rgmixedcg {
     optr->solver=RGMIXEDCG;
     if(myverbose) printf("  Solver set to RGMixedCG line %d operator %d\n", line_of_file, current_operator);

--- a/read_input.l
+++ b/read_input.l
@@ -1673,7 +1673,7 @@ static inline void rmQuotes(char *str){
   }
 }
 
-<RATMONOMIAL,CLRATMONOMIAL>{
+<RATMONOMIAL,CLRATMONOMIAL,RATCORMONOMIAL,CLRATCORMONOMIAL>{
   {SPC}*Solver{EQL} {
     solver_caller=YY_START;
     BEGIN(RATMSOLVER);

--- a/solver/Makefile.in
+++ b/solver/Makefile.in
@@ -44,7 +44,8 @@ libsolver_TARGETS = bicgstab_complex gmres incr_eigcg eigcg restart_X ortho \
 		    rg_mixed_cg_her rg_mixed_cg_her_nd \
                     dirac_operator_eigenvectors	spectral_proj \
                     jdher_su3vect cg_her_su3vect eigenvalues_Jacobi \
-		    mcr cr mcr4complex bicg_complex monomial_solve
+		    mcr cr mcr4complex bicg_complex monomial_solve \
+		    solver_types
 
 libsolver_OBJECTS = $(addsuffix .o, ${libsolver_TARGETS})
 

--- a/solver/cg_mms_tm.c
+++ b/solver/cg_mms_tm.c
@@ -86,11 +86,11 @@ int cg_mms_tm(spinor ** const P, spinor * const Q,
   alphas[0] = 1.0;
   betas[0] = 0.0;
   sigma[0] = solver_params->shifts[0]*solver_params->shifts[0];
-  if(g_proc_id == 0 && g_debug_level > 2) printf("# CGMMS: shift %d is %e\n", 0, sigma[0]);
+  if(g_proc_id == 0 && g_debug_level > 1) printf("# CGMMS: shift %d is %e\n", 0, sigma[0]);
 
   for(int im = 1; im < no_shifts; im++) {
     sigma[im] = solver_params->shifts[im]*solver_params->shifts[im] - sigma[0];
-    if(g_proc_id == 0 && g_debug_level > 2) printf("# CGMMS: shift %d is %e\n", im, sigma[im]);
+    if(g_proc_id == 0 && g_debug_level > 1) printf("# CGMMS: shift %d is %e\n", im, sigma[im]);
     // these will be the result spinor fields
     zero_spinor_field(P[im], N);
     // these are intermediate fields

--- a/solver/cg_mms_tm.h
+++ b/solver/cg_mms_tm.h
@@ -28,6 +28,6 @@
 #include "matrix_mult_typedef.h"
 #include "su3.h"
 
-int cg_mms_tm(spinor ** const P,spinor * const Q, solver_pm_t * const params, double * reached_prec);
+int cg_mms_tm(spinor ** const P,spinor * const Q, solver_params_t * const params, double * reached_prec);
 
 #endif

--- a/solver/cg_mms_tm_nd.h
+++ b/solver/cg_mms_tm_nd.h
@@ -29,6 +29,6 @@
 
 int cg_mms_tm_nd(spinor ** const Pup, spinor ** const Pdn, 
 		 spinor * const Qup, spinor * const Qdn, 
-		 solver_pm_t * solver_pm);
+		 solver_params_t * solver_params);
 
 #endif

--- a/solver/mixed_cg_mms_tm_nd.c
+++ b/solver/mixed_cg_mms_tm_nd.c
@@ -28,10 +28,10 @@
  * in modulus. The code will use shift[i]^2, which are all >0
  *
  * parameters:
- * shifts are given to the solver in solver_pm->shifts
- * number of shifts is in solver_pm->no_shifts
- * the operator to invert in solver_pm->M_ndpsi
- * the 32 bit operator to invert in solver_pm->M_ndpsi32
+ * shifts are given to the solver in solver_params->shifts
+ * number of shifts is in solver_params->no_shifts
+ * the operator to invert in solver_params->M_ndpsi
+ * the 32 bit operator to invert in solver_params->M_ndpsi32
  ***********************************************************************/
 
 #ifdef HAVE_CONFIG_H
@@ -68,14 +68,14 @@ static void free_mms_tm_nd_32();
 
 int mixed_cg_mms_tm_nd(spinor ** const Pup, spinor ** const Pdn, 
 		 spinor * const Qup, spinor * const Qdn, 
-		 solver_pm_t * solver_pm) {
+		 solver_params_t * solver_params) {
 
-  double eps_sq = solver_pm->squared_solver_prec;
-  int noshifts = solver_pm->no_shifts;
-  int rel_prec = solver_pm->rel_prec;
-  int max_iter = solver_pm->max_iter;
+  double eps_sq = solver_params->squared_solver_prec;
+  int noshifts = solver_params->no_shifts;
+  int rel_prec = solver_params->rel_prec;
+  int max_iter = solver_params->max_iter;
   int check_abs, check_rel;
-  double * shifts = solver_pm->shifts;
+  double * shifts = solver_params->shifts;
   int Nshift = noshifts;
  
   // algorithm
@@ -92,7 +92,7 @@ int mixed_cg_mms_tm_nd(spinor ** const Pup, spinor ** const Pdn,
   
   int use_eo=1, eofactor=2;
   //not even-odd?
-  if(solver_pm->sdim == VOLUME) {
+  if(solver_params->sdim == VOLUME) {
     eofactor = 1;
     use_eo = 0;
   }
@@ -109,7 +109,7 @@ int mixed_cg_mms_tm_nd(spinor ** const Pup, spinor ** const Pdn,
   if( (g_cart_id == 0 && g_debug_level > 2)) printf("# CGMMSND_mixed: Initial mms residue: %.6e\n", rr);
   if(rr < 1.0e-4){
     if( (g_cart_id == 0 && g_debug_level > 2)) printf("# CGMMSND_mixed: norm of source too low: falling back to double mms solver %.6e\n", rr);
-    return(cg_mms_tm_nd(Pup, Pdn, Qup, Qdn, solver_pm));
+    return(cg_mms_tm_nd(Pup, Pdn, Qup, Qdn, solver_params));
   }
   
   r0r0   = rr;	// for relative precision 
@@ -210,8 +210,8 @@ int mixed_cg_mms_tm_nd(spinor ** const Pup, spinor ** const Pdn,
                     square_norm_32(help_low_dn,N,1);   
    printf("square_norm(Q_low) = %e\n", sqn_low);  
    
-   solver_pm->M_ndpsi32(sf32[2], sf32[3], help_low_up, help_low_dn);
-   solver_pm->M_ndpsi(sf[2], sf[3], help_high_up, help_high_dn);
+   solver_params->M_ndpsi32(sf32[2], sf32[3], help_low_up, help_low_dn);
+   solver_params->M_ndpsi(sf[2], sf[3], help_high_up, help_high_dn);
    
    assign_to_64(sf[4], sf32[2], N);
    assign_to_64(sf[5], sf32[3], N);   
@@ -273,7 +273,7 @@ int mixed_cg_mms_tm_nd(spinor ** const Pup, spinor ** const Pdn,
     
   for (j = 0; j < max_iter; j++) {   
       // A*d(k)
-    solver_pm->M_ndpsi32(Ad_up, Ad_dn, d_up,  d_dn);     
+    solver_params->M_ndpsi32(Ad_up, Ad_dn, d_up,  d_dn);     
     //add zero'th shift
     assign_add_mul_r_32(Ad_up, d_up, (float) sigma[0], N);
     assign_add_mul_r_32(Ad_dn, d_dn, (float) sigma[0], N);
@@ -384,7 +384,7 @@ int mixed_cg_mms_tm_nd(spinor ** const Pup, spinor ** const Pdn,
       addto_32(x_dn_d, x_dn, N);      
  
       
-      solver_pm->M_ndpsi(Ax_up_d, Ax_dn_d, x_up_d,  x_dn_d);
+      solver_params->M_ndpsi(Ax_up_d, Ax_dn_d, x_up_d,  x_dn_d);
       //add zero'th shift
       assign_add_mul_r(Ax_up_d, x_up_d, sigma[0], N);
       assign_add_mul_r(Ax_dn_d, x_dn_d, sigma[0], N);
@@ -478,7 +478,7 @@ int mixed_cg_mms_tm_nd(spinor ** const Pup, spinor ** const Pdn,
     if(g_cart_id == 0) printf("# CGMMSND_mixed: Checking mms result:\n");
     //loop over all shifts (-> Nshift) 
     for(int im = 0; im < Nshift; im++){
-      solver_pm->M_ndpsi(sf[0], sf[1], Pup[im], Pdn[im]);
+      solver_params->M_ndpsi(sf[0], sf[1], Pup[im], Pdn[im]);
       assign_add_mul_r(sf[0], Pup[im] , shifts[im]*shifts[im], N);
       assign_add_mul_r(sf[1], Pdn[im] , shifts[im]*shifts[im], N);
       diff(sf[2], sf[0], Qup, N);

--- a/solver/mixed_cg_mms_tm_nd.h
+++ b/solver/mixed_cg_mms_tm_nd.h
@@ -28,6 +28,6 @@
 
 int mixed_cg_mms_tm_nd(spinor ** const Pup, spinor ** const Pdn, 
 		 spinor * const Qup, spinor * const Qdn, 
-		 solver_pm_t * solver_pm);
+		 solver_params_t * solver_params);
 
 #endif

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -88,7 +88,7 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
 #ifdef TM_USE_QPHIX
   if(solver_params.external_inverter == QPHIX_INVERTER){
     spinor** temp;
-    init_solver_field(&temp, VOLUME/2, 1);
+    init_solver_field(&temp, VOLUMEPLUSRAND/2, 1);
     
     // using CG for the HMC, we always want to have the solution of (Q Q^dagger) x = b, which is equivalent to
     // gamma_5 (M M^dagger)^{-1} gamma_5 b
@@ -166,7 +166,7 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
   }
 #ifdef WIP
     spinor** temp;
-    init_solver_field(&temp, VOLUME/2, 1);
+    init_solver_field(&temp, VOLUMEPLUSRAND/2, 1);
     f(temp[0], P);
     diff(temp[0], temp[0], Q, VOLUME/2);
     double diffnorm = square_norm(temp[0], VOLUME/2, 1); 
@@ -185,7 +185,7 @@ int solve_mshift_oneflavour(spinor ** const P, spinor * const Q, solver_params_t
 #ifdef TM_USE_QPHIX
   if( solver_params->external_inverter == QPHIX_INVERTER ){
     spinor** temp;
-    init_solver_field(&temp, VOLUME/2, 1);
+    init_solver_field(&temp, VOLUMEPLUSRAND/2, 1);
     gamma5(temp[0], Q, VOLUME/2);
     iteration_count = invert_eo_qphix_oneflavour_mshift(P, temp[0],
                                                         solver_params->max_iter, solver_params->squared_solver_prec,
@@ -214,7 +214,7 @@ int solve_mshift_oneflavour(spinor ** const P, spinor * const Q, solver_params_t
   double reached_prec = -1.0;
   iteration_count = cg_mms_tm(P, Q, solver_params, &reached_prec);
 #ifdef WIP
-  init_solver_field(&temp, VOLUME/2, 1);
+  init_solver_field(&temp, VOLUMEPLUSRAND/2, 1);
   // FIXME: in the shift-by-shift branch, the shifted operator exists explicitly and could be used to 
   // truly check the residual here
   solver_params->M_psi(temp[0], P[0]);
@@ -257,9 +257,9 @@ int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn,
       spinor** checkPdn;
 #ifdef TM_USE_QPHIX
       if( solver_params->external_inverter == QPHIX_INVERTER ){
-        init_solver_field(&temp, VOLUME/2, 2);
-        init_solver_field(&checkPup, VOLUME/2, solver_params->no_shifts);
-        init_solver_field(&checkPdn, VOLUME/2, solver_params->no_shifts);
+        init_solver_field(&temp, VOLUMEPLUSRAND/2, 2);
+        init_solver_field(&checkPup, VOLUMEPLUSRAND/2, solver_params->no_shifts);
+        init_solver_field(&checkPdn, VOLUMEPLUSRAND/2, solver_params->no_shifts);
         // by switching up and down below, we do the gamma5 tau1 (M.M^dagger)^{-1} tau1 gamma5 = [ Q(+mu,eps) Q(-mu,eps) ]^{-1}
         gamma5(temp[0], Qup, VOLUME/2);
         gamma5(temp[1], Qdn, VOLUME/2);
@@ -305,7 +305,7 @@ int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn,
 #endif
       iteration_count = cg_mms_tm_nd(Pup, Pdn, Qup, Qdn, solver_params);
 #ifdef WIP
-      init_solver_field(&temp, VOLUME/2, 2);
+      init_solver_field(&temp, VOLUMEPLUSRAND/2, 2);
       // FIXME: in the shift-by-shift branch, the shifted operator exists explicitly and could be used to 
       // truly check the residual here
       solver_params->M_ndpsi(temp[0], temp[1], Pup[0], Pdn[0]);

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -258,8 +258,8 @@ int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn,
         // by switching up and down below, we do the gamma5 tau1 (M.M^dagger)^{-1} tau1 gamma5 = [ Q(+mu,eps) Q(-mu,eps) ]^{-1}
         gamma5(temp[0], Qup, VOLUME/2);
         gamma5(temp[1], Qdn, VOLUME/2);
-        iteration_count = invert_eo_qphix_twoflavour_mshift(/*Pup, Pdn, temp[0], temp[1],*/
-                                                            Pdn, Pup, temp[1], temp[0],
+        iteration_count = invert_eo_qphix_twoflavour_mshift(Pup, Pdn, temp[0], temp[1],
+//                                                          Pdn, Pup, temp[1], temp[0],
                                                             solver_params->max_iter, solver_params->squared_solver_prec,
                                                             solver_params->type, solver_params->rel_prec,
                                                             *solver_params,

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -95,7 +95,8 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
     // gamma_5 (M M^dagger)^{-1} gamma_5 b
     // FIXME: this needs to be adjusted to also support BICGSTAB
     gamma5(temp[1], Q, VOLUME/2);
-    iteration_count = invert_eo_qphix(NULL, P, NULL, temp[1], eps_sq, max_iter, solver_type, rel_prec, solver_params, sloppy, compression, f);
+    iteration_count = invert_eo_qphix_oneflavour(P, temp[1], eps_sq, max_iter, solver_type, 
+                                                 rel_prec, solver_params, sloppy, compression);
     mul_gamma5(P, VOLUME/2);
 
 #ifdef WIP

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -145,7 +145,7 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
       }
     }
   } 
-  if(use_solver == CG){
+  else if(use_solver == CG){
     iteration_count =  cg_her(P, Q, max_iter, eps_sq, rel_prec, N, f);
   }
   else if(use_solver == BICGSTAB){
@@ -192,7 +192,7 @@ int solve_mshift_oneflavour(spinor ** const P, spinor * const Q, solver_params_t
     for( int shift = 0; shift < solver_params->no_shifts; shift++){
       mul_gamma5(P[shift], VOLUME/2);
     }
-  }
+  } else
 #endif // TM_USE_QPHIX
   if( solver_params->external_inverter == NO_EXT_INV ){
     double reached_prec = -1.0;
@@ -214,42 +214,6 @@ int solve_mshift_oneflavour(spinor ** const P, spinor * const Q, solver_params_t
     finalize_solver(temp, 1);
   }
   return iteration_count;
-}
-
-// this is a debugging function which can be used to write the solutions of the multi-shift inversion to file
-void write_mms_nd_props(spinor** const Pup, spinor ** const Pdn, solver_params_t * solver_params, const char * name,
-                        const int iteration_count ){
-  int append = 0;
-  char filename[300];
-  WRITER * writer = NULL;
-  paramsInverterInfo *inverterInfo = NULL;
-  paramsPropagatorFormat *propagatorFormat = NULL;
-  
-  const int num_flavour = 1;
-  const int precision = 64;
-
-  sprintf(filename, "%s.cgmms.prop", name);
-  
-  for(int im = 0; im < solver_params->no_shifts; im++) {
-    if(im==0) construct_writer(&writer, filename, 0);
-    else construct_writer(&writer, filename, 1);
-    
-    if (im==0) {
-      inverterInfo = construct_paramsInverterInfo(0.0, iteration_count, DBTMWILSON, num_flavour);
-      inverterInfo->cgmms_mass = solver_params->shifts[im]/(2 * g_kappa);
-      write_spinor_info(writer, 0, inverterInfo, 0);
-      free(inverterInfo);
-    }
-    
-    propagatorFormat = construct_paramsPropagatorFormat(precision, num_flavour);
-    write_propagator_format(writer, propagatorFormat);
-    free(propagatorFormat);
-    
-    int status = write_spinor(writer, &Pup[im], &Pdn[im], num_flavour, precision);
-    if(g_proc_id==0) printf("Writer status: %d\n", status);
-    
-    destruct_writer(writer);
-  }
 }
 
 int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn, 

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -1,6 +1,7 @@
 /***********************************************************************
  *
  * Copyright (C) 2014 Florian Burger
+ *               2017 Bartosz Kostrzewa
  *
  * This file is part of tmLQCD.
  *
@@ -69,10 +70,6 @@
 #include <io/params.h>
 #include <io/spinor.h>
 
-/* BaKo: this and the stuff below will be removed as soon as everything works
- *       for all operators */       
-#define WIP
-
 #ifdef HAVE_GPU
 #include"../GPU/cudadefs.h"
 extern  int linsolve_eo_gpu (spinor * const P, spinor * const Q, const int max_iter, 
@@ -91,11 +88,15 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
                      const int N, matrix_mult f, int solver_type){
   int iteration_count = 0;
   int use_solver = solver_type;
+  // set up for performing checks of the residual
+  // the temporary field is also required by the QPhiX solve
+  spinor** temp;
+  if(g_debug_level > 0 || solver_params.external_inverter == QPHIX_INVERTER){
+    init_solver_field(&temp, VOLUMEPLUSRAND/2, 1);
+  }
+
 #ifdef TM_USE_QPHIX
   if(solver_params.external_inverter == QPHIX_INVERTER){
-    spinor** temp;
-    init_solver_field(&temp, VOLUMEPLUSRAND/2, 1);
-    
     // using CG for the HMC, we always want to have the solution of (Q Q^dagger) x = b, which is equivalent to
     // gamma_5 (M M^dagger)^{-1} gamma_5 b
     // FIXME: this needs to be adjusted to also support BICGSTAB
@@ -103,19 +104,9 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
     iteration_count = invert_eo_qphix_oneflavour(P, temp[0], max_iter, eps_sq, solver_type, 
                                                  rel_prec, solver_params, solver_params.sloppy_precision, solver_params.compression_type);
     mul_gamma5(P, VOLUME/2);
-
-#ifdef WIP
-    f(temp[0], P);
-    diff(temp[0], temp[0], Q, VOLUME/2);
-    double diffnorm = square_norm(temp[0], VOLUME/2, 1); 
-    if( g_proc_id == 0 ){
-      printf("# QPhiX residual check: %e\n", diffnorm);
-    }
-#endif // WIP
-    finalize_solver(temp, 1);
-    return(iteration_count);
   } else
-#endif  
+#endif
+
   if(use_solver == MIXEDCG || use_solver == RGMIXEDCG){
     // the default mixed solver is rg_mixed_cg_her
     int (*msolver_fp)(spinor * const, spinor * const, solver_params_t, 
@@ -126,6 +117,7 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
       msolver_fp = mixed_cg_her;
     }
 
+    // FIXME: this GPU stuff needs to go...
     if(usegpu_flag){   
       #ifdef HAVE_GPU     
 	      #ifdef TEMPORALGAUGE
@@ -141,15 +133,12 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
     else{
       if(f==Qtm_pm_psi){   
         iteration_count =  msolver_fp(P, Q, solver_params, max_iter, eps_sq, rel_prec, N, f, &Qtm_pm_psi_32);
-        return(iteration_count);
       }
       else if(f==Q_pm_psi){     
 	iteration_count =  msolver_fp(P, Q, solver_params, max_iter, eps_sq, rel_prec, N, f, &Q_pm_psi_32);
-	return(iteration_count);      
       } else if(f==Qsw_pm_psi){
         copy_32_sw_fields();
         iteration_count = msolver_fp(P, Q, solver_params, max_iter, eps_sq, rel_prec, N, f, &Qsw_pm_psi_32);
-        return(iteration_count);
       } else {
         if(g_proc_id==0) printf("Warning: 32 bit matrix not available. Falling back to CG in 64 bit\n"); 
         use_solver = CG;
@@ -170,28 +159,29 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
     if(g_proc_id==0) printf("Error: solver not allowed for degenerate solve. Aborting...\n");
     exit(2);
   }
-#ifdef WIP
-    spinor** temp;
-    init_solver_field(&temp, VOLUMEPLUSRAND/2, 1);
+  if(g_debug_level > 0){
     f(temp[0], P);
     diff(temp[0], temp[0], Q, VOLUME/2);
     double diffnorm = square_norm(temp[0], VOLUME/2, 1); 
     if( g_proc_id == 0 ){
-      printf("# tmLQCD residual check: %e\n", diffnorm);
+      printf("# solve_degenerate residual check: %e\n", diffnorm);
     }
+  }
+  if(g_debug_level > 0 || solver_params.external_inverter == QPHIX_INVERTER){
     finalize_solver(temp, 1);
-#endif // WIP
+  }
   return(iteration_count);
 }
 
 int solve_mshift_oneflavour(spinor ** const P, spinor * const Q, solver_params_t* solver_params){
   int iteration_count = 0;
   spinor ** temp;
+  if(g_debug_level > 0 || solver_params->external_inverter == QPHIX_INVERTER){
+    init_solver_field(&temp, VOLUMEPLUSRAND/2, 1);
+  }
   
 #ifdef TM_USE_QPHIX
   if( solver_params->external_inverter == QPHIX_INVERTER ){
-    spinor** temp;
-    init_solver_field(&temp, VOLUMEPLUSRAND/2, 1);
     gamma5(temp[0], Q, VOLUME/2);
     iteration_count = invert_eo_qphix_oneflavour_mshift(P, temp[0],
                                                         solver_params->max_iter, solver_params->squared_solver_prec,
@@ -202,39 +192,31 @@ int solve_mshift_oneflavour(spinor ** const P, spinor * const Q, solver_params_t
     for( int shift = 0; shift < solver_params->no_shifts; shift++){
       mul_gamma5(P[shift], VOLUME/2);
     }
-#ifdef WIP
+  }
+#endif // TM_USE_QPHIX
+  if( solver_params->external_inverter == NO_EXT_INV ){
+    double reached_prec = -1.0;
+    iteration_count = cg_mms_tm(P, Q, solver_params, &reached_prec);
+  }
+
+  if(g_debug_level > 0){
     // FIXME: in the shift-by-shift branch, the shifted operator exists explicitly and could be used to 
     // truly check the residual here
     solver_params->M_psi(temp[0], P[0]);
     diff(temp[0], temp[0], Q, VOLUME/2);
     double diffnorm = square_norm(temp[0], VOLUME/2, 1); 
     if( g_proc_id == 0 ){
-      printf("# QPhiX residual check: %e\n", diffnorm);
+      printf("# solve_mshift_oneflavour residual check: %e\n", diffnorm);
+      printf("# NOTE that this currently repors the residual for the *unishfted* operator!\n");
     }
-#endif // WIP
+  }
+  if(g_debug_level > 0 || solver_params->external_inverter == QPHIX_INVERTER){
     finalize_solver(temp, 1);
-    return(iteration_count);
   }
-#endif // TM_USE_QPHIX
-
-  double reached_prec = -1.0;
-  iteration_count = cg_mms_tm(P, Q, solver_params, &reached_prec);
-#ifdef WIP
-  init_solver_field(&temp, VOLUMEPLUSRAND/2, 1);
-  // FIXME: in the shift-by-shift branch, the shifted operator exists explicitly and could be used to 
-  // truly check the residual here
-  solver_params->M_psi(temp[0], P[0]);
-  diff(temp[0], temp[0], Q, VOLUME/2);
-  double diffnorm = square_norm(temp[0], VOLUME/2, 1); 
-  if( g_proc_id == 0 ){
-    printf("# tmLQCD residual check: %e\n", diffnorm);
-  }
-  finalize_solver(temp, 1);
-#endif // WIP      
-
   return iteration_count;
 }
 
+// this is a debugging function which can be used to write the solutions of the multi-shift inversion to file
 void write_mms_nd_props(spinor** const Pup, spinor ** const Pdn, solver_params_t * solver_params, const char * name,
                         const int iteration_count ){
   int append = 0;
@@ -273,7 +255,36 @@ void write_mms_nd_props(spinor** const Pup, spinor ** const Pdn, solver_params_t
 int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn, 
                  spinor * const Qup, spinor * const Qdn, 
                  solver_params_t * solver_params){ 
-  int iteration_count = 0; 
+  int iteration_count = 0;
+  
+  spinor** temp;
+  if(g_debug_level > 0 || solver_params->external_inverter == QPHIX_INVERTER){
+    init_solver_field(&temp, VOLUMEPLUSRAND/2, 2);
+  }
+#ifdef TM_USE_QPHIX
+  if(solver_params->external_inverter == QPHIX_INVERTER){
+    //  gamma5 (M.M^dagger)^{-1} gamma5 = [ Q(+mu,eps) Q(-mu,eps) ]^{-1}
+    gamma5(temp[0], Qup, VOLUME/2);
+    gamma5(temp[1], Qdn, VOLUME/2);
+    iteration_count = invert_eo_qphix_twoflavour_mshift(Pup, Pdn, temp[0], temp[1],
+                                                        solver_params->max_iter, solver_params->squared_solver_prec,
+                                                        solver_params->type, solver_params->rel_prec,
+                                                        *solver_params,
+                                                        solver_params->sloppy_precision,
+                                                        solver_params->compression_type);
+    
+    // the tmLQCD ND operator used for HMC is normalised by the inverse of the maximum eigenvalue
+    // so the inverse of Q^2 is normalised by the square of the maximum eigenvalue
+    // or, equivalently, the square of the inverse of the inverse
+    // note that in the QPhiX interface, we also correctly normalise the shifts
+    const double maxev_sq = (1.0/phmc_invmaxev)*(1.0/phmc_invmaxev);
+    for( int shift = 0; shift < solver_params->no_shifts; shift++){
+      mul_r_gamma5(Pup[shift], maxev_sq, VOLUME/2);
+      mul_r_gamma5(Pdn[shift], maxev_sq, VOLUME/2);
+    }
+  } else
+#endif //TM_USE_QPHIX
+  if(solver_params->external_inverter == NO_EXT_INV){
     if(solver_params->type==MIXEDCGMMSND){
       if(usegpu_flag){
 	#ifdef HAVE_GPU      
@@ -289,93 +300,27 @@ int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn,
       else{
 	iteration_count = mixed_cg_mms_tm_nd(Pup, Pdn, Qup, Qdn, solver_params);
       }
-    }
-    else if (solver_params->type==CGMMSND){
-      spinor** temp;
-      
-      spinor** checkPup;
-      spinor** checkPdn;
-#ifdef TM_USE_QPHIX
-      if( solver_params->external_inverter == QPHIX_INVERTER ){
-        init_solver_field(&temp, VOLUMEPLUSRAND/2, 2);
-        //  gamma5 (M.M^dagger)^{-1} gamma5 = [ Q(+mu,eps) Q(-mu,eps) ]^{-1}
-        gamma5(temp[0], Qup, VOLUME/2);
-        gamma5(temp[1], Qdn, VOLUME/2);
-        iteration_count = invert_eo_qphix_twoflavour_mshift(Pup, Pdn, temp[0], temp[1],
-//                                                             Pdn, Pup, temp[1], temp[0],
-                                                            solver_params->max_iter, solver_params->squared_solver_prec,
-                                                            solver_params->type, solver_params->rel_prec,
-                                                            *solver_params,
-                                                            solver_params->sloppy_precision,
-                                                            solver_params->compression_type);
-        
-        // the tmLQCD ND operator used for HMC is normalised by the inverse of the maximum eigenvalue
-        // so the inverse of Q^2 is normalised by the square of the maximum eigenvalue
-        // or, equivalently, the square of the inverse of the inverse
-        // note that in the QPhiX interface, we also correctly normalise the shifts
-        const double maxev_sq = (1.0/phmc_invmaxev)*(1.0/phmc_invmaxev);
-        for( int shift = 0; shift < solver_params->no_shifts; shift++){
-          mul_r_gamma5(Pup[shift], maxev_sq, VOLUME/2);
-          mul_r_gamma5(Pdn[shift], maxev_sq, VOLUME/2);
-        }
-        
-//         init_solver_field(&checkPup, VOLUMEPLUSRAND/2, solver_params->no_shifts);
-//         init_solver_field(&checkPdn, VOLUMEPLUSRAND/2, solver_params->no_shifts);
-//         int tm_iteration_count = cg_mms_tm_nd(checkPup, checkPdn, Qup, Qdn, solver_params);
-//         
-//         write_mms_nd_props(Pup,Pdn,solver_params,"qphix",iteration_count);
-//         write_mms_nd_props(checkPup,checkPdn,solver_params,"tmlqcd",tm_iteration_count);
-//         
-//         MPI_Barrier(MPI_COMM_WORLD);
-//         fflush(stdout);
-//         MPI_Barrier(MPI_COMM_WORLD);
-//         
-//         fatal_error("Debug: stopping here\n","solve_mms_nd");
-//         
-//         for(int shift = 0; shift < solver_params->no_shifts; shift++){
-//           diff(temp[0], checkPup[shift], Pup[shift], VOLUME/2);
-//           diff(temp[1], checkPdn[shift], Pdn[shift], VOLUME/2);
-//           
-//           if(g_proc_id==0){
-//             printf("|| Pup[%d] - checkPup[%d] ||^2 = %.6e \n", shift, shift, square_norm(temp[0],VOLUME/2,1));
-//             printf("|| Pdn[%d] - checkPdn[%d] ||^2 = %.6e \n", shift, shift, square_norm(temp[1],VOLUME/2,1));
-//           }
-//         }
-//         finalize_solver(checkPup, solver_params->no_shifts);
-//         finalize_solver(checkPdn, solver_params->no_shifts);
-#ifdef WIP
-//         FIXME: in the shift-by-shift branch, the shifted operator exists explicitly and could be used to 
-//         truly check the residual here
-        solver_params->M_ndpsi(temp[0], temp[1], Pup[0], Pdn[0]);
-        diff(temp[0], temp[0], Qup, VOLUME/2);
-        diff(temp[1], temp[1], Qdn, VOLUME/2);
-        double diffnorm = square_norm(temp[0], VOLUME/2, 1) + square_norm(temp[1], VOLUME/2, 1); 
-        if( g_proc_id == 0 ){
-          printf("# QPhiX residual check: %e\n", diffnorm);
-        }
-#endif // WIP
-        finalize_solver(temp, 2);
-        return(iteration_count);
-      }
-#endif
+    } else if (solver_params->type==CGMMSND){
       iteration_count = cg_mms_tm_nd(Pup, Pdn, Qup, Qdn, solver_params);
-#ifdef WIP
-      init_solver_field(&temp, VOLUMEPLUSRAND/2, 2);
-      // FIXME: in the shift-by-shift branch, the shifted operator exists explicitly and could be used to 
-      // truly check the residual here
-      solver_params->M_ndpsi(temp[0], temp[1], Pup[0], Pdn[0]);
-      diff(temp[0], temp[0], Qup, VOLUME/2);
-      diff(temp[1], temp[1], Qdn, VOLUME/2);
-      double diffnorm = square_norm(temp[0], VOLUME/2, 1) + square_norm(temp[1], VOLUME/2, 1); 
-      if( g_proc_id == 0 ){
-        printf("# tmLQCD residual check: %e\n", diffnorm);
-      }
-      finalize_solver(temp, 2);
-#endif // WIP      
-    }
-    else{
+    } else {
       if(g_proc_id==0) printf("Error: solver not allowed for ND mms solve. Aborting...\n");
       exit(2);      
     }
+  }
+  if( g_debug_level > 0 ){
+    // FIXME: in the shift-by-shift branch, the shifted operator exists explicitly and could be used to 
+    // truly check the residual here
+    solver_params->M_ndpsi(temp[0], temp[1], Pup[0], Pdn[0]);
+    diff(temp[0], temp[0], Qup, VOLUME/2);
+    diff(temp[1], temp[1], Qdn, VOLUME/2);
+    double diffnorm = square_norm(temp[0], VOLUME/2, 1) + square_norm(temp[1], VOLUME/2, 1); 
+    if( g_proc_id == 0 ){
+      printf("# solve_mms_nd residual check: %e\n", diffnorm);
+      printf("# NOTE that this currently repors the residual for the *unishfted* operator!\n");
+    }
+  }
+  if( g_debug_level > 0 || solver_params->external_inverter == QPHIX_INVERTER ){
+    finalize_solver(temp, 2);
+  }
   return(iteration_count);
 }

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -94,15 +94,15 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
     // using CG for the HMC, we always want to have the solution of (Q Q^dagger) x = b, which is equivalent to
     // gamma_5 (M M^dagger)^{-1} gamma_5 b
     // FIXME: this needs to be adjusted to also support BICGSTAB
-    gamma5(temp[1], Q, VOLUME/2);
-    iteration_count = invert_eo_qphix_oneflavour(P, temp[1], max_iter, eps_sq, solver_type, 
+    gamma5(temp[0], Q, VOLUME/2);
+    iteration_count = invert_eo_qphix_oneflavour(P, temp[0], max_iter, eps_sq, solver_type, 
                                                  rel_prec, solver_params, sloppy, compression);
     mul_gamma5(P, VOLUME/2);
 
 #ifdef WIP
-    f(temp[1], P);
-    diff(temp[1], temp[1], Q, VOLUME/2);
-    double diffnorm = square_norm(temp[1], VOLUME/2, 1); 
+    f(temp[0], P);
+    diff(temp[0], temp[0], Q, VOLUME/2);
+    double diffnorm = square_norm(temp[0], VOLUME/2, 1); 
     if( g_proc_id == 0 ){
       printf("# QPhiX residual check: %e\n", diffnorm);
     }
@@ -168,9 +168,9 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
 #ifdef WIP
     spinor** temp;
     init_solver_field(&temp, VOLUME/2, 1);
-    f(temp[1], P);
-    diff(temp[1], temp[1], Q, VOLUME/2);
-    double diffnorm = square_norm(temp[1], VOLUME/2, 1); 
+    f(temp[0], P);
+    diff(temp[0], temp[0], Q, VOLUME/2);
+    double diffnorm = square_norm(temp[0], VOLUME/2, 1); 
     if( g_proc_id == 0 ){
       printf("# tmLQCD residual check: %e\n", diffnorm);
     }

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -91,7 +91,7 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
     spinor** temp;
     init_solver_field(&temp, VOLUME/2, 1);
     
-    // usign CG for the HMC, we always want to have the solution of (Q Q^dagger) x = b, which is equivalent to
+    // using CG for the HMC, we always want to have the solution of (Q Q^dagger) x = b, which is equivalent to
     // gamma_5 (M M^dagger)^{-1} gamma_5 b
     // FIXME: this needs to be adjusted to also support BICGSTAB
     gamma5(temp[1], Q, VOLUME/2);

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -89,29 +89,25 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
 #ifdef TM_USE_QPHIX
   if(external_inverter == QPHIX_INVERTER){
     spinor** temp;
-#ifdef WIP
-    init_solver_field(&temp, VOLUME/2, 2);
-#else
     init_solver_field(&temp, VOLUME/2, 1);
-#endif
+    
     // usign CG for the HMC, we always want to have the solution of (Q Q^dagger) x = b, which is equivalent to
     // gamma_5 (M M^dagger)^{-1} gamma_5 b
     // FIXME: this needs to be adjusted to also support BICGSTAB
     gamma5(temp[1], Q, VOLUME/2);
     iteration_count = invert_eo_qphix(NULL, P, NULL, temp[1], eps_sq, max_iter, solver_type, rel_prec, solver_params, sloppy, compression, f);
     mul_gamma5(P, VOLUME/2);
+
 #ifdef WIP
     f(temp[1], P);
-    gamma5(temp[2], Q, VOLUME/2);
-    diff(temp[1], temp[1], temp[2], VOLUME/2);
+    //gamma5(temp[2], Q, VOLUME/2);
+    diff(temp[1], temp[1], Q, VOLUME/2);
     double diffnorm = square_norm(temp[1], VOLUME/2, 1); 
     if( g_proc_id == 0 ){
       printf("# QPhiX residual check: %e\n", diffnorm);
     }
-    finalize_solver(temp, 2);
-#else
-    finalize_solver(temp, 1);
 #endif // WIP
+    finalize_solver(temp, 1);
     return(iteration_count);
   } else
 #endif  

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -95,7 +95,7 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
     // gamma_5 (M M^dagger)^{-1} gamma_5 b
     // FIXME: this needs to be adjusted to also support BICGSTAB
     gamma5(temp[1], Q, VOLUME/2);
-    iteration_count = invert_eo_qphix_oneflavour(P, temp[1], eps_sq, max_iter, solver_type, 
+    iteration_count = invert_eo_qphix_oneflavour(P, temp[1], max_iter, eps_sq, solver_type, 
                                                  rel_prec, solver_params, sloppy, compression);
     mul_gamma5(P, VOLUME/2);
 

--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -100,7 +100,6 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
 
 #ifdef WIP
     f(temp[1], P);
-    //gamma5(temp[2], Q, VOLUME/2);
     diff(temp[1], temp[1], Q, VOLUME/2);
     double diffnorm = square_norm(temp[1], VOLUME/2, 1); 
     if( g_proc_id == 0 ){

--- a/solver/monomial_solve.h
+++ b/solver/monomial_solve.h
@@ -19,14 +19,17 @@
 #ifndef _MONOMIAL_SOLVE_H
 #define _MONOMIAL_SOLVE_H
 
-
 #include"solver/matrix_mult_typedef.h"
 #include"solver/solver_params.h"
 #include"su3.h"
-    int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_params, const int max_iter, 
-           double eps_sq, const int rel_prec, const int N, matrix_mult f, int solver_type);
-    int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn, 
-                     spinor * const Qup, spinor * const Qdn, 
-                     solver_pm_t * solver_pm);
+
+int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_params,
+                     const int max_iter, double eps_sq, const int rel_prec, 
+                     const int N, matrix_mult f, int solver_type, const ExternalInverter external_inverter,
+                     const SloppyPrecision sloppy, const CompressionType compression);
+
+int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn, 
+                 spinor * const Qup, spinor * const Qdn, 
+                 solver_params_t * solver_params);
 
 #endif

--- a/solver/monomial_solve.h
+++ b/solver/monomial_solve.h
@@ -19,9 +19,10 @@
 #ifndef _MONOMIAL_SOLVE_H
 #define _MONOMIAL_SOLVE_H
 
-#include"solver/matrix_mult_typedef.h"
-#include"solver/solver_params.h"
-#include"su3.h"
+#include "misc_types.h"
+#include "solver/matrix_mult_typedef.h"
+#include "solver/solver_params.h"
+#include "su3.h"
 
 int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_params,
                      const int max_iter, double eps_sq, const int rel_prec, 

--- a/solver/monomial_solve.h
+++ b/solver/monomial_solve.h
@@ -26,8 +26,9 @@
 
 int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_params,
                      const int max_iter, double eps_sq, const int rel_prec, 
-                     const int N, matrix_mult f, int solver_type, const ExternalInverter external_inverter,
-                     const SloppyPrecision sloppy, const CompressionType compression);
+                     const int N, matrix_mult f, int solver_type);
+
+int solve_mshift_oneflavour(spinor ** const P, spinor * const Q, solver_params_t* solver_params);
 
 int solve_mms_nd(spinor ** const Pup, spinor ** const Pdn, 
                  spinor * const Qup, spinor * const Qdn, 

--- a/solver/solver.h
+++ b/solver/solver.h
@@ -26,30 +26,7 @@
 #include "solver/matrix_mult_typedef_bi.h"
 #include "solver/matrix_mult_typedef_nd.h"
 
-typedef struct {
-  // solver type
-  int type;
-  // maximal number of iterations
-  int max_iter;
-  // use relative precision
-  int rel_prec;
-  // number of shifts in multi shift solvers
-  int no_shifts;
-  // dimension of spinors
-  int sdim;
-  // squared desired residue
-  double squared_solver_prec;
-  // single flavour matrix to invert
-  matrix_mult M_psi;
-  // 32bit single flavour matrix to invert
-  matrix_mult32 M_psi32;  
-  // flavour doublet matrix to invert
-  matrix_mult_nd M_ndpsi;
-  // 32bit flavour doublet matrix to invert
-  matrix_mult_nd32 M_ndpsi32;  
-  // pointer to array of shifts
-  double * shifts;
-} solver_pm_t;
+#include "solver/solver_params.h"
 
 #include"solver/gmres.h"
 #include"solver/gmres_dr.h"

--- a/solver/solver.h
+++ b/solver/solver.h
@@ -64,4 +64,6 @@
 
 #include "solver/sumr.h"
 
+#include "solver/monomial_solve.h"
+
 #endif

--- a/solver/solver_params.h
+++ b/solver/solver_params.h
@@ -27,8 +27,16 @@
  ****************************************************************************/
 
 
-#ifndef _SOLVER_PARAMS_H
-#define _SOLVER_PARAMS_H
+#ifndef SOLVER_PARAMS_H
+#define SOLVER_PARAMS_H
+
+#include "solver/matrix_mult_typedef.h"
+#include "solver/matrix_mult_typedef_nd.h"
+
+typedef enum solution_type_t {
+  TM_SOLUTION_M_MDAG = 0,
+  TM_SOLUTION_M
+} solution_type_t;
 
 typedef struct {
 
@@ -56,6 +64,30 @@ typedef struct {
      where the maximum is over the iterated residuals since the last update */  
   float mcg_delta; 
 
+  // solver type
+  int type;
+  // maximal number of iterations
+  int max_iter;
+  // use relative precision
+  int rel_prec;
+  // number of shifts in multi shift solvers
+  int no_shifts;
+  // dimension of spinors
+  int sdim;
+  // squared desired residue
+  double squared_solver_prec;
+  // single flavour matrix to invert
+  matrix_mult M_psi;
+  // 32bit single flavour matrix to invert
+  matrix_mult32 M_psi32;  
+  // flavour doublet matrix to invert
+  matrix_mult_nd M_ndpsi;
+  // 32bit flavour doublet matrix to invert
+  matrix_mult_nd32 M_ndpsi32;  
+  // pointer to array of shifts
+  double * shifts;
+  
+  solution_type_t solution_type;
   
 } solver_params_t;
 

--- a/solver/solver_params.h
+++ b/solver/solver_params.h
@@ -34,6 +34,8 @@
 #include "solver/matrix_mult_typedef.h"
 #include "solver/matrix_mult_typedef_nd.h"
 
+#include "misc_types.h"
+
 typedef enum solution_type_t {
   TM_SOLUTION_M_MDAG = 0,
   TM_SOLUTION_M
@@ -89,6 +91,10 @@ typedef struct {
   double * shifts;
   
   solution_type_t solution_type;
+  
+  CompressionType compression_type;
+  SloppyPrecision sloppy_precision;
+  ExternalInverter external_inverter;
   
 } solver_params_t;
 

--- a/solver/solver_params.h
+++ b/solver/solver_params.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (C) 2002,2003,2004,2005,2006,2007,2008 Carsten Urbach
+ *               2017                               Bartosz Kostrzewa
  *
  * This file is part of tmLQCD.
  *

--- a/solver/solver_types.c
+++ b/solver/solver_types.c
@@ -1,0 +1,27 @@
+/***************************************************************************
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008 Carsten Urbach
+ *               2017                               Bartosz Kostrzewa
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ ****************************************************************************/
+
+#include "solver/solver_types.h"
+
+int solver_is_mixed( const int solver_type ){
+  return( solver_type == MIXEDCG || solver_type == RGMIXEDCG || solver_type == MIXEDCGMMSND ||
+          solver_type == MIXEDBICGSTAB );
+}
+

--- a/solver/solver_types.h
+++ b/solver/solver_types.h
@@ -1,3 +1,23 @@
+/***************************************************************************
+ * Copyright (C) 2002,2003,2004,2005,2006,2007,2008 Carsten Urbach
+ *               2017                               Bartosz Kostrzewa
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ ****************************************************************************/
+
 #ifndef _SOLVER_TYPES_H
 #define _SOLVER_TYPES_H
 
@@ -24,7 +44,10 @@ typedef enum SOLVER_TYPE {
  MCR,
  CR,
  BICG,
- MG
+ MG,
+ MIXEDBICGSTAB
 } SOLVER_TYPE;
+
+int solver_is_mixed( const int solver_type );
 
 #endif

--- a/solver/solver_types.h
+++ b/solver/solver_types.h
@@ -45,7 +45,8 @@ typedef enum SOLVER_TYPE {
  CR,
  BICG,
  MG,
- MIXEDBICGSTAB
+ MIXEDBICGSTAB,
+ DUMMYHERMTEST
 } SOLVER_TYPE;
 
 int solver_is_mixed( const int solver_type );

--- a/struct_accessors.h
+++ b/struct_accessors.h
@@ -1,0 +1,193 @@
+/***********************************************************************
+ *
+ * Copyright (C) 2017 Bartosz Kostrzewa
+ *
+ * This file is part of tmLQCD.
+ *
+ * tmLQCD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * tmLQCD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ***********************************************************************/
+
+#ifndef STRUCT_ACCESSORS_H
+#define STRUCT_ACCESSORS_H
+
+#include "su3.h"
+#include <stdlib.h>
+
+static inline double su3_get_elem_linear(const su3* const matrix, int cc, int reim){
+  switch(cc){
+    case 0:
+      if(reim==0) return( creal(matrix->c00) );
+      else return( cimag(matrix->c00) );
+      break;
+    case 1:
+      if(reim==0) return( creal(matrix->c01) );
+      else return( cimag(matrix->c01) );
+      break;
+    case 2:
+      if(reim==0) return( creal(matrix->c02) );
+      else return( cimag(matrix->c02) );
+      break;
+    case 3:
+      if(reim==0) return( creal(matrix->c10) );
+      else return( cimag(matrix->c10) );
+      break;
+    case 4:
+      if(reim==0) return( creal(matrix->c11) );
+      else return( cimag(matrix->c11) );
+      break;
+    case 5:
+      if(reim==0) return( creal(matrix->c12) );
+      else return( cimag(matrix->c12) );
+      break;
+    case 6:
+      if(reim==0) return( creal(matrix->c20) );
+      else return( cimag(matrix->c20) );
+      break;
+    case 7:
+      if(reim==0) return( creal(matrix->c21) );
+      else return( cimag(matrix->c21) );
+      break;
+    case 8:
+      if(reim==0) return( creal(matrix->c22) );
+      else return( cimag(matrix->c22) );
+      break;
+    default:
+      exit(-222);
+  }
+}
+
+static inline double su3_get_elem(const su3* const matrix, int c0, int c1, int reim){
+  return su3_get_elem_linear(matrix, 3*c0+c1, reim);
+}
+
+static inline double spinor_get_elem_linear(const spinor* const matrix, int sc, int reim){
+  switch(sc){
+    case 0:
+      if(reim==0) return( creal(matrix->s0.c0) );
+      else return( cimag(matrix->s0.c0) );
+      break;
+    case 1:
+      if(reim==0) return( creal(matrix->s0.c1) );
+      else return( cimag(matrix->s0.c1) );
+      break;
+    case 2:
+      if(reim==0) return( creal(matrix->s0.c2) );
+      else return( cimag(matrix->s0.c2) );
+      break;
+    case 3:
+      if(reim==0) return( creal(matrix->s1.c0) );
+      else return( cimag(matrix->s1.c0) );
+      break;
+    case 4:
+      if(reim==0) return( creal(matrix->s1.c1) );
+      else return( cimag(matrix->s1.c1) );
+      break;
+    case 5:
+      if(reim==0) return( creal(matrix->s1.c2) );
+      else return( cimag(matrix->s1.c2) );
+      break;
+    case 6:
+      if(reim==0) return( creal(matrix->s2.c0) );
+      else return( cimag(matrix->s2.c0) );
+      break;
+    case 7:
+      if(reim==0) return( creal(matrix->s2.c1) );
+      else return( cimag(matrix->s2.c1) );
+      break;
+    case 8:
+      if(reim==0) return( creal(matrix->s2.c2) );
+      else return( cimag(matrix->s2.c2) );
+      break;
+    case 9:
+      if(reim==0) return( creal(matrix->s3.c0) );
+      else return( cimag(matrix->s3.c0) );
+      break;
+    case 10:
+      if(reim==0) return( creal(matrix->s3.c1) );
+      else return( cimag(matrix->s3.c1) );
+      break;
+    case 11:
+      if(reim==0) return( creal(matrix->s3.c2) );
+      else return( cimag(matrix->s3.c2) );
+      break;
+    default:
+      exit(-223);
+  }
+}
+
+static inline double spinor_get_elem(const spinor* const matrix, int s, int c, int reim){
+  return spinor_get_elem_linear(matrix, 3*s+c, reim);
+}
+
+static inline void spinor_set_elem_linear(spinor* const matrix, int sc, const double rein, const double imin){
+  switch(sc){
+    case 0:
+      *(reinterpret_cast<double*const>(&(matrix->s0.c0))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s0.c0))+1) = imin;
+      break;
+    case 1:
+      *(reinterpret_cast<double*const>(&(matrix->s0.c1))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s0.c1))+1) = imin;
+      break;
+    case 2:
+      *(reinterpret_cast<double*const>(&(matrix->s0.c2))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s0.c2))+1) = imin;
+      break;
+    case 3:
+      *(reinterpret_cast<double*const>(&(matrix->s1.c0))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s1.c0))+1) = imin;
+      break;
+    case 4:
+      *(reinterpret_cast<double*const>(&(matrix->s1.c1))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s1.c1))+1) = imin;
+      break;
+    case 5:
+      *(reinterpret_cast<double*const>(&(matrix->s1.c2))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s1.c2))+1) = imin;
+      break;
+    case 6:
+      *(reinterpret_cast<double*const>(&(matrix->s2.c0))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s2.c0))+1) = imin;
+      break;
+    case 7:
+      *(reinterpret_cast<double*const>(&(matrix->s2.c1))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s2.c1))+1) = imin;
+      break;
+    case 8:
+      *(reinterpret_cast<double*const>(&(matrix->s2.c2))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s2.c2))+1) = imin;
+      break;
+    case 9:
+      *(reinterpret_cast<double*const>(&(matrix->s3.c0))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s3.c0))+1) = imin;
+      break;
+    case 10:
+      *(reinterpret_cast<double*const>(&(matrix->s3.c1))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s3.c1))+1) = imin;
+      break;
+    case 11:
+      *(reinterpret_cast<double*const>(&(matrix->s3.c2))  ) = rein;
+      *(reinterpret_cast<double*const>(&(matrix->s3.c2))+1) = imin;
+      break;
+    default:
+      exit(-224);
+  }
+}
+
+static inline void spinor_set_elem(spinor* const matrix, int s, int c, const double rein, const double imin){
+  spinor_set_elem_linear(matrix, 3*s+c, rein, imin);
+}
+
+#endif

--- a/struct_accessors.h
+++ b/struct_accessors.h
@@ -134,52 +134,52 @@ static inline double spinor_get_elem(const spinor* const matrix, int s, int c, i
 static inline void spinor_set_elem_linear(spinor* const matrix, int sc, const double rein, const double imin){
   switch(sc){
     case 0:
-      *(reinterpret_cast<double*const>(&(matrix->s0.c0))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s0.c0))+1) = imin;
+      *(((double*const)(&(matrix->s0.c0)))  ) = rein;
+      *(((double*const)(&(matrix->s0.c0)))+1) = imin;
       break;
     case 1:
-      *(reinterpret_cast<double*const>(&(matrix->s0.c1))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s0.c1))+1) = imin;
+      *(((double*const)(&(matrix->s0.c1)))  ) = rein;
+      *(((double*const)(&(matrix->s0.c1)))+1) = imin;
       break;
     case 2:
-      *(reinterpret_cast<double*const>(&(matrix->s0.c2))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s0.c2))+1) = imin;
+      *(((double*const)(&(matrix->s0.c2)))  ) = rein;
+      *(((double*const)(&(matrix->s0.c2)))+1) = imin;
       break;
     case 3:
-      *(reinterpret_cast<double*const>(&(matrix->s1.c0))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s1.c0))+1) = imin;
+      *(((double*const)(&(matrix->s1.c0)))  ) = rein;
+      *(((double*const)(&(matrix->s1.c0)))+1) = imin;
       break;
     case 4:
-      *(reinterpret_cast<double*const>(&(matrix->s1.c1))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s1.c1))+1) = imin;
+      *(((double*const)(&(matrix->s1.c1)))  ) = rein;
+      *(((double*const)(&(matrix->s1.c1)))+1) = imin;
       break;
     case 5:
-      *(reinterpret_cast<double*const>(&(matrix->s1.c2))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s1.c2))+1) = imin;
+      *(((double*const)(&(matrix->s1.c2)))  ) = rein;
+      *(((double*const)(&(matrix->s1.c2)))+1) = imin;
       break;
     case 6:
-      *(reinterpret_cast<double*const>(&(matrix->s2.c0))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s2.c0))+1) = imin;
+      *(((double*const)(&(matrix->s2.c0)))  ) = rein;
+      *(((double*const)(&(matrix->s2.c0)))+1) = imin;
       break;
     case 7:
-      *(reinterpret_cast<double*const>(&(matrix->s2.c1))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s2.c1))+1) = imin;
+      *(((double*const)(&(matrix->s2.c1)))  ) = rein;
+      *(((double*const)(&(matrix->s2.c1)))+1) = imin;
       break;
     case 8:
-      *(reinterpret_cast<double*const>(&(matrix->s2.c2))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s2.c2))+1) = imin;
+      *(((double*const)(&(matrix->s2.c2)))  ) = rein;
+      *(((double*const)(&(matrix->s2.c2)))+1) = imin;
       break;
     case 9:
-      *(reinterpret_cast<double*const>(&(matrix->s3.c0))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s3.c0))+1) = imin;
+      *(((double*const)(&(matrix->s3.c0)))  ) = rein;
+      *(((double*const)(&(matrix->s3.c0)))+1) = imin;
       break;
     case 10:
-      *(reinterpret_cast<double*const>(&(matrix->s3.c1))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s3.c1))+1) = imin;
+      *(((double*const)(&(matrix->s3.c1)))  ) = rein;
+      *(((double*const)(&(matrix->s3.c1)))+1) = imin;
       break;
     case 11:
-      *(reinterpret_cast<double*const>(&(matrix->s3.c2))  ) = rein;
-      *(reinterpret_cast<double*const>(&(matrix->s3.c2))+1) = imin;
+      *(((double*const)(&(matrix->s3.c2)))  ) = rein;
+      *(((double*const)(&(matrix->s3.c2)))+1) = imin;
       break;
     default:
       exit(-224);


### PR DESCRIPTION
First trajectory with det_monomial works (perfect agreement). After that, it seems that something breaks.

1)  Combined solver_pm_t and solver_params_t (finally!)
2)  Changed how external inverters are called ->
    UseExternalInverter = {qphix,quda,no}, rather than
    Use{Qphix,Quda}Inverter = {yes,no}
3)  QPhiX solver interface can now do solves with external source
    preparation and supports returning the solution to the EO
    preconditioned system or the reconstructed solution, as required.
    Similarly, it can also return the solution to the M M^dag system
    rather than the full solution, as required.
4)  Added external inverter parameter to monomials.
5)  Solver interfaces now also pass through compression and sloppy
    precision, as required.
6)  invert_eo and invert_clover_eo call QPhiX with NULL pointers for the
    even checkerboards, such that tmLQCD can prepare the source.
7)  added support for QPhiX in solve_degenerate
8)  Ugly hack in det_monomial to insert an additional factor of gamma5
    required because QPhiX solves M M^dag rather than {Q^+}{Q^-}
9)  Pass-through of matrix_mult type to invert_qphix_eo. At present this
    is not used, but it might prove necessary in the future. Optionally
    it can be removed at some point.
10) Added "solution_type_t" enum, such that an object calling solvers
    (a monomial or an operator), can tell the solver wrapper whether
    the solution to (M M^dag) x = b is required (TM_SOLUTION_M_MDAG) or
    whether the solution to M x = b should be extracted before the
    solution is returned.