### PR TITLE
mg_eig_preserve_deflation does not need to guarded any more

### DIFF
--- a/quda_interface.c
+++ b/quda_interface.c
@@ -1559,11 +1559,9 @@ void _updateQudaMultigridPreconditioner(){
     tm_stopwatch_push(&g_timers, "MG_Preconditioner_Setup_Update", "");
 
     tm_debug_printf(0,0,"# TM_QUDA: Updating MG Preconditioner Setup for gauge_id: %f\n", quda_gauge_state.gauge_id);
-#ifdef TM_QUDA_EXPERIMENTAL
     if( quda_input.mg_eig_preserve_deflation == QUDA_BOOLEAN_YES ){
       tm_debug_printf(0,0,"# TM_QUDA: Deflation subspace for gauge_id: %f will be re-used!\n", quda_gauge_state.gauge_id);
     }
-#endif
 
     updateMultigridQuda(quda_mg_preconditioner, &quda_mg_param);
 
@@ -1823,9 +1821,7 @@ void _setQudaMultigridParam(QudaMultigridParam* mg_param) {
   QudaInvertParam * mg_inv_param = mg_param->invert_param;
   _setMGInvertParam(mg_inv_param, &inv_param);
 
-#ifdef TM_QUDA_EXPERIMENTAL
   mg_param->preserve_deflation = quda_input.mg_eig_preserve_deflation;
-#endif
 
   mg_param->n_level = quda_input.mg_n_level;
   for (int level=0; level < mg_param->n_level; level++) {

--- a/read_input.l
+++ b/read_input.l
@@ -1970,24 +1970,12 @@ static inline double fltlist_next_token(int * const list_end){
     free(input_copy);
   }
   {SPC}*MGEigPreserveDeflationSubspace{EQL}yes {
-#ifdef TM_QUDA_EXPERIMENTAL
     quda_input.mg_eig_preserve_deflation = QUDA_BOOLEAN_YES;
     if(myverbose) printf("  MGEigPreserveDeflationSubspace set to YES in line %d\n", line_of_file);
-#else
-    char error_message[ERR_MSG_LEN];
-    snprintf(error_message, ERR_MSG_LEN, "You attempted to set 'MGEigPreserveDeflationSubspace' even though tmLQCD was compiled with '--disable-quda-experimental'. In order to use experimental QUDA features, tmLQCD must be compiled with '--enable-quda-experimental'");
-    yy_fatal_error(error_message);
-#endif
   }
   {SPC}*MGEigPreserveDeflationSubspace{EQL}no {
-#ifdef TM_QUDA_EXPERIMENTAL
     quda_input.mg_eig_preserve_deflation = QUDA_BOOLEAN_YES;
     if(myverbose) printf("  MGEigPreserveDeflationSubspace set to YES in line %d\n", line_of_file);
-#else
-    char error_message[ERR_MSG_LEN];
-    snprintf(error_message, ERR_MSG_LEN, "You attempted to set 'MGEigPreserveDeflationSubspace' even though tmLQCD was compiled with '--disable-quda-experimental'. In order to use experimental QUDA features, tmLQCD must be compiled with '--enable-quda-experimental'");
-    yy_fatal_error(error_message);
-#endif
   }
   {SPC}*MGEigSolverCoarseGuess{EQL}yes {
     quda_input.mg_coarse_guess = QUDA_BOOLEAN_YES;


### PR DESCRIPTION
mg_eig_preserve_deflation is now supported even in QUDA-1.1.x, no need to guard it with TM_QUDA_EXPERIMENTAL