### PR TITLE
add MPI_Barrier so that the output is written even if the next conf is missing

### DIFF
--- a/meas/correlators.c
+++ b/meas/correlators.c
@@ -240,6 +240,7 @@ void correlators_measurement(const int traj, const int id, const int ieo) {
         free(Cpp); free(Cpa); free(Cp4);
       }
       free(sCpp); free(sCpa); free(sCp4);
+      MPI_Barrier(MPI_COMM_WORLD);
 #else
       free(Cpp); free(Cpa); free(Cp4);
 #endif


### PR DESCRIPTION
The problem was observed in 
```
/p/project1/isdlqcd/garofalo1/pion/cB211.072.64b/slurm-11561415_1502.out
```
The next conf was missing and the output of the current conf was not written.