### PR TITLE
typo in documentation: BarrierMonomialsConverge

### DIFF
--- a/doc/input.tex
+++ b/doc/input.tex
@@ -185,7 +185,7 @@ supported general input paramters:
   OpenMP support. On some architectures, the {\ttfamily OMP\_NUM\_THREADS}
   environment variable needs to be set to the same value for correct
   operation. The default is 1.
-\item  {\ttfamily BarrierMonomialsConvergence}:\\
+\item  {\ttfamily BarrierMonomialsConverge}:\\
   Possible values:  {\ttfamily yes} or  {\ttfamily no}. The default is  {\ttfamily no}. 
   If set to  {\ttfamily yes} the convergence is checked for each monomial, 
   and if any of the solvers returns a number of iterations equal to $-1$, 


### PR DESCRIPTION
In the documentation to parameter was called `BarrierMonomialsConvergence`, not `BarrierMonomialsConverge`, resulting in a failure when parsing the input file.