### PR TITLE
in line with our requirement for a c99 compiler, remove hand-written …

### DIFF
--- a/io/utils.h
+++ b/io/utils.h
@@ -35,17 +35,6 @@
 #include <io/dml.h>
 
 
-#ifndef isnan
-
-# define isnan(x)						\
-  ( ( sizeof(x) == sizeof(long double) ) ? isnan_ld(x)		\
-    : ( ( sizeof(x) == sizeof(double) ) ? isnan_d(x)		\
-                                        : isnan_f (x)           \
-      )                                                         \
-  )
-
-#endif
-
 /* These are factory functions, since the constructors for c-lime and lemon are different
    and they need different ways of opening files. Moving this to utility functions unclutters
    the main code, since we don't need additional #ifdefs anymore.


### PR DESCRIPTION
…isnan macro because it may lead to hard-to-diagnose build errors