### PR TITLE
in the hmc_mk2 profiler, optionally include all timings

### DIFF
--- a/profiling/hmc_mk2/README.md
+++ b/profiling/hmc_mk2/README.md
@@ -3,18 +3,21 @@ We use tmLQCD hierarchical timer and R to produce profiles of the HMC.
 To collect time informations from the file `example_log.out` type
 
 ```
-    Rscript make_profile.R example_log.out output_basename
+    Rscript make_profile.R example_log.out output_basename [1]
 ```
 
 The `make_profile.R` file will first collect the data and then render the file `profile.Rmd`, producing the pdf `output_basename.pdf`, where the name of the output file is set by passing something for `output_basename`.
+The last argument is optional and controls whether all timings are included in per-monomial plots and tables or timings below 5% of the total time spent in that particular step (heatbath, derivative, acceptance) for a particular monomial are grouped under the "other" category.
 
-Alternatively, the script can also be sourced from an interactive session:
+Alternatively, the script can also be sourced from an interactive session where the variables `infile` and `outbase` must be defined.
 
 ```
 > infile <- "example_log.out"
 > outbase <- "output_basename"
 > source("make_profile.R")
 ```
+
+The treshold for whether all timings should be shown on a per-monomial basis is set via the `other_threshold` variable and defaults to `0.05`.
 
 The R packages `dplyr, data.tree, stringr` and `microseq` are required for data extraction and the R packages `ggplot2, knitr, treemap, hadron` and `kableExtra` are required to render the Rmarkdown document.
 

--- a/profiling/hmc_mk2/profile.Rmd
+++ b/profiling/hmc_mk2/profile.Rmd
@@ -116,7 +116,7 @@ cat("\\par\n")
 cat(knitr::kable(dplyr::select(hb_acc_der_data, monomial, type, time, prop, invocations, unit_time),
                  format = 'latex',
                  booktabs = TRUE,
-                 digits = 1,
+                 digits = 3,
                  linesep = "") %>%
     kableExtra::kable_styling(latex_options = "striped")
 )
@@ -156,7 +156,7 @@ if(!all(is.na(quda_data))){
   cat(knitr::kable(plot_data,
                    format = 'latex',
                    booktabs = TRUE,
-                   digits = 1,
+                   digits = 2,
                    caption = sprintf("Time spent in different QUDA regions. Compare to total time of %.1f seconds.",
                                      total_time)) %>%
       kableExtra::kable_styling(latex_options = "striped")
@@ -197,7 +197,7 @@ for( mon in total_per_mon$monomial ){
     cat(knitr::kable(dplyr::select(type_data, level, name, time, prop, invocations, unit_time),
                      format = 'latex',
                      booktabs = TRUE,
-                     digits = 1,
+                     digits = 3,
                      linesep = "",
                      caption = sprintf("%s %s", mon, tp) ) %>%
           kable_styling(latex_options = "HOLD_position") %>%


### PR DESCRIPTION
Through a third command line argument, in the per-monomial tables and plots rather than grouping timings below 5% in the 'other' category, all timings can now be shown.