### PR TITLE
Fix issue #393

### DIFF
--- a/operator/D_psi.c
+++ b/operator/D_psi.c
@@ -49,7 +49,7 @@
 #include "boundary.h"
 #include "gamma.h"
 #include "linalg_eo.h"
-#ifdef MPI
+#ifdef TM_USE_MPI
 # include "xchange/xchange.h"
 #endif
 #include "update_backward_gauge.h"
@@ -127,6 +127,9 @@ void D_psi_prec(spinor * const P, spinor * const Q){
 #undef _PSWITCH
 #undef _PTSWITCH
 
+#ifdef TM_USE_OMP
+#  define static
+#endif
 
 /* direction +t */
 void boundary_D_0(spinor * const r, spinor * const s, su3 * const u) {
@@ -312,6 +315,11 @@ void boundary_D_7(spinor * const r, spinor * const s, su3 * restrict u) {
 
   return;
 }
+
+#ifdef TM_USE_OMP
+#  undef static
+#endif
+
 
 // now come the SSE versions
 // currently they are disabled, because incompatible

--- a/operator/D_psi.c
+++ b/operator/D_psi.c
@@ -348,11 +348,11 @@ void Dtm_psi(spinor * const P, spinor * const Q){
   }
 #endif
 
-# if defined MPI
+# if defined TM_USE_MPI
   xchange_lexicfield(Q);
 # endif
 
-#ifdef OMP
+#ifdef TM_USE_OMP
 #pragma omp parallel
   {
 #endif
@@ -365,18 +365,18 @@ void Dtm_psi(spinor * const P, spinor * const Q){
     fact1 = 1. + g_mu * I;
     fact2 = conj(fact1);
 
-#ifndef OMP
+#ifndef TM_USE_OMP
     iy=g_iup[0][0];
     sp=(spinor *) Q + iy;
     up=&g_gauge_field[0][0];
 #endif
 
     /************************ loop over all lattice sites *************************/
-#ifdef OMP
+#ifdef TM_USE_OMP
 #pragma omp for
 #endif
     for (ix=0;ix<VOLUME;ix++){
-#ifdef OMP
+#ifdef TM_USE_OMP
       iy=g_iup[ix][0];
       up=&g_gauge_field[ix][0];
       sp=(spinor *) Q + iy;
@@ -727,7 +727,7 @@ void Dtm_psi(spinor * const P, spinor * const Q){
       /******************************** end of loop *********************************/
 
     }
-#ifdef OMP
+#ifdef TM_USE_OMP
   } /* OpenMP closing brace */
 #endif
 }
@@ -747,11 +747,11 @@ void Dsw_psi(spinor * const P, spinor * const Q){
   }
 #endif
 
-# if defined MPI
+# if defined TM_USE_MPI
   xchange_lexicfield(Q);
 # endif
 
-#ifdef OMP
+#ifdef TM_USE_OMP
 #pragma omp parallel
   {
 #endif
@@ -760,18 +760,18 @@ void Dsw_psi(spinor * const P, spinor * const Q){
     spinor *s,*sp,*sm,*rn;
     spinor ALIGN stmp,rs;
 
-#ifndef OMP
+#ifndef TM_USE_OMP
     iy=g_iup[0][0];
     sp=(spinor *) Q + iy;
     up=&g_gauge_field[0][0];
 #endif
 
     /************************ loop over all lattice sites *************************/
-#ifdef OMP
+#ifdef TM_USE_OMP
 #pragma omp for
 #endif
     for (ix=0;ix<VOLUME;ix++){
-#ifdef OMP
+#ifdef TM_USE_OMP
       iy=g_iup[ix][0];
       up=&g_gauge_field[ix][0];
       sp=(spinor *) Q + iy;
@@ -1117,7 +1117,7 @@ void Dsw_psi(spinor * const P, spinor * const Q){
       /******************************** end of loop *********************************/
 
     }
-#ifdef OMP
+#ifdef TM_USE_OMP
   } /* OpenMP closing brace */
 #endif
 }


### PR DESCRIPTION
This is a fix to issue #393.

    The problem are the explicit SSE version of non-even/odd D_psi and
    Dsw_psi.
    The only feasible workaround at the moment is to disable SSE2|3 in
    D_psi.
    This will not affect the even/odd versions, which are still available
    in SSE2|3.
    
    In the future we'll remove these macros completely.
