### PR TITLE
tmLQCD_invert_init should return if the input file cannot be found

### DIFF
--- a/include/tmLQCD.h
+++ b/include/tmLQCD.h
@@ -29,9 +29,6 @@
 
 #include "config.h"
 
-#include "struct_accessors.h"
-#include "global.h"
-
 #ifdef __cplusplus
 extern "C"
 {

--- a/include/tmLQCD.h
+++ b/include/tmLQCD.h
@@ -29,6 +29,9 @@
 
 #include "config.h"
 
+#include "struct_accessors.h"
+#include "global.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/wrapper/lib_wrapper.c
+++ b/wrapper/lib_wrapper.c
@@ -97,6 +97,7 @@ int tmLQCD_invert_init(int argc, char *argv[], const int _verbose, const int ext
   /* Read the input file */
   if( (read_input("invert.input")) != 0) {
     fprintf(stderr, "tmLQCD_init_invert: Could not find input file: invert.input\nAborting...");
+    return(-1);
   }
 
 #ifndef TM_USE_MPI


### PR DESCRIPTION
expose global.h and struct_accessors.h through tmLQCD.h, return error state in lib_wrapper if invert.input cannot be found

