### PR TITLE
tables position within same section + caption

### DIFF
--- a/profiling/hmc_mk2/profile.Rmd
+++ b/profiling/hmc_mk2/profile.Rmd
@@ -196,7 +196,9 @@ for( mon in total_per_mon$monomial ){
                      format = 'latex',
                      booktabs = TRUE,
                      digits = 1,
-                     linesep = "") %>%
+                     linesep = "",
+                     caption = sprintf("%s %s", mon, tp) ) %>%
+          kable_styling(latex_options = "HOLD_position") %>%
         kableExtra::kable_styling(latex_options = c("striped"),
                                   stripe_index = which( (type_data$level %% 2) == 1 ))
     )


### PR DESCRIPTION
I found confusing in the profile tool the position of the tables
![example_table_out_section](https://user-images.githubusercontent.com/9364983/157454789-bfe5e17f-b4d6-48b1-87cf-d00126caf7a5.png)

so I did two things:
- Force the table to be placed in the same subsection;
- Add a caption to the table.

the result is now the following
![image](https://user-images.githubusercontent.com/9364983/157456230-ea11be3b-fb36-4126-9587-04ea2e811c42.png)

