### PR TITLE
Fixed overflow in printout of rectan-term to output.data (appears for…

### DIFF
--- a/update_tm.c
+++ b/update_tm.c
@@ -375,7 +375,7 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
     }
     fprintf(datafile, "%d %e", accept, etime-atime);
     if(g_rgi_C1 > 0. || g_rgi_C1 < 0) {
-      fprintf(datafile, " %e", (*rectangle_energy)/(12*VOLUME*g_nproc));
+      fprintf(datafile, " %e", (*rectangle_energy)/(12.*VOLUME*g_nproc));
     }
     fprintf(datafile, "\n");
     fflush(datafile);


### PR DESCRIPTION
Normalisation factor for rectangular term is not converted before division. Leads to an overflow, when lattice is of size 112x112x112x224.