### PR TITLE
change mechanism by which QUDA MG state's dependence on state of gauge (and clover) field is tracked

### DIFF
--- a/gettime.c
+++ b/gettime.c
@@ -87,7 +87,9 @@ void tm_stopwatch_push(tm_timers_t * const timers, const char * const name, cons
   }
   timers->t[++(timers->lvl)] = gettime();
   if( strcmp(name, "") == 0 ){
-    fatal_error("name may not be empty!", __func__);
+    char msg[200];
+    snprintf(msg, 200, "name may not be empty! (group: %s)", group);
+    fatal_error(msg, __func__);
   } else {
     const int empty_group = strcmp(group, "") == 0;
     snprintf(timers->callstack[timers->lvl], TM_TIMING_STACK_PATH_LENGTH,

--- a/monomial/detratio_monomial.c
+++ b/monomial/detratio_monomial.c
@@ -226,7 +226,7 @@ void detratio_heatbath(const int id, hamiltonian_field_t * const hf) {
   mnl->iter0 = 0;
   mnl->iter1 = 0;
   if(mnl->even_odd_flag) {
-    tm_stopwatch_push(&g_timers, "", "random_energy0");
+    tm_stopwatch_push(&g_timers, "random_energy0", "");
     random_spinor_field_eo(mnl->w_fields[0], mnl->rngrepro, RN_GAUSS);
     mnl->energy0  = square_norm(mnl->w_fields[0], VOLUME/2, 1);
     tm_stopwatch_pop(&g_timers, 0, 1, "");


### PR DESCRIPTION
This fixes one more bug due to which yet another instance of a dangling pointer in the MG Setup is resolved. This re-appared due to fixing another part of the logic through 221bf0980da0128df8d9f2702f65f7ab1cc19c69).

As a nice side effect, it reduces the number of Setup updates that should occur during the HMC (the setup will only be updated when necessary).