### PR TITLE
re-expose refinenement precision

### DIFF
--- a/invert_doublet_eo.c
+++ b/invert_doublet_eo.c
@@ -86,7 +86,7 @@ int invert_doublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
                                    Even_s, Odd_s, Even_c, Odd_c,
                                    precision, max_iter,
                                    solver_flag, rel_prec, even_odd_flag,
-                                   sloppy, compression );
+                                   sloppy, solver_params.refinement_precision, compression );
   }
 #endif
 
@@ -223,7 +223,7 @@ int invert_cloverdoublet_eo(spinor * const Even_new_s, spinor * const Odd_new_s,
                                    Even_s, Odd_s, Even_c, Odd_c,
                                    precision, max_iter,
                                    solver_flag, rel_prec, even_odd_flag,
-                                   sloppy, compression );
+                                   sloppy, solver_params.refinement_precision, compression );
   }
 #endif
 

--- a/monomial/monomial.c
+++ b/monomial/monomial.c
@@ -114,6 +114,7 @@ int add_monomial(const int type) {
   monomial_list[no_monomials].solver_params.external_inverter = _default_external_inverter;
   monomial_list[no_monomials].solver_params.sloppy_precision = _default_operator_sloppy_precision_flag;
   monomial_list[no_monomials].external_library = _default_external_library;
+  monomial_list[no_monomials].solver_params.refinement_precision = _default_operator_sloppy_precision_flag;
   monomial_list[no_monomials].even_odd_flag = _default_even_odd_flag;
   monomial_list[no_monomials].forcefactor = 1.;
   monomial_list[no_monomials].use_rectangles = 0;

--- a/operator.c
+++ b/operator.c
@@ -91,6 +91,7 @@ int add_operator(const int type) {
   optr->mu = _default_g_mu;
   optr->c_sw = _default_c_sw;
   optr->sloppy_precision = _default_operator_sloppy_precision_flag;
+  optr->solver_params.refinement_precision = _default_operator_sloppy_precision_flag;
   optr->compression_type = _default_compression_type;
   optr->external_inverter = _default_external_inverter;
   optr->solver_params.solution_type = TM_SOLUTION_M;

--- a/quda_interface.h
+++ b/quda_interface.h
@@ -136,6 +136,7 @@ int invert_doublet_eo_quda(spinor * const Even_new_s, spinor * const Odd_new_s,
                            const double precision, const int max_iter,
                            const int solver_flag, const int rel_prec, const int even_odd_flag,
                            const SloppyPrecision sloppy_precision,
+                           const SloppyPrecision refinement_precision,
                            CompressionType compression);
 
 // apply the TM operator using QUDA

--- a/read_input.l
+++ b/read_input.l
@@ -1370,6 +1370,22 @@ static inline double fltlist_next_token(int * const list_end){
     if(myverbose) printf("  Use sloppy precision (half) in the inverter (if supported by the inverter) line %d operator %d\n", line_of_file, current_operator);
     optr->sloppy_precision = SLOPPY_HALF;
   }
+  {SPC}*RefinementPrecision{EQL}float {
+    optr->solver_params.refinement_precision = SLOPPY_SINGLE;
+    if(myverbose!=0) printf("  Refinement precision (if supported by the chosen solver) set to single precision line %d operator %d\n", line_of_file, current_operator);
+  }
+  {SPC}*RefinementPrecision{EQL}single {
+    optr->solver_params.refinement_precision = SLOPPY_SINGLE;
+    if(myverbose!=0) printf("  Refinement precision (if supported by the chosen solver) set to single precision line %d operator %d\n", line_of_file, current_operator);
+  }
+  {SPC}*RefinementPrecision{EQL}half {
+    optr->solver_params.refinement_precision = SLOPPY_HALF;
+    if(myverbose!=0) printf("  Refinement precision (if supported by the chosen solver) set to half precision line %d operator %d\n", line_of_file, current_operator);
+  }
+  {SPC}*RefinementPrecision{EQL}double {
+    optr->solver_params.refinement_precision = SLOPPY_DOUBLE;
+    if(myverbose!=0) printf("  Refinement precision (if supported by the chosen solver) set to double precision line %d operator %d\n", line_of_file, current_operator);
+  }
   {SPC}*UseCompression{EQL}12 {
     if(myverbose) printf("  Use 12 compression in the inverter (if supported) line %d operator %d\n", line_of_file, current_operator);
     optr->compression_type = COMPRESSION_12;
@@ -2536,6 +2552,22 @@ static inline double fltlist_next_token(int * const list_end){
     sscanf(yytext, " %[a-zA-Z] = %d", name, &a);
     mnl->rat.order = a;
     if(myverbose!=0) printf("  Degree of rational approximation set to %d line %d monomial %d\n", a, line_of_file, current_monomial);
+  }
+  {SPC}*RefinementPrecision{EQL}float {
+    mnl->solver_params.refinement_precision = SLOPPY_SINGLE;
+    if(myverbose!=0) printf("  Refinement precision (if supported by the chosen solver) set to single precision line %d monomial %d\n", line_of_file, current_monomial);
+  }
+  {SPC}*RefinementPrecision{EQL}single {
+    mnl->solver_params.refinement_precision = SLOPPY_SINGLE;
+    if(myverbose!=0) printf("  Refinement precision (if supported by the chosen solver) set to single precision line %d monomial %d\n", line_of_file, current_monomial);
+  }
+  {SPC}*RefinementPrecision{EQL}half {
+    mnl->solver_params.refinement_precision = SLOPPY_HALF;
+    if(myverbose!=0) printf("  Refinement precision (if supported by the chosen solver) set to half precision line %d monomial %d\n", line_of_file, current_monomial);
+  }
+  {SPC}*RefinementPrecision{EQL}double {
+    mnl->solver_params.refinement_precision = SLOPPY_DOUBLE;
+    if(myverbose!=0) printf("  Refinement precision (if supported by the chosen solver) set to double precision line %d monomial %d\n", line_of_file, current_monomial);
   }
 }
 <NDPOLYMONOMIAL,CLPOLYMONOMIAL,NDRATMONOMIAL,NDRATCORMONOMIAL,NDCLRATMONOMIAL,NDCLRATCORMONOMIAL,RATMONOMIAL,RATCORMONOMIAL,CLRATMONOMIAL,CLRATCORMONOMIAL>{

--- a/solver/solver_params.h
+++ b/solver/solver_params.h
@@ -94,6 +94,7 @@ typedef struct {
   
   CompressionType compression_type;
   SloppyPrecision sloppy_precision;
+  SloppyPrecision refinement_precision;
   ExternalInverter external_inverter;
 
   int use_initial_guess;  


### PR DESCRIPTION
Add back support for writing something like

```
BeginMonomial NDCLOVERRAT
  Timescale = 1
  kappa = 0.1400645
  CSW = 1.74
  AcceptancePrecision =  1e-21
  ForcePrecision = 1e-16
  StildeMin = 0.0000376
  StildeMax = 4.7
  MaxSolverIterations = 500
  Name = ndcloverrat_0_3
  DegreeOfRational = 10
  Cmin = 0
  Cmax = 3
  ComputeEVFreq = 0
  2Kappamubar = 0.0394421632
  2Kappaepsbar = 0.0426076209
  AddTrLog = yes
  UseExternalInverter = quda
  UseSloppyPrecision = single
  RefinementPrecision = half    # <- refinement precision                                                                                                                                                                                                                                                
  solver = cgmmsnd
EndMonomial
```

which allows the multi-shift solver to run up to single precision and then refines any unconverged shifts using double-half mixed CG, leading to another 20-25% improvement in time to solution for those monomials.
