### PR TITLE
propagate QPhiX changs toe offline_measurement executable and fix the…

### DIFF
--- a/meas/correlators.c
+++ b/meas/correlators.c
@@ -123,7 +123,7 @@ void correlators_measurement(const int traj, const int id, const int ieo) {
 #endif
       if(g_debug_level > 1 && g_proc_id == 0) {
         printf("# timeslice set to %d (T=%d) for online measurement\n", t0, g_nproc_t*T);
-        printf("# online measurements parameters: kappa = %g, mu = %g\n", optr->kappa, optr->mu/2./optr->kappa);
+        printf("# online measurements parameters: kappa = %.12f, mu = %.12f\n", optr->kappa, optr->mu/2./optr->kappa);
       }
       atime = gettime();
 

--- a/meas/measurements.c
+++ b/meas/measurements.c
@@ -61,15 +61,11 @@ int init_measurements(){
     if(measurement_list[i].type == ONLINE) {
       measurement_list[i].measurefunc = &correlators_measurement;
       measurement_list[i].max_source_slice = g_nproc_t*T;
-      measurement_list[i].no_samples = 1;
-      measurement_list[i].all_time_slices = 0;
     }
 
     if(measurement_list[i].type == PIONNORM) {
       measurement_list[i].measurefunc = &pion_norm_measurement;
       measurement_list[i].max_source_slice = g_nproc_z*LZ;
-      measurement_list[i].no_samples = 1;
-      measurement_list[i].all_time_slices = 0;
     }
     
     if(measurement_list[i].type == POLYAKOV) {

--- a/offline_measurement.c
+++ b/offline_measurement.c
@@ -38,7 +38,7 @@
 #endif
 #ifdef TM_USE_OMP
 # include <omp.h>
-#endif
+#endif 
 #include "global.h"
 #include "git_hash.h"
 #include "getopt.h"
@@ -79,6 +79,15 @@
 #include "operator/tm_operators.h"
 #include "operator/Dov_psi.h"
 #include "gettime.h"
+#ifdef TM_USE_QUDA
+#  include "quda_interface.h"
+#endif
+#ifdef TM_USE_QPHIX
+#  include "qphix_interface.h"
+#endif
+#ifdef DDalphaAMG
+#  include "DDalphaAMG_interface.h"
+#endif
 #include "meas/measurements.h"
 
 extern int nstore;
@@ -119,32 +128,9 @@ int main(int argc, char *argv[])
   verbose = 0;
   g_use_clover_flag = 0;
 
-#ifdef TM_USE_MPI
-
-#  ifdef TM_USE_OMP
-  int mpi_thread_provided;
-  MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &mpi_thread_provided);
-#  else
-  MPI_Init(&argc, &argv);
-#  endif
-
-  MPI_Comm_rank(MPI_COMM_WORLD, &g_proc_id);
-#else
-  g_proc_id = 0;
-#endif
-
   process_args(argc,argv,&input_filename,&filename);
   set_default_filenames(&input_filename, &filename);
-
-  /* Read the input file */
-  if( (j = read_input(input_filename)) != 0) {
-    fprintf(stderr, "Could not find input file: %s\nAborting...\n", input_filename);
-    exit(-1);
-  }
-
-#ifdef TM_USE_OMP
-  init_openmp();
-#endif
+  init_parallel_and_read_input(argc, argv, input_filename);
 
   /* this DBW2 stuff is not needed for the inversion ! */
   if (g_dflgcr_flag == 1) {

--- a/offline_measurement.c
+++ b/offline_measurement.c
@@ -38,7 +38,7 @@
 #endif
 #ifdef TM_USE_OMP
 # include <omp.h>
-#endif 
+#endif
 #include "global.h"
 #include "git_hash.h"
 #include "getopt.h"


### PR DESCRIPTION
… setting of the correlators parameters 'no_samples' and 'all_time_slices', which were overridden in init_measurements