### PR TITLE
Some fixes required to build TMLQCD on Daint with libsmear

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -42,7 +42,7 @@ LDFLAGS="$LDFLAGS -L\${HOME}/lib -L\${top_builddir}/lib"
 CCLD=${CC}
 
 # compilation in operator is slowest so we do it first, saves time in parallel compiles
-USESUBDIRS="operator linalg solver monomial buffers cu io meas xchange init rational wrapper"
+USESUBDIRS="operator linalg solver monomial buffers cu io meas xchange init rational smearing wrapper"
 
 AC_CHECK_HEADERS([stdint.h],
 [ dnl for inttypes.h and stdint.h for uint_xxx types

--- a/monomial/poly_monomial.c
+++ b/monomial/poly_monomial.c
@@ -48,7 +48,7 @@
 
 
 
-inline void setPhmcVars(monomial *mnl){
+static inline void setPhmcVars(monomial *mnl){
   phmc_invmaxev=1.0/mnl->MDPolyLmax;
   phmc_dop_n_cheby=(mnl->MDPolyDegree/2)+1;
   phmc_Cpol=mnl->MDPolyLocNormConst;

--- a/smearing/ape.ih
+++ b/smearing/ape.ih
@@ -13,8 +13,8 @@
 #include <ranlxd.h>
 #include <sse.h>
 #include <get_staples.h>
-#include <xchange_gauge.h>
-#include <xchange.h>
+#include <xchange/xchange_gauge.h>
+#include <xchange/xchange.h>
 #include <io/gauge.h>
 #include <update_backward_gauge.h>
 

--- a/smearing/hex.h
+++ b/smearing/hex.h
@@ -6,9 +6,18 @@
 /* Just to have a consistent look to the interface  */
 typedef struct hyp_parameters hex_parameters;
 
+#if 0
 /* All defined in terms of arrays of tuples -- needed to allow for g_gauge_field as input */
 void stout_exclude_none(gauge_field_t buff_out, double const coeff, gauge_field_array_t staples, gauge_field_t buff_in);
 void stout_exclude_one (gauge_field_array_t buff_out, double const coeff, gauge_field_array_t staples, gauge_field_t buff_in);
 void stout_exclude_two (gauge_field_array_t buff_out, double const coeff, gauge_field_array_t staples, gauge_field_t buff_in);
 
 int hex_smear(gauge_field_t m_field_out, hex_parameters const *params, gauge_field_t m_field_in);  /*  4 components in, 4 components out */
+#endif
+
+
+void stout_exclude_one(su3_tuple **buff_out, double const coeff, su3_tuple **staples, su3_tuple *buff_in);
+void stout_exclude_two(su3_tuple **buff_out, double const coeff, su3_tuple **staples, su3_tuple *buff_in);
+void stout_exclude_none(su3_tuple *buff_out, double const coeff, su3_tuple **staples, su3_tuple *buff_in);
+
+int hex_smear(su3_tuple *m_field_out, hex_parameters const *params, su3_tuple *m_field_in);

--- a/smearing/hex.ih
+++ b/smearing/hex.ih
@@ -13,8 +13,8 @@
 #include <ranlxd.h>
 #include <sse.h>
 #include <get_staples.h>
-#include <xchange_gauge.h>
-#include <xchange.h>
+#include <xchange/xchange_gauge.h>
+#include <xchange/xchange.h>
 #include <io/gauge.h>
 #include <update_backward_gauge.h>
 

--- a/smearing/hyp.ih
+++ b/smearing/hyp.ih
@@ -13,8 +13,8 @@
 #include <ranlxd.h>
 #include <sse.h>
 #include <get_staples.h>
-#include <xchange_gauge.h>
-#include <xchange.h>
+#include <xchange/xchange_gauge.h>
+#include <xchange/xchange.h>
 #include <io/gauge.h>
 #include <update_backward_gauge.h>
 

--- a/smearing/stout.ih
+++ b/smearing/stout.ih
@@ -23,8 +23,8 @@
 #include <ranlxd.h>
 #include <sse.h>
 #include <get_staples.h>
-#include <xchange_gauge.h>
-#include <xchange.h>
+#include <xchange/xchange_gauge.h>
+#include <xchange/xchange.h>
 #include <io/gauge.h>
 #include <update_backward_gauge.h>
 

--- a/smearing/utils.h
+++ b/smearing/utils.h
@@ -30,7 +30,10 @@ enum I2
   I2_3_02 = 10, I2_3_20 = 10, I2_3_12 = 11, I2_3_21 = 11
 };
 
+#if 0
 void generic_staples(gauge_field_t buff_out, int x, int mu, gauge_field_t buff_in);
+#endif
+void generic_staples(su3 *buff_out, int x, int mu, su3_tuple *buff_in);
 void generic_exchange(void *field_in, int bytes_per_site);
 void project_antiherm(su3 *omega);
 void project_herm(su3 *omega);

--- a/smearing/utils.ih
+++ b/smearing/utils.ih
@@ -13,8 +13,8 @@
 #include <ranlxd.h>
 #include <sse.h>
 #include <get_staples.h>
-#include <xchange_gauge.h>
-#include <xchange.h>
+#include <xchange/xchange_gauge.h>
+#include <xchange/xchange.h>
 #include <io/gauge.h>
 #include <update_backward_gauge.h>
 

--- a/smearing/utils_project_antiherm.c
+++ b/smearing/utils_project_antiherm.c
@@ -3,7 +3,7 @@
 void project_antiherm(su3 *omega)
 {
   static const double fac_3 = 1.00 / 3.00;
-  double tr_omega = creal(-I * fac_3 * (omega->c00 + omega->c11 + omega->c22);
+  double tr_omega = creal(-I * fac_3 * (omega->c00 + omega->c11 + omega->c22));
 
   
   omega->c00 = (cimag(omega->c00) - tr_omega) * I;


### PR DESCRIPTION
This PR includes a fix for one compilation issue and turns on the libsmear library with fixes for the various headers to ensure that it builds correctly. If libsmear is intentionally disabled by default, I can also redo the PR removing those bits (i.e. just leaving the one fix for the compilation bug).