### PR TITLE
change logic for setting MG param coarse_grid_solution_type

### DIFF
--- a/quda_interface.c
+++ b/quda_interface.c
@@ -1984,9 +1984,7 @@ void _setQudaMultigridParam(QudaMultigridParam* mg_param) {
     // set to QUDA_MATPC_SOLUTION to inject single parity field into coarse grid
     // if we are using an outer even-odd preconditioned solve, then we
     // use single parity injection into the coarse grid
-    // mg_param->coarse_grid_solution_type[level] = (level == 0 && inv_param.solve_type == QUDA_DIRECT_PC_SOLVE) ? 
-    //                                                 QUDA_MATPC_SOLUTION : 
-    //                                                 QUDA_MAT_SOLUTION;
+    // on all other levels than the fine one we always use QUDA_MATPC_SOLUTION
     mg_param->coarse_grid_solution_type[level] = (level == 0 && inv_param.solve_type == QUDA_DIRECT_SOLVE) ? 
                                                     QUDA_MAT_SOLUTION : 
                                                     QUDA_MATPC_SOLUTION;

--- a/quda_interface.c
+++ b/quda_interface.c
@@ -1984,9 +1984,12 @@ void _setQudaMultigridParam(QudaMultigridParam* mg_param) {
     // set to QUDA_MATPC_SOLUTION to inject single parity field into coarse grid
     // if we are using an outer even-odd preconditioned solve, then we
     // use single parity injection into the coarse grid
-    mg_param->coarse_grid_solution_type[level] = (level == 0 && inv_param.solve_type == QUDA_DIRECT_PC_SOLVE) ? 
-                                                    QUDA_MATPC_SOLUTION : 
-                                                    QUDA_MAT_SOLUTION;
+    // mg_param->coarse_grid_solution_type[level] = (level == 0 && inv_param.solve_type == QUDA_DIRECT_PC_SOLVE) ? 
+    //                                                 QUDA_MATPC_SOLUTION : 
+    //                                                 QUDA_MAT_SOLUTION;
+    mg_param->coarse_grid_solution_type[level] = (level == 0 && inv_param.solve_type == QUDA_DIRECT_SOLVE) ? 
+                                                    QUDA_MAT_SOLUTION : 
+                                                    QUDA_MATPC_SOLUTION;
 
     mg_param->omega[level] = quda_input.mg_omega[level]; // over/under relaxation factor
 


### PR DESCRIPTION
When I was adding the HMC additions, I accidentally messed up the logic for `coarse_grid_solution_type` and was injecting a full field on all intermediate and coarse levels :facepalm:

This PR significantly improves MG performance (4 Booster nodes, 64c128 lattice, physical point) and will also restore analysis performance to previous levels:

### old

```
GCR: Convergence at 53 iterations, L2 relative residual: iterated = 7.315033e-10, true = 7.315033e-10 (requested = 1.000000e-09)
# TM_QUDA: Time for invertQuda 1.596819e+01 s level: 3 proc_id: 0 /HMC/correlators_measurement/invert_eo_quda/invertQuda
# TM_QUDA: Done: 53 iter / 15.7261 secs = 25234.6 Gflops
# TM_QUDA: Time for reorder_spinor_fromQuda 6.752734e-02 s level: 3 proc_id: 0 /HMC/correlators_measurement/invert_eo_quda/reorder_spinor_fromQuda
# TM_QUDA: Time for invert_eo_quda 2.134693e+01 s level: 2 proc_id: 0 /HMC/correlators_measurement/invert_eo_quda
# Inversion done in 53 iterations, squared residue = 9.589332e-13!
```

### new

```
# TM_QUDA: Time for invertQuda 3.727005e+00 s level: 3 proc_id: 0 /HMC/correlators_measurement/invert_eo_quda/invertQuda
# TM_QUDA: Done: 33 iter / 3.47978 secs = 24770.2 Gflops
# TM_QUDA: Time for reorder_spinor_fromQuda 7.029620e-02 s level: 3 proc_id: 0 /HMC/correlators_measurement/invert_eo_quda/reorder_spinor_fromQuda
# TM_QUDA: Time for invert_eo_quda 3.914286e+00 s level: 2 proc_id: 0 /HMC/correlators_measurement/invert_eo_quda
# Inversion done in 33 iterations, squared residue = 1.686466e-12!
```

Just need to make sure that it doesn't break anything, but this will help us quite a bit...
