### PR TITLE
using tmLQCD via libwrapper leads to inconsistent nstore

### DIFF
--- a/wrapper/lib_wrapper.c
+++ b/wrapper/lib_wrapper.c
@@ -223,6 +223,10 @@ int tmLQCD_read_gauge(const int nconfig) {
     printf("# Finished reading gauge field.\n");
     fflush(stdout);
   }
+
+  // set the global nstore parameter
+  nstore = nconfig;
+
 #ifdef TM_USE_MPI
   if(!lowmem_flag){
     xchange_gauge(g_gauge_field);


### PR DESCRIPTION
When used as a library, the gauge field can be loaded via the external application by passing an integer configuration number to ```tmLQCD_read_gauge```. Unfortunately, doing so does not set ```nstore```and thus tmLQCD may be left in an inconsistent state.