### PR TITLE
Do MPI initialisation in tmLQCD_invert_init

### DIFF
--- a/include/tmLQCD.h
+++ b/include/tmLQCD.h
@@ -41,6 +41,11 @@ extern "C"
   typedef struct {
     unsigned int nproc, nproc_t, nproc_x, nproc_y, nproc_z, cart_id, proc_id, time_rank, omp_num_threads;
     unsigned int proc_coords[4];
+#ifdef TM_USE_MPI
+    MPI_Comm cart_grid;
+#else
+    int cart_grid;
+#endif
   } tmLQCD_mpi_params;
 
   int tmLQCD_invert_init(int argc, char *argv[], const int verbose, const int external_id);

--- a/wrapper/lib_wrapper.c
+++ b/wrapper/lib_wrapper.c
@@ -370,7 +370,9 @@ int tmLQCD_get_mpi_params(tmLQCD_mpi_params * params) {
   params->proc_coords[1] = g_proc_coords[1];
   params->proc_coords[2] = g_proc_coords[2];
   params->proc_coords[3] = g_proc_coords[3];
-
+#ifdef TM_USE_MPI
+  params->cart_grid = g_cart_grid;
+#endif
   return(0);
 }
 

--- a/xchange/xchange_deri.c
+++ b/xchange/xchange_deri.c
@@ -38,7 +38,7 @@
 #include "su3adj.h"
 #include "xchange_deri.h"
 
-inline void addup_ddummy(su3adj** const df, const int ix, const int iy) {
+static inline void addup_ddummy(su3adj** const df, const int ix, const int iy) {
   for(int mu = 0; mu < 4; mu++) {
     df[ix][mu].d1 += ddummy[iy][mu].d1;
     df[ix][mu].d2 += ddummy[iy][mu].d2;


### PR DESCRIPTION
It seems that having tmLQCD initialise MPI will be beneficial at least for the design of some programs (CVC for example).

@sunpho84 How would this change affect Nissa? I would like to find a compromise which works for all (potential) client codes, but someone needs to call MPI_Init. There's a change about to land which allows runtime selection of the MPI thread level.