### PR TITLE
bug fix: wrong plaquette in metadata just after reversibility check

### DIFF
--- a/update_tm.c
+++ b/update_tm.c
@@ -188,7 +188,7 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
     }
     if(accept) {
       /* save gauge file to disk before performing reversibility check */
-      xlfInfo = construct_paramsXlfInfo((*plaquette_energy)/(6.*VOLUME*g_nproc), traj_counter);
+      xlfInfo = construct_paramsXlfInfo((new_plaquette_energy)/(6.*VOLUME*g_nproc), traj_counter);
       // Should write this to temporary file first, and then check
       if(g_proc_id == 0 && g_debug_level > 0) {
         fprintf(stdout, "# Writing gauge field to file %s.\n", tmp_filename);


### PR DESCRIPTION
The xlf-info LIME record contained a wrong value of the plaquette when the reversibility check occurs.
To reproduce it, take for instance "sample-input/sample-hmc0.input" and set (to make it simpler and faster) for instance:
Measurements = 11
ReversibilityCheckIntervall = 10

The plaquette value in the "xlf-info" header of the resulting conf is wrong (it corresponds to the plaquette computed on the reversed trajectory).
I checked that the averaged plaquette computed and the value written in "output.data" agree and both disagree with the value in the "xlf-info".