### PR TITLE
MAIN_PROGRAM mechanism has been superceded for a while, INIT_GLOBALS …

### DIFF
--- a/offline_measurement.c
+++ b/offline_measurement.c
@@ -21,8 +21,6 @@
  *
  *******************************************************************************/
 
-#define MAIN_PROGRAM
-
 #include <lime.h>
 #ifdef HAVE_CONFIG_H
 #include "tmlqcd_config.h"

--- a/read_input.l
+++ b/read_input.l
@@ -54,6 +54,7 @@ EQL {SPC}*={SPC}*
 #include <string.h>
 #define INIT_GLOBALS
 #include "global.h"
+#undef INIT_GLOBALS
 #include "read_input.h"
 #include "default_input_values.h"
 #include "monomial/monomial.h"


### PR DESCRIPTION
…in read_input.l was not undef'ed after global.h was included, however. This caused linking problems on certain machines