### PR TITLE
Fixed bug in quda_interface.c

### DIFF
--- a/quda_interface.c
+++ b/quda_interface.c
@@ -483,7 +483,7 @@ void _loadCloverQuda(QudaInvertParam *inv_param) {
   } else {
     tm_stopwatch_push(&g_timers, "loadCloverQuda", "");
     if (first_call) {
-      first_call = 1;
+      first_call = 0;
     } else {
       freeCloverQuda();
     }


### PR DESCRIPTION
If-statement had no effect due to setting first_call = 1 in first branch, i.e. freeCloverQuda() was never called.