### PR TITLE
Quda regenerate mg setup

### DIFF
--- a/quda_interface.c
+++ b/quda_interface.c
@@ -2182,9 +2182,8 @@ int invert_eo_degenerate_quda(spinor * const out,
 
     if (solver_flag == MG) {
       // re-running (once) the inversion which failed
-      if (quda_mg_setup_state->force_reset == 0) {
-        quda_mg_setup_state->force_reset = 1;
-        _updateQudaMultigridPreconditioner();  // regenerate the MG setup
+      if (quda_mg_setup_state.force_reset == 0) {
+        quda_mg_setup_state.force_reset = 1;
         return invert_eo_degenerate_quda(out, in, precision, max_iter, solver_flag, rel_prec,
                                          even_odd_flag, solver_params, sloppy_precision,
                                          compression, QpQm);
@@ -2195,10 +2194,6 @@ int invert_eo_degenerate_quda(spinor * const out,
       }
     }
     return (-1);
-  } else {
-    if (g_proc_id == 0) {
-      quda_mg_inversion_failed = 0; // resetting for the next solver call
-    }
   }
 
   return(iterations);

--- a/quda_interface.c
+++ b/quda_interface.c
@@ -2239,6 +2239,10 @@ int invert_eo_degenerate_quda(spinor * const out,
       }
     }
     return (-1);
+  } else {
+    if (g_proc_id == 0) {
+      quda_mg_inversion_failed = 0; // resetting for the next solver call
+    }
   }
 
   return(iterations);
@@ -2340,6 +2344,10 @@ int invert_eo_quda_oneflavour_mshift(spinor ** const out,
       }
     }
     return(-1);
+  } else {
+    if (g_proc_id == 0) {
+      quda_mg_inversion_failed = 0; // resetting for the next solver call
+    }
   }
 
   return(iterations);
@@ -2470,6 +2478,10 @@ int invert_eo_quda_twoflavour_mshift(spinor ** const out_up, spinor ** const out
       }
     }
     return(-1);
+  } else {
+    if (g_proc_id == 0) {
+      quda_mg_inversion_failed = 0; // resetting for the next solver call
+    }
   }
 
   return(iterations);

--- a/quda_interface.c
+++ b/quda_interface.c
@@ -2191,7 +2191,8 @@ int invert_eo_degenerate_quda(spinor * const out,
     if (solver_flag == MG) {
       // when the MG fails to converge, the reason may be a degenerated MG setup
       // or, if this happens in the HMC, bad luck with the evolved setup
-      // we try to regenerate it once and abort if that doesn't help
+      // we try to force refresh it once and abort if that doesn't help
+
       // we use this variable to break out of the recursion 
       static int quda_mg_setup_was_force_refreshed = 0;
       if( quda_mg_setup_was_force_refreshed == 0 ){

--- a/quda_interface.c
+++ b/quda_interface.c
@@ -1543,15 +1543,7 @@ void _updateQudaMultigridPreconditioner(){
     }
     inv_param.preconditioner = quda_mg_preconditioner;
 
-    // during a force reset we only update the parameters tracked in the MG state
-    // this is in order to not disrupt the normal sequence of update and refresh 
-    // operations as a function of the gauge_id
-    if(quda_mg_setup_state.force_refresh == 1){
-      quda_mg_setup_state_update(&quda_mg_setup_state, &quda_gauge_state, &quda_clover_state,
-                                 g_mu, g_kappa, g_c_sw);
-    } else {
-      set_quda_mg_setup_state(&quda_mg_setup_state, &quda_gauge_state, &quda_clover_state);
-    }
+    set_quda_mg_setup_state(&quda_mg_setup_state, &quda_gauge_state, &quda_clover_state);
 
     tm_stopwatch_pop(&g_timers, 0, 1, "TM_QUDA");
 

--- a/quda_interface.c
+++ b/quda_interface.c
@@ -2182,17 +2182,20 @@ int invert_eo_degenerate_quda(spinor * const out,
 
     if (solver_flag == MG) {
       // re-running (once) the inversion which failed
-      if (quda_mg_setup_state.force_reset == 0) {
-        quda_mg_setup_state.force_reset = 1;
-        return invert_eo_degenerate_quda(out, in, precision, max_iter, solver_flag, rel_prec,
-                                         even_odd_flag, solver_params, sloppy_precision,
-                                         compression, QpQm);
-      } else {  // abort if the inversion failed too many times
+      quda_mg_setup_state.force_reset = 1;
+      size_t ret_value = invert_eo_degenerate_quda(out, in, precision, max_iter, solver_flag,
+                                                   rel_prec, even_odd_flag, solver_params,
+                                                   sloppy_precision, compression, QpQm);
+      if (ret_value == -1) {  // abort if the inversion failed too many times
         fatal_error("MG solver failed for more than 2 times in a row.",
                     "invert_eo_degenerate_quda");
         return (-1);
+      } else {  // reset of MG worked. Restoring initial value of 'force_reset'
+        quda_mg_setup_state.force_reset = 0;
+        return ret_value;
       }
     }
+
     return (-1);
   }
 

--- a/quda_interface.c
+++ b/quda_interface.c
@@ -144,6 +144,12 @@ void* quda_mg_preconditioner;
 // on the given level)
 QudaEigParam mg_eig_param[QUDA_MAX_MG_LEVEL];
 
+/**
+ * When using the quda MG solver, this variable stores the number of failed inversions.
+ * It is used in order to decide how many times to retry the inversion after regenerating the MG setup.
+ */
+int quda_mg_inversion_failed = 0;
+
 // input params specific to tmLQCD QUDA interface
 tm_QudaParams_t quda_input;
 
@@ -184,6 +190,14 @@ void _setOneFlavourSolverParam(const double kappa, const double c_sw, const doub
                                const int solver_type, const int even_odd,
                                const double eps_sq, const int maxiter,
                                const int single_parity_solve, const int QpQm);
+
+/**
+ * Regenerate the MG setup. To be used e.g. when an MG-based solver in doesn't converge.
+ * @param mg_param Contains all metadata regarding host and device
+   *               storage and solver parameters
+ */
+void forceRegenerateMGSetupQuda(const CompressionType compression);
+
 
 void set_default_gauge_param(QudaGaugeParam * gauge_param){
   // local lattice size
@@ -2052,6 +2066,32 @@ void _setQudaMultigridParam(QudaMultigridParam* mg_param) {
   strcpy(mg_param->vec_outfile, "");
 }
 
+void forceRegenerateMGSetupQuda(const CompressionType compression){
+    if(g_proc_id == 0){ printf("# Regenerating the MG setup."); }
+
+    // calling loadGaugeQuda() just in case it hasn't been caled before
+    _loadGaugeQuda(compression);
+
+    // destroying the MG setup
+    if( quda_mg_preconditioner != NULL ){
+      destroyMultigridQuda(quda_mg_preconditioner);
+      quda_mg_preconditioner = NULL;
+    }
+    reset_quda_mg_setup_state(&quda_mg_setup_state);
+
+    // setup the MG according to the parameters in 'param'
+    mg_inv_param = newQudaInvertParam();
+    quda_mg_param = newQudaMultigridParam();
+    for( int level = 0; level < QUDA_MAX_MG_LEVEL; ++level ){
+      mg_eig_param[level] = newQudaEigParam();
+    }
+    newMultigridQuda(&quda_mg_param);
+    
+    return;
+}
+
+
+
 int invert_eo_degenerate_quda(spinor * const out,
                               spinor * const in,
                               const double precision, const int max_iter,
@@ -2175,8 +2215,31 @@ int invert_eo_degenerate_quda(spinor * const out,
 
   tm_stopwatch_pop(&g_timers, 0, 0, "TM_QUDA");
 
-  if(iterations >= max_iter)
-    return(-1);
+  if (iterations >= max_iter) {
+    if (g_proc_id == 0) {
+      printf("# TM_QUDA: iterations == -1\n");
+    }
+    if (solver_flag == MG) {
+      // re-running the inversion which failed
+      if (g_proc_id == 0) {
+        quda_mg_inversion_failed += 1;
+      }
+
+      if (quda_mg_inversion_failed < 2) {
+        forceRegenerateMGSetupQuda(compression);  // regenerate the MG setup
+        return invert_eo_degenerate_quda(out, in, precision, max_iter, solver_flag, rel_prec,
+                                  even_odd_flag, solver_params, sloppy_precision, compression,
+                                  QpQm);
+      } else {  // abort if the inversion failed too many times
+        if (g_proc_id == 0) {
+          fatal_error("MG solver failed for more than 2 times in a row.",
+                      "invert_eo_degenerate_quda");
+          return (-1);
+        }
+      }
+    }
+    return (-1);
+  }
 
   return(iterations);
 }
@@ -2254,8 +2317,30 @@ int invert_eo_quda_oneflavour_mshift(spinor ** const out,
 
   tm_stopwatch_pop(&g_timers, 0, 0, "TM_QUDA");
 
-  if(iterations >= max_iter)
+  if(iterations >= max_iter){
+    if (g_proc_id == 0) {
+      printf("# TM_QUDA: iterations == -1\n");
+    }
+    if (solver_flag == MG) {
+      // re-running the inversion which failed
+      if (g_proc_id == 0) {
+        quda_mg_inversion_failed += 1;
+      }
+
+      if (quda_mg_inversion_failed < 2) {
+        forceRegenerateMGSetupQuda(compression);  // regenerate the MG setup
+        return invert_eo_quda_oneflavour_mshift(out, in, precision, max_iter, solver_flag, rel_prec,
+                                  even_odd_flag, solver_params, sloppy_precision, compression);
+      } else {  // abort if the inversion failed too many times
+        if (g_proc_id == 0) {
+          fatal_error("MG solver failed for more than 2 times in a row.",
+                      "invert_eo_quda_oneflavour_mshift");
+          return (-1);
+        }
+      }
+    }
     return(-1);
+  }
 
   return(iterations);
 }
@@ -2361,8 +2446,31 @@ int invert_eo_quda_twoflavour_mshift(spinor ** const out_up, spinor ** const out
 
   tm_stopwatch_pop(&g_timers, 0, 0, "TM_QUDA");
 
-  if(iterations >= max_iter)
+  if(iterations >= max_iter){
+    if (g_proc_id == 0) {
+      printf("# TM_QUDA: iterations == -1\n");
+    }
+    if (solver_flag == MG) {
+      // re-running the inversion which failed
+      if (g_proc_id == 0) {
+        quda_mg_inversion_failed += 1;
+      }
+
+      if (quda_mg_inversion_failed < 2) {
+        forceRegenerateMGSetupQuda(compression);  // regenerate the MG setup
+        return invert_eo_quda_twoflavour_mshift(out_up, out_dn, in_up, in_dn, precision, max_iter,
+                                                solver_flag, rel_prec, even_odd_flag, solver_params,
+                                                sloppy_precision, compression);
+      } else {  // abort if the inversion failed too many times
+        if (g_proc_id == 0) {
+          fatal_error("MG solver failed for more than 2 times in a row.",
+                      "invert_eo_quda_twoflavour_mshift");
+          return (-1);
+        }
+      }
+    }
     return(-1);
+  }
 
   return(iterations);
 }

--- a/quda_interface.c
+++ b/quda_interface.c
@@ -2216,6 +2216,7 @@ int invert_eo_degenerate_quda(spinor * const out,
           return ret_value;
         }
       } else {
+        // break out of the recursion here
         return iterations;
       }
     }

--- a/quda_types.h
+++ b/quda_types.h
@@ -126,6 +126,7 @@ typedef struct tm_QudaMGSetupState_t {
   double theta_y;
   double theta_z;
   double theta_t;
+  int force_reset = 0; // set to 1 when the MG doesn't converge
 } tm_QudaMGSetupState_t;
 
 typedef struct tm_QudaCloverState_t {
@@ -283,7 +284,9 @@ static inline int check_quda_mg_setup_state(const tm_QudaMGSetupState_t * const 
       ( fabs(quda_mg_setup_state->theta_y - quda_gauge_state->theta_y) > 2*DBL_EPSILON ) || 
       ( fabs(quda_mg_setup_state->theta_z - quda_gauge_state->theta_z) > 2*DBL_EPSILON ) || 
       ( fabs(quda_mg_setup_state->theta_t - quda_gauge_state->theta_t) > 2*DBL_EPSILON ) || 
-      ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) >= quda_params->mg_reset_setup_mdu_threshold ) ){
+      ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) >= quda_params->mg_reset_setup_mdu_threshold ) ||
+      quda_mg_setup_state->force_reset == 1
+    ){
     return TM_QUDA_MG_SETUP_RESET;
   // when in the HMC, we have to refresh the setup at regular intervals specified
   // by mg_refresh_setup_mdu_threshold, which triggers a few setup iterations to be

--- a/quda_types.h
+++ b/quda_types.h
@@ -126,7 +126,7 @@ typedef struct tm_QudaMGSetupState_t {
   double theta_y;
   double theta_z;
   double theta_t;
-  int force_reset; // set to 1 when the MG doesn't converge
+  int force_refresh; // set to 1 when the MG doesn't converge
 } tm_QudaMGSetupState_t;
 
 typedef struct tm_QudaCloverState_t {
@@ -284,18 +284,21 @@ static inline int check_quda_mg_setup_state(const tm_QudaMGSetupState_t * const 
       ( fabs(quda_mg_setup_state->theta_y - quda_gauge_state->theta_y) > 2*DBL_EPSILON ) || 
       ( fabs(quda_mg_setup_state->theta_z - quda_gauge_state->theta_z) > 2*DBL_EPSILON ) || 
       ( fabs(quda_mg_setup_state->theta_t - quda_gauge_state->theta_t) > 2*DBL_EPSILON ) || 
-      ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) >= quda_params->mg_reset_setup_mdu_threshold ) ||
-      ( quda_mg_setup_state->force_reset == 1 )
+      ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) >= quda_params->mg_reset_setup_mdu_threshold )
     ){
     return TM_QUDA_MG_SETUP_RESET;
   // when in the HMC, we have to refresh the setup at regular intervals specified
   // by mg_refresh_setup_mdu_threshold, which triggers a few setup iterations to be
   // run with the existing null vectors as initial guesses, thus refreshing
   // the MG setup for the evolved gauge
-  } else if ( ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) < 
+  // we also forcibly refresh the setup when the corresponding flag is set in the
+  // quda_mg_setup_state 
+  } else if ( ( ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) < 
                        quda_params->mg_reset_setup_mdu_threshold ) &&
               ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) >= 
-                       quda_params->mg_refresh_setup_mdu_threshold ) ) {
+                       quda_params->mg_refresh_setup_mdu_threshold ) ) ||
+              ( quda_mg_setup_state->force_refresh == 1) 
+    ){
     return TM_QUDA_MG_SETUP_REFRESH;
   // in other cases, e.g., when the operator parameters change or if the gauge_id has "moved" only a little,
   // we don't need to redo the setup, we can simply rebuild the coarse operators with the
@@ -332,7 +335,18 @@ static inline void set_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg
   quda_mg_setup_state->kappa = g_kappa;
   quda_mg_setup_state->mu = g_mu;
   quda_mg_setup_state->initialised = 1;
-  quda_mg_setup_state->force_reset = 0;
+  quda_mg_setup_state->force_refresh = 0;
+  quda_gauge_state->mg_needs_update = 0;
+  quda_clover_state->mg_needs_update = 0;
+}
+
+static inline void set_quda_mg_setup_state_no_gauge_id(tm_QudaMGSetupState_t * const quda_mg_setup_state,
+                                                       tm_QudaGaugeState_t * const quda_gauge_state,
+                                                       tm_QudaCloverState_t * const quda_clover_state) {
+  quda_mg_setup_state->c_sw = g_c_sw;
+  quda_mg_setup_state->kappa = g_kappa;
+  quda_mg_setup_state->mu = g_mu;
+  quda_mg_setup_state->force_refresh = 0;
   quda_gauge_state->mg_needs_update = 0;
   quda_clover_state->mg_needs_update = 0;
 }
@@ -340,7 +354,7 @@ static inline void set_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg
 static inline void reset_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg_setup_state){
   quda_mg_setup_state->gauge_id = -1;
   quda_mg_setup_state->initialised = 0;
-  quda_mg_setup_state->force_reset = 0;
+  quda_mg_setup_state->force_refresh = 0;
   quda_mg_setup_state->mu = -1.0;
   quda_mg_setup_state->c_sw = -1.0;
   quda_mg_setup_state->mu = -1.0;

--- a/quda_types.h
+++ b/quda_types.h
@@ -285,7 +285,7 @@ static inline int check_quda_mg_setup_state(const tm_QudaMGSetupState_t * const 
       ( fabs(quda_mg_setup_state->theta_z - quda_gauge_state->theta_z) > 2*DBL_EPSILON ) || 
       ( fabs(quda_mg_setup_state->theta_t - quda_gauge_state->theta_t) > 2*DBL_EPSILON ) || 
       ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) >= quda_params->mg_reset_setup_mdu_threshold ) ||
-      quda_mg_setup_state->force_reset == 1
+      ( quda_mg_setup_state->force_reset == 1 )
     ){
     return TM_QUDA_MG_SETUP_RESET;
   // when in the HMC, we have to refresh the setup at regular intervals specified
@@ -340,6 +340,7 @@ static inline void set_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg
 static inline void reset_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg_setup_state){
   quda_mg_setup_state->gauge_id = -1;
   quda_mg_setup_state->initialised = 0;
+  quda_mg_setup_state->force_reset = 0;
   quda_mg_setup_state->mu = -1.0;
   quda_mg_setup_state->c_sw = -1.0;
   quda_mg_setup_state->mu = -1.0;

--- a/quda_types.h
+++ b/quda_types.h
@@ -126,7 +126,7 @@ typedef struct tm_QudaMGSetupState_t {
   double theta_y;
   double theta_z;
   double theta_t;
-  int force_reset = 0; // set to 1 when the MG doesn't converge
+  int force_reset; // set to 1 when the MG doesn't converge
 } tm_QudaMGSetupState_t;
 
 typedef struct tm_QudaCloverState_t {
@@ -332,6 +332,7 @@ static inline void set_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg
   quda_mg_setup_state->kappa = g_kappa;
   quda_mg_setup_state->mu = g_mu;
   quda_mg_setup_state->initialised = 1;
+  quda_mg_setup_state->force_reset = 0;
   quda_gauge_state->mg_needs_update = 0;
   quda_clover_state->mg_needs_update = 0;
 }


### PR DESCRIPTION
Reply to the issue https://github.com/etmc/tmLQCD/issues/527 .

### Edits

I edited the ```quda_interface.c``` file as follows:
- I created a function ```void forceRegenerateMGSetupQuda(const CompressionType compression)``` which regenerates the MG setup.
  * At the beginning ```_loadGaugeQuda()``` is called. For how it is implemented now, maybe it's redundant because this function is always called after one call of that function.
  * In order to destroy the MG setup, the same MG-related functions called in ```_endQuda()``` are used.
  * In order to regenerate the MG setup, the same MG-related functions called in ```_initQuda()``` are used.
- This function is called inside each ```invert_*()``` function defined in that file, whenever one's using the MG and the latter didn't converge.
- Any time the MG doesn't converge, the inversion is done one more time in order to check for possible instabilities. This is implemented through a global variable updated as the MG doesn't converge.

### Note

We can think about adding a global parameter, to be specified in the input file, which limits the number of regenerations of the MG setup. Now the latter is implicitly set to 1.