### PR TITLE
Fix implicit declaration compiling with qphix

### DIFF
--- a/wrapper/lib_wrapper.c
+++ b/wrapper/lib_wrapper.c
@@ -63,6 +63,8 @@
 #include "read_input.h"
 #include "sighandler.h"
 #include "start.h"
+#include "operator/clover_leaf.h"
+#include "qphix_interface.h"
 
 #define CONF_FILENAME_LENGTH 500
 


### PR DESCRIPTION
Fix compiler warning for implicit function declaration, while compiling tmLQCD with QPhiX.
- add the missing headers