### PR TITLE
move checking for CUDA or HIP libraries outside of the QUDA config block

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -894,132 +894,64 @@ else
 fi
 
 
-AC_MSG_CHECKING(whether we want to use CUDA GPU)
-AC_ARG_ENABLE(gpu,
-  AS_HELP_STRING([--enable-gpu],[use GPU [default=no]]),
-  usegpu=$enableval, usegpu=no)
-if test $usegpu = yes; then
-  AC_MSG_RESULT(yes)
-  AC_DEFINE(HAVE_GPU,1,Using CUDA GPU)
-  NVCC="nvcc"
-  USESUBDIRS="$USESUBDIRS GPU"
-  GPUDIR="GPU"
-  LIBS="$LIBS -lcuda -lcudart -lcublas"
-  
-  AC_MSG_CHECKING([where to search for CUDA libs])
-  AC_ARG_WITH(cuda,
-    AS_HELP_STRING([--with-cuda[=dir]], [use CUDA GPU with lib dir [default=/usr/local/cuda/lib]]),
-    cuda_dir=$withval, cuda_dir="/usr/local/cuda/lib")
-  AC_MSG_RESULT($cuda_dir)
-  if test $usegpu = yes; then  
-    LDFLAGS="$LDFLAGS -L$cuda_dir"
-  fi
-
-
-  AC_MSG_CHECKING([CUDA compile args])
-  AC_ARG_WITH(cudacompileargs,
-    AS_HELP_STRING([--with-cudacompileargs[=string]], [use CUDA compile args [default="--gpu-architecture sm_13 --use_fast_math -O3"]]),
-    cuda_compileargs=$withval, cuda_compileargs="--gpu-architecture sm_13 --use_fast_math -O3")
-  AC_MSG_RESULT($cuda_compileargs)
-  if test $usegpu = yes; then  
-    GPUCFLAGS="$GPUCFLAGS $cuda_compileargs"
-  fi
-  if test $enable_mpi = yes; then
-    GPUMPICOMPILER="--compiler-bindir mpicc"
-    if test $withmpidimension != 1; then
-      AC_MSG_ERROR(ERROR! The GPU Code is only parallelized in t-direction so far!)
-    fi
-  else
-    GPUMPICOMPILER=""
-  fi
-else
-  AC_MSG_RESULT(no)
-  NVCC=""
-fi
-
-
 AC_SUBST(USESUBDIRS)
-AC_SUBST(NVCC)
-AC_SUBST(GPUDIR)
-AC_SUBST(GPUCFLAGS)
-AC_SUBST(GPUMPICOMPILER)
 
-# check usage of cuda
-AC_MSG_CHECKING([whether we want to use CUDA GPU])
+AC_MSG_CHECKING(whether we want to use CUDA)
 AC_ARG_WITH(cudadir,
-  AS_HELP_STRING([--with-cudadir[=dir]], [if using CUDA, then set CUDA lib dir [default=/usr/local/cuda/lib]]),
-  [echo yes
-  cuda_dir=$withval
-  CUDA_AVAILABLE=1
-  ],
-  [echo no
-  cuda_dir=$withval
-  CUDA_AVAILABLE=0
-  ]
-)
-if $CUDA_AVAILABLE; then
-  AC_MSG_RESULT($cuda_dir)
-  LDFLAGS="$LDFLAGS -L$cuda_dir -lcuda -lcublas"
-  AC_CHECK_LIB([cudart],
-              [cudaMalloc],
-              [],
-              [AC_MSG_ERROR([Can't link a simple program against library cudart.])]
-              )
-fi
+            AS_HELP_STRING([--with-cudadir[=dir]], [use CUDA library (specify 'lib' directory)]),
+             [AC_MSG_RESULT($withval)
+              CUDA_AVAILABLE=1
+              cuda_dir=$withval
+              LDFLAGS="$LDFLAGS -L${cuda_dir} -lcuda"
+              AC_CHECK_LIB([cudart],
+                           [cudaMalloc],
+                           [],
+                           [AC_MSG_ERROR([Can't link a simple program against library cudart.])])],
+             [AC_MSG_RESULT(no)
+              CUDA_AVAILABLE=0])
 
-# check usage of hip
-AC_MSG_CHECKING([whether we want to use HIP GPU])
+AC_MSG_CHECKING(whether we want to use HIP)
 AC_ARG_WITH(hipdir,
-  AS_HELP_STRING([--with-hipdir[=dir]], [if using HIP, then set HIP lib dir [default=/usr/local/hip/lib]]),
-    [echo yes
-      hip_dir=$withval
-      HIP_AVAILABLE=1
-    ],
-    [echo no
-      hip_dir=$withval
-      HIP_AVAILABLE=0
-    ]
-  )
-
-if $HIP_AVAILABLE; then
-  AC_MSG_RESULT($hip_dir)
-  LDFLAGS="$LDFLAGS -L$hip_dir -lhip -lcublas"
-  AC_CHECK_LIB([hiprt],
-                [hipMalloc],
-                [],
-                [AC_MSG_ERROR([Can't link a simple program against library hiprt.])]
-                )
-fi
+            AS_HELP_STRING([--with-hipdir[=dir]], [use HIP library (specify 'lib' directory)]),
+             [AC_MSG_RESULT($withval)
+              HIP_AVAILABLE=1
+              hip_dir=$withval
+              LDFLAGS="$LDFLAGS -L${hip_dir} -lhip",
+              AC_CHECK_LIB([hiprt],
+                           [hipMalloc],
+                           [],
+                           [AC_MSG_ERROR([Can't link a simple program against library hiprt.])])],
+             [AC_MSG_RESULT(no)
+              HIP_AVAILABLE=0])
 
 
 # QUDA library for GPUs
-AC_MSG_CHECKING(whether we want to use QUDA GPU)
+AC_MSG_CHECKING(whether we want to use QUDA)
 AC_ARG_WITH(qudadir,
-            AS_HELP_STRING([--with-qudadir[=dir]], [use QUDA, to be found in dir]),
-             [echo yes
+            AS_HELP_STRING([--with-qudadir[=dir]], [use QUDA library (specify directory which contains 'include' and 'lib' subdirs)]),
+             [AC_MSG_RESULT($withval)
+              if test $CUDA_AVAILABLE -ne 1 && test $HIP_AVAILABLE -ne 1; then
+                AC_MSG_ERROR([Need either CUDA or HIP to link against QUDA!])
+              fi
               QUDA_AVAILABLE=1
               AC_DEFINE(TM_USE_QUDA,1,Using QUDA GPU)
               quda_dir=$withval
               LDFLAGS="$LDFLAGS -L${quda_dir}/lib"
               INCLUDES="$INCLUDES -I${quda_dir}/include/"
               QUDA_INTERFACE="quda_interface"
-              
-              # Perform test in C++
-              AC_LANG_PUSH([C++])
               AC_CHECK_LIB([quda],
                            [freeGaugeQuda],
                            [],
                            [AC_MSG_ERROR([Can't link a simple program against library libquda. (Did you set CXX properly?)])]
                            )
-              AC_LANG_PUSH([C++])
               #QUDA needs to be linked with C++ linker
               CCLD=${CXX}
              ],
-             [echo no
+             [AC_MSG_RESULT(no)
               QUDA_AVAILABLE=0
               QUDA_INTERFACE=""
               ]
-              )
+            )
 AC_SUBST([QUDA_AVAILABLE])
 
 AC_MSG_CHECKING(whether the QUDA version is experimental)

--- a/configure.in
+++ b/configure.in
@@ -916,11 +916,11 @@ AC_ARG_WITH(hipdir,
              [AC_MSG_RESULT($withval)
               HIP_AVAILABLE=1
               hip_dir=$withval
-              LDFLAGS="$LDFLAGS -L${hip_dir} -lhip",
-              AC_CHECK_LIB([hiprt],
+              LDFLAGS="$LDFLAGS -L${hip_dir} -lamdhip64"
+              AC_CHECK_LIB([amdhip64],
                            [hipMalloc],
                            [],
-                           [AC_MSG_ERROR([Can't link a simple program against library hiprt.])])],
+                           [AC_MSG_ERROR([Can't link a simple program against library amdhip64.])])],
              [AC_MSG_RESULT(no)
               HIP_AVAILABLE=0])
 


### PR DESCRIPTION
This seems to work for me to link QUDA with CUDA. I haven't tried QUDA with HIP yet.