### PR TITLE
Bugfix in cloverdet_monomial

### DIFF
--- a/monomial/cloverdet_monomial.c
+++ b/monomial/cloverdet_monomial.c
@@ -267,17 +267,14 @@ double cloverdet_acc(const int id, hamiltonian_field_t *const hf) {
   g_kappa = mnl->kappa;
   boundary(mnl->kappa);
 
-  if (g_debug_level > 2 || g_strict_residual_check ||
-      !(mnl->external_library == QUDA_LIB &&
-        mnl->solver_params.external_inverter == QUDA_INVERTER)) {
-    sw_term((const su3 **)hf->gaugefield, mnl->kappa, mnl->c_sw);
+  sw_term((const su3 **)hf->gaugefield, mnl->kappa, mnl->c_sw);
 
-    if (!mnl->even_odd_flag) {
-      N = VOLUME;
-    } else {
-      sw_invert(EE, mnl->mu);
-    }
+  if (!mnl->even_odd_flag) {
+    N = VOLUME;
+  } else {
+    sw_invert(EE, mnl->mu);
   }
+
   g_sloppy_precision_flag = 0;
 
   if (mnl->solver == MG || mnl->solver == BICGSTAB) {


### PR DESCRIPTION
Fixes a bug in cloverdet monomial that is triggered if both of the following conditions are true
1.) external_library == QUDA_LIB && external_inverter == QUDA_INVERTER && no strict residual check is required
2.) one or more cloverrat monomials are present