### PR TITLE
added interface for saving gauge back to host

### DIFF
--- a/quda_interface.h
+++ b/quda_interface.h
@@ -97,6 +97,7 @@ void _initQuda();
 void _endQuda();
 void _loadGaugeQuda(const CompressionType);
 void _loadCloverQuda(QudaInvertParam * inv_param);
+void _saveGaugeQuda( const su3 ** const gaugefield, const int savegaugetype, const CompressionType compression );
 
 // direct line to QUDA inverter, no messing about with even/odd reordering
 // source and propagator  Should be full VOLUME spinor fields 


### PR DESCRIPTION
added interface function `_saveGaugeQuda` to save gauge from QUDA back to host. Reordering back to tmLQCD format is performed with `reorder_gauge_fromQuda`.