### PR TITLE
no_eigenvalues already defined extern in the related header

### DIFF
--- a/solver/eigenvalues.c
+++ b/solver/eigenvalues.c
@@ -58,7 +58,7 @@ double * eigenvls = NULL;
 double max_eigenvalue;
 double * inv_eigenvls = NULL;
 int eigenvalues_for_cg_computed = 0;
-int no_eigenvalues, evlength;
+int evlength;
 
 /* the folowing two are needed for the overlap */
 double ev_minev=-1., ev_qnorm=-1.;


### PR DESCRIPTION
Fix this
```
/usr/bin/ld: ./lib/libsolver.a(eigenvalues.o):/home/francesco/QCD/SORGENTI/tmLQCD/build_quda/solver/../../solver/eigenvalues.c:61: multiple definition of `no_eigenvalues'; ./lib/libhmc.a(read_input.o):/home/francesco/QCD/SORGENTI/tmLQCD/build_quda/../read_input.l:222: first defined here
```