### PR TITLE
Fix a typo in the tmLQCD cmake module

### DIFF
--- a/cmake/tmLQCDConfig.cmake.in
+++ b/cmake/tmLQCDConfig.cmake.in
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.23)
 
 if (NOT TARGET tmlqcd::tmlqcd)
 
+  set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
   # store CXX compiler id. Used in MKL package.
   set(TM_C_COMPILER_ID @CMAKE_C_COMPILER_ID@)
   if(NOT ${CMAKE_C_COMPILER_ID})
@@ -27,7 +29,7 @@ if (NOT TARGET tmlqcd::tmlqcd)
 
   if (@TM_USE_LEMON@)
     set(TM_USE_LEMON @TM_USE_LEMON@)
-    find_dependency(Lemon ${mode})
+    find_dependency(lemon ${mode})
   endif()
 
   find_package(BLAS ${mode})
@@ -75,5 +77,5 @@ if (NOT TARGET tmlqcd::tmlqcd)
     set(TM_USE_GAUGE_COPY @TM_USE_GAUGE_COPY@)
   endif()
 
-  include("${CMAKE_CURRENT_LIST_DIR}/tmlQCDTargets.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/tmLQCDTargets.cmake")
 endif()

--- a/cmake/tmLQCDConfig.cmake.in
+++ b/cmake/tmLQCDConfig.cmake.in
@@ -4,12 +4,6 @@ if (NOT TARGET tmlqcd::tmlqcd)
 
   set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
-  # store CXX compiler id. Used in MKL package.
-  set(TM_C_COMPILER_ID @CMAKE_C_COMPILER_ID@)
-  if(NOT ${CMAKE_C_COMPILER_ID})
-    set(CMAKE_C_COMPILER_ID ${TM_C_COMPILER_ID})
-  endif()
-
   # pass REQUIRED or QUIET depending on top Config call
   if(tmlQCD_c_FIND_REQUIRED)
     set(mode REQUIRED)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -371,7 +371,8 @@ list(
   ${SOLVER_SRC_C}
   ${TEST_SRC_C}
   ${MEAS_SRC_C}
-  ${PROJECT_BINARY_DIR}/git_hash.c)
+  ${PROJECT_BINARY_DIR}/git_hash.c
+  wrapper/lib_wrapper.c)
 
 include_directories(
   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>


### PR DESCRIPTION
The tmLQCD module was not working as intended because of some typo and absence of tmLQCD cmake modules path. This PR solves these issues.
- lib_wrapper.c is compiled and included in the library. The wrapper code can be found in src/lib/wrapper.c
- Removed a forgotten Makefile.in
- Removed a wrong comment