### PR TITLE
Ensure gauge_id member is initialized when the gauge_status is created

### DIFF
--- a/misc_types.h
+++ b/misc_types.h
@@ -159,6 +159,7 @@ static inline tm_GaugeState_t new_tm_GaugeState(const char * const name) {
   tm_GaugeState_t ret;
   ret.loaded = 0;
   ret.halo_state.exchanged = 0;
+  ret.gauge_id = 0;
   snprintf(ret.name, TM_GAUGE_FIELD_NAME_LENGTH, "%s", name);
   return(ret);
 }


### PR DESCRIPTION
I'm in the process o fixing a nasty segmentation fault that arises in random places around. With the help of @Marcogarofalo 
I've managed to run the code under valgrind, and I'm proceeding to fix each complain in turn, this is the first one

```
==20258== Use of uninitialised value of size 8
==20258==    at 0xBD369EC: __printf_fp_l (in /usr/lib64/power9/libc-2.28.so)
==20258==    by 0x1FFF007AAF: ???
==20258==    by 0xBD32623: printf_positional (in /usr/lib64/power9/libc-2.28.so)
==20258==    by 0xBD33BDF: vfprintf@@GLIBC_2.17 (in /usr/lib64/power9/libc-2.28.so)
==20258==    by 0x10045397: vprintf (stdio.h:41)
==20258==    by 0x10045397: tm_debug_printf (tm_debug_printf.c:35)
==20258==    by 0x100481F7: _loadGaugeQuda (quda_interface.c:565)
==20258==    by 0x1004BDB3: invert_eo_degenerate_quda (quda_interface.c:2062)
==20258==    by 0x1013FB13: solve_degenerate (monomial_solve.c:127)
==20258==    by 0x100775A7: cloverdetratio_heatbath (cloverdetratio_monomial.c:287)
==20258==    by 0x100366A3: update_tm (update_tm.c:130)
==20258==    by 0x1000758F: main (hmc_tm.c:402)
==20258==  Uninitialised value was created by a stack allocation
==20258==    at 0x10150A18: init_global_states (init_global_states.c:25)
```

My understanding is that the `gauge_id` is not set to zero right where it should (at the creation of the state), but a complicated mechanism is in place.  The `gauge_id` is referred in several places (some of clearly harmless, some of which possibly harmful)